### PR TITLE
[Improvement] BezierButton monochromeLight button spec 수정

### DIFF
--- a/Sources/BezierSwift/MasterComponent/BezierButton/BezierButton.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierButton/BezierButton.swift
@@ -151,7 +151,7 @@ public enum ButtonType: Equatable {
     switch self {
     case .primary(let buttonColor):
       switch buttonColor {
-      case .monochromeDark: return .txtWhiteNormal
+      case .monochromeLight, .monochromeDark: return .txtWhiteNormal
       default: return .bgtxtAbsoluteWhiteDark
       }
     case .secondary(let color), .tertiary(let color):
@@ -194,7 +194,7 @@ public enum ButtonType: Equatable {
     switch self {
     case .primary(let buttonColor):
       switch buttonColor {
-      case .monochromeDark: return .txtWhiteNormal
+      case .monochromeLight, .monochromeDark: return .txtWhiteNormal
       default: return .bgtxtAbsoluteWhiteDark
       }
     case .secondary(let color), .tertiary(let color):
@@ -280,7 +280,7 @@ public enum ButtonType: Equatable {
           return .bgtxtAbsoluteBlackLighter
         }
       case .monochromeLight:
-        return .bgBlackLighter
+        return .bgBlackDarker
       case .monochromeDark:
         return .bgGreyDarkest
       case .absoulteWhite:
@@ -669,8 +669,7 @@ struct BezierButton_Previews: PreviewProvider {
       BezierButton(size: .large, type: .primary(.green), resizing: .fill, title: "Get started", leftImage: Image(systemName: "trash")) {
         print("")
       }
-      
-      
+
       BezierButton(size: .large, type: .primary(.blue), resizing: .hug, title: "Get started", leftImage: Image(systemName: "trash"), rightImage: Image(systemName: "trash")) {
         print("")
       }


### PR DESCRIPTION
## 어떤 PR 인가요?
BezierButton이 primary 타입일 때 monochromeLight 색상에 대한 스펙이 피그마와 달라 이를 일치하도록 수정하는 PR입니다.

## 작업 내용
- BezierButton primary monochromeLight에 대한 스펙에 따라 textColor, imageTintColor, backgroundColor를 지정

## Reference
- 스레드 [링크1](https://desk.channel.io/root/threads/groups/Bezier-62019/65379be1365b6bf3bc38/65379be1365b6bf3bc38), [링크2](https://desk.channel.io/root/threads/groups/모바일-42672/6538a6e4e8c361c8f926/6538a6e4e8c361c8f926)
- [피그마 링크](https://www.figma.com/file/P428nBSEU9WAN9jeBjyjNj/Mobile-Component?type=design&node-id=8400-155683&mode=design&t=dTHBhuqIEiQhS93g-4)

## Checklist
- [ ] PR 제목을 라벨과 함께 명령형으로 작성했습니다.
- [ ] [코딩 컨벤션](https://github.com/channel-io/ios-convention-guide) 에 맞춰서 작성했습니다
- [ ] 리뷰 리퀘스트 전에 더 이상 스스로 리뷰할게 없을 정도까지 셀프 리뷰를 진행했습니다
- [ ] 변경사항에 대한 테스트코드를 추가했습니다. 또는, 테스트코드가 필요없는 이유가 있습니다(현재는 옵셔널입니다)

