### PR TITLE
[MOB-418] hideKeyboard 함수 추가 및 다이얼로그에 적용

### DIFF
--- a/Sources/BezierSwift/BezierSwift.swift
+++ b/Sources/BezierSwift/BezierSwift.swift
@@ -17,6 +17,18 @@ public final class BezierSwift {
   
   weak var bezierWindow: BezierWindow?
   var allowHitTest: Bool { self.dialogViewModel.item.isNotNil }
+  
+  func hideKeyboard() {
+    // NOTE: BezierDialog update 시 firstResponder 전달이 안돼서 키보드가 닫히지 않는 문제가 있습니다.
+    // Keyboard 를 닫아 키보드 입력을 막기 위한 함수입니다. by Tom 2024.04.17
+    DispatchQueue.main.async {
+      if #available(iOS 15.0, *) {
+        self.bezierWindow?.windowScene?.keyWindow?.endEditing(true)
+      } else {
+        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+      }
+    }
+  }
 }
 
 extension BezierSwift {
@@ -60,10 +72,12 @@ extension BezierSwift {
 extension BezierSwift {
   public static func showDialog(param: BezierDialogParam) {
     BezierSwift.shared.dialogViewModel.update(item: BezierDialogItem(param: param))
+    BezierSwift.shared.hideKeyboard()
   }
   
   public static func showDialog(item: BezierDialogItem) {
     BezierSwift.shared.dialogViewModel.update(item: item)
+    BezierSwift.shared.hideKeyboard()
   }
   
   public static func dismissDialog(id: UUID) {

--- a/Sources/BezierSwift/BezierSwift.swift
+++ b/Sources/BezierSwift/BezierSwift.swift
@@ -30,11 +30,13 @@ public final class BezierSwift {
   fileprivate func hideKeyboard() {
     // NOTE: BezierDialog update 시 firstResponder 전달이 안돼서 키보드가 닫히지 않는 문제가 있습니다.
     // Keyboard 를 닫아 키보드 입력을 막기 위한 함수입니다. by Tom 2024.04.17
-    DispatchQueue.main.async {
-      if #available(iOS 15.0, *) {
-        self.bezierWindow?.windowScene?.keyWindow?.endEditing(true)
-      } else {
-        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+    if self.config.hideKeyboardOnDialogDisplay {
+      DispatchQueue.main.async {
+        if #available(iOS 15.0, *) {
+          self.bezierWindow?.windowScene?.keyWindow?.endEditing(true)
+        } else {
+          UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+        }
       }
     }
   }

--- a/Sources/BezierSwift/BezierSwift.swift
+++ b/Sources/BezierSwift/BezierSwift.swift
@@ -8,6 +8,14 @@
 import UIKit
 
 public final class BezierSwift {
+  public struct Config {
+    fileprivate let hideKeyboardOnDialogDisplay: Bool
+    
+    public init(hideKeyboardOnDialogDisplay: Bool = true) {
+      self.hideKeyboardOnDialogDisplay = hideKeyboardOnDialogDisplay
+    }
+  }
+  
   static let shared = BezierSwift()
   
   private init() { }
@@ -17,8 +25,9 @@ public final class BezierSwift {
   
   weak var bezierWindow: BezierWindow?
   var allowHitTest: Bool { self.dialogViewModel.item.isNotNil }
+  var config = Config()
   
-  func hideKeyboard() {
+  fileprivate func hideKeyboard() {
     // NOTE: BezierDialog update 시 firstResponder 전달이 안돼서 키보드가 닫히지 않는 문제가 있습니다.
     // Keyboard 를 닫아 키보드 입력을 막기 위한 함수입니다. by Tom 2024.04.17
     DispatchQueue.main.async {
@@ -34,10 +43,14 @@ public final class BezierSwift {
 extension BezierSwift {
   @available(iOS, deprecated: 16.0)
   @MainActor
-  public static func initializeWindow(windowLevel: UIWindow.Level = .bezierSwift) -> UIWindow {
+  public static func initializeWindow(
+    windowLevel: UIWindow.Level = .bezierSwift,
+    config: Config = Config()
+  ) -> UIWindow {
     guard let bezierWindow = BezierSwift.shared.bezierWindow else {
       let bezierWindow = BezierWindow(frame: UIScreen.main.bounds, windowLevel: windowLevel)
       BezierSwift.shared.bezierWindow = bezierWindow
+      BezierSwift.shared.config = config
       return bezierWindow
     }
     
@@ -47,11 +60,13 @@ extension BezierSwift {
   @MainActor
   public static func initializeWindow(
     windowScene: UIWindowScene,
-    windowLevel: UIWindow.Level = .bezierSwift
+    windowLevel: UIWindow.Level = .bezierSwift,
+    config: Config = Config()
   ) -> UIWindow {
     guard let bezierWindow = BezierSwift.shared.bezierWindow else {
       let bezierWindow = BezierWindow(windowScene: windowScene, windowLevel: windowLevel)
       BezierSwift.shared.bezierWindow = bezierWindow
+      BezierSwift.shared.config = config
       return bezierWindow
     }
     
@@ -88,4 +103,3 @@ extension BezierSwift {
     BezierSwift.shared.dialogViewModel.dismiss()
   }
 }
-


### PR DESCRIPTION
## 어떤 PR 인가요?
<!-- 3줄이내로 PR에 대해 간략히 작성합니다. 3줄을 넘어야한다면 PR을 나누는걸 추천드려요. -->
베지어 다이얼로그 update 시 keyWindow 의 키보드를 닫는 PR 입니다.

## 작업 내용
<!-- 작업 리스팅, 리뷰어에게 필요한 작업 설명 등을 남겨주세요 -->
- windowScene의 keyWinodw.endEditing() 함수를 호출해서 키보드를 닫도록 합니다.

## 스크린샷 혹은 동영상
<img src="https://github.com/channel-io/BezierSwift/assets/14305293/54893c9d-494f-4ca4-b01f-3ac516ec425d" width="300">

## Reference
<!-- 기획이나 레퍼런스가 정리된 링크를 첨부합니다.  (팀챗, 노션) -->

## Issue-number
<!-- - closed: #이슈번호 -->

## Checklist
- [x] PR 제목을 라벨과 함께 명령형으로 작성했습니다.
- [x] [코딩 컨벤션](https://github.com/channel-io/ios-convention-guide) 에 맞춰서 작성했습니다
- [x] 리뷰 리퀘스트 전에 더 이상 스스로 리뷰할게 없을 정도까지 셀프 리뷰를 진행했습니다
- [ ] 변경사항에 대한 테스트코드를 추가했습니다. 또는, 테스트코드가 필요없는 이유가 있습니다(현재는 옵셔널입니다)
