### PR TITLE
[Etc] 베지어 토스트 radius 20 으로 변경

### DIFF
--- a/Sources/BezierSwift/MasterComponent/BezierToast/BezierToast.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierToast/BezierToast.swift
@@ -60,7 +60,7 @@ public struct BezierToast: View, Themeable {
     }
     .background(self.palette(.bgBlackDarker))
     .applyBlurEffect()
-    .applyBezierCornerRadius(type: .round22)
+    .applyBezierCornerRadius(type: .round20)
     .frame(maxWidth: Constant.contentMaxWidth)
     .padding(.horizontal, Metric.horizontalPadding)
   }


### PR DESCRIPTION
## 어떤 PR 인가요?
베지어 토스트 corner radius 를 22 에서 20 으로 변경합니다.

## 작업 내용
<img src="https://github.com/channel-io/BezierSwift/assets/25315898/c9c55227-9b00-4076-884c-0cb912725eb4" width="300">

## Reference
[팀챗](https://desk.channel.io/root/groups/Bezier-62019/65715ec8a087ae83c10e)

## Checklist
- [x] PR 제목을 라벨과 함께 명령형으로 작성했습니다.
- [x] [코딩 컨벤션](https://github.com/channel-io/ios-convention-guide) 에 맞춰서 작성했습니다
- [x] 리뷰 리퀘스트 전에 더 이상 스스로 리뷰할게 없을 정도까지 셀프 리뷰를 진행했습니다
- [ ] 변경사항에 대한 테스트코드를 추가했습니다. 또는, 테스트코드가 필요없는 이유가 있습니다(현재는 옵셔널입니다)

