### PR TITLE
[MOB-1773] foreground yellow가 olive 색상을 참조하는 문제 수정

### DIFF
--- a/BezierSwift/Sources/Foundation/Color/BezierColor.swift
+++ b/BezierSwift/Sources/Foundation/Color/BezierColor.swift
@@ -93,9 +93,9 @@ extension BezierColor {
   public static var fgOliveDark: BezierColor { BezierColor(functionalColorToken: .fgOliveDark) }
 
   // MARK: ForegroundYellow
-  public static var fgYellowNormal: BezierColor { BezierColor(functionalColorToken: .fgOliveNormal) }
-  public static var fgYellowLight: BezierColor { BezierColor(functionalColorToken: .fgOliveLight) }
-  public static var fgYellowDark: BezierColor { BezierColor(functionalColorToken: .fgOliveDark) }
+  public static var fgYellowNormal: BezierColor { BezierColor(functionalColorToken: .fgYellowNormal) }
+  public static var fgYellowLight: BezierColor { BezierColor(functionalColorToken: .fgYellowLight) }
+  public static var fgYellowDark: BezierColor { BezierColor(functionalColorToken: .fgYellowDark) }
 
   // MARK: ForegroundPink
   public static var fgPinkNormal: BezierColor { BezierColor(functionalColorToken: .fgPinkNormal) }


### PR DESCRIPTION
## 어떤 PR인가요?

BezierColor의 외부 참조가 가능한 static property fgYellowNormal, fgYellowLight, fgYellowDark가 내부에서 사용하는 functional color token을 각각 Olive 색상을 보고 있어 이를 수정합니다.

추가로 다른 컬러도 확인해보았는데 잘못 바라보고 있는 것은 이거 하나뿐이었습니다