### PR TITLE
[Fix] BezierToast Binding nil 처리 추가

### DIFF
--- a/Sources/BezierSwift/MasterComponent/BezierToast/BezierToastViewModifier.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierToast/BezierToastViewModifier.swift
@@ -53,5 +53,9 @@ struct BezierToastViewModifier: ViewModifier {
     ]
     
     NSLayoutConstraint.activate(toastConstraints)
+    
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
+      self.viewModel = nil
+    }
   }
 }


### PR DESCRIPTION
nil 처리 전까지 토스트가 계속 호출 되는 이슈가 있어 뷰 생성 후 바로 삭제되도록 추가 헀습니다.

BezierToastViewModifire BezierToast까지 바인딩이 안된 상태라 뷰 생성 이후 바로 삭제되도록 처리했습니다.