### PR TITLE
[Etc] 베지어 다이얼로그 버튼 최대 개수 올바르게 수정

### DIFF
--- a/Sources/BezierSwift/MasterComponent/BezierDialog/BezierDialog.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierDialog/BezierDialog.swift
@@ -21,8 +21,8 @@ private enum Metric {
 }
 
 private enum Constant {
-  static let maxHorizontalButtonCount = 4
-  static let maxVerticalButtonCount = 2
+  static let maxHorizontalButtonCount = 2
+  static let maxVerticalButtonCount = 4
 }
 
 struct BezierDialog: View, Themeable {


### PR DESCRIPTION
## 어떤 PR 인가요?
<!-- 3줄이내로 PR에 대해 간략히 작성합니다. 3줄을 넘어야한다면 PR을 나누는걸 추천드려요. -->

베지어 다이얼로그 스펙에 맞게 수직 4개, 수평 2개로 버튼 최대 개수를 변경합니다.

## 스크린샷 혹은 동영상

<img src="https://github.com/channel-io/BezierSwift/assets/25315898/18762699-94cf-41f7-aeb0-9fb3d5b2a31d" width="300">


