### PR TITLE
[MOB-1753] StatusBadge, ChatBadge 구현

### DIFF
--- a/BezierSwift/Sources/Components/Badges/ChatBadge.swift
+++ b/BezierSwift/Sources/Components/Badges/ChatBadge.swift
@@ -7,11 +7,6 @@
 
 import SwiftUI
 
-private enum Constant {
-  static let backgroundColor: BezierColor = .bgWhiteHighest
-  static let iconColor: BezierColor = .fgBlackDarker
-}
-
 /// ChatBadge는 Avatar와 함께 사용되며 아이콘을 사용해 Root(Avatar)의 상태가 Private임을 알려줍니다.
 struct ChatBadge: View {
   private let configuration: ChatBadgeConfiguration
@@ -24,17 +19,17 @@ struct ChatBadge: View {
 
   public var body: some View {
     ZStack(alignment: .center) {
-      BezierIcon
-        .lock
-        .image
-        .frame(width: self.configuration.iconLength, height: self.configuration.iconLength)
-        .foregroundColor(Constant.iconColor.color)
-    }
-    .frame(width: self.configuration.length, height: self.configuration.length)
-    .background(
       Circle()
-        .foregroundColor(Constant.backgroundColor.color)
-    )
+        .fill(BezierColor.bgWhiteHighest.color)
+
+      BezierIcon.lock.image
+        // TODO: BezierButton 병합후 View.frame(length:) 로 변경합니다. - by Finn 2024.08.09
+        .frame(width: self.configuration.iconLength, height: self.configuration.iconLength)
+        .foregroundColor(BezierColor.fgBlackDarker.color)
+    }
+    // TODO: BezierButton 병합후 View.frame(length:) 로 변경합니다. - by Finn 2024.08.09
+    .frame(width: self.configuration.length, height: self.configuration.length)
+    .compositingGroup()
   }
 }
 

--- a/BezierSwift/Sources/Components/Badges/ChatBadge.swift
+++ b/BezierSwift/Sources/Components/Badges/ChatBadge.swift
@@ -1,0 +1,67 @@
+//
+//  ChatBadge.swift
+//
+//
+//  Created by 구본욱 on 8/9/24.
+//
+
+import SwiftUI
+
+private enum Constant {
+  static let backgroundColor: BezierColor = .bgWhiteHighest
+  static let iconColor: BezierColor = .fgBlackDarker
+}
+
+/// ChatBadge는 Avatar와 함께 사용되며 아이콘을 사용해 Root(Avatar)의 상태가 Private임을 알려줍니다.
+struct ChatBadge: View {
+  private let configuration: ChatBadgeConfiguration
+  
+  /// 주어진 ChatBadgeConfiguration에 따른 ChatBadge를 생성합니다.
+  /// - Parameter configuration: ChatBadge의 사이즈를 결정짓는 configuration 객체입니다.
+  public init(configuration: ChatBadgeConfiguration) {
+    self.configuration = configuration
+  }
+
+  public var body: some View {
+    ZStack(alignment: .center) {
+      BezierIcon
+        .lock
+        .image
+        .frame(width: self.configuration.iconLength, height: self.configuration.iconLength)
+        .foregroundColor(Constant.iconColor.color)
+    }
+    .frame(width: self.configuration.length, height: self.configuration.length)
+    .background(
+      Circle()
+        .foregroundColor(Constant.backgroundColor.color)
+    )
+  }
+}
+
+#Preview("Light Mode") {
+  VStack {
+    ChatBadge(configuration: .init(size: .medium))
+    ChatBadge(configuration: .init(size: .large))
+  }
+  .frame(maxWidth: .infinity, maxHeight: .infinity)
+  .background(
+    Rectangle()
+      .foregroundColor(BezierColor.bgBlackDark.color)
+  )
+  .ignoresSafeArea()
+  .preferredColorScheme(.light)
+}
+
+#Preview("Dark Mode") {
+  VStack {
+    ChatBadge(configuration: .init(size: .medium))
+    ChatBadge(configuration: .init(size: .large))
+  }
+  .frame(maxWidth: .infinity, maxHeight: .infinity)
+  .background(
+    Rectangle()
+      .foregroundColor(BezierColor.bgBlackDark.color)
+  )
+  .ignoresSafeArea()
+  .preferredColorScheme(.dark)
+}

--- a/BezierSwift/Sources/Components/Badges/ChatBadgeConfiguration.swift
+++ b/BezierSwift/Sources/Components/Badges/ChatBadgeConfiguration.swift
@@ -1,0 +1,42 @@
+//
+//  ChatBadgeConfiguration.swift
+//
+//
+//  Created by 구본욱 on 8/9/24.
+//
+
+import Foundation
+
+/// ChatBadge의 사이즈와 아이콘 형태를 결정짓는 configuration  객체입니다.
+public struct ChatBadgeConfiguration: Sendable, Equatable {
+  public enum Size: Sendable {
+    case medium
+    case large
+  }
+
+  let size: Size
+
+  var length: CGFloat {
+    switch self.size {
+    case .medium:
+      return 12
+    case .large:
+      return 20
+    }
+  }
+
+  var iconLength: CGFloat {
+    switch self.size {
+    case .medium:
+      return 10
+    case .large:
+      return 16
+    }
+  }
+  
+  /// ChatBadge의 사이즈를 결정짓는 configuration 객체를 생성합니다.
+  /// - Parameter size: 일반적으로 medium이 쓰이며, Root(Avatar)가 일정 사이즈 이상인 경우 large를 사용합니다.
+  public init(size: Size) {
+    self.size = size
+  }
+}

--- a/BezierSwift/Sources/Components/Badges/StatusBadge.swift
+++ b/BezierSwift/Sources/Components/Badges/StatusBadge.swift
@@ -7,10 +7,6 @@
 
 import SwiftUI
 
-private enum Constant {
-  static let backgroundColor: BezierColor = .bgWhiteHighest
-}
-
 /// StatusBadge는 Avatar와 함께 사용되며 Root(Avatar)의 상태를 아이콘이나 이미지를 사용해 직관적으로 알려줍니다.
 public struct StatusBadge: View {
   private let configuration: StatusBadgeConfiguration
@@ -23,25 +19,24 @@ public struct StatusBadge: View {
 
   public var body: some View {
     ZStack(alignment: .center) {
+      Circle()
+        .fill(BezierColor.bgWhiteHighest.color)
+
       self.icon
-        .frame(
-          width: self.configuration.iconLength,
-          height: self.configuration.iconLength
-        )
+        // TODO: BezierButton 병합후 View.frame(length:) 로 변경합니다. - by Finn 2024.08.09
+        .frame(width: self.configuration.iconLength, height: self.configuration.iconLength)
         .foregroundColor(self.configuration.iconColor.color)
     }
+    // TODO: BezierButton 병합후 View.frame(length:) 로 변경합니다. - by Finn 2024.08.09
     .frame(width: self.configuration.length, height: self.configuration.length)
-    .background(
-      Circle()
-        .foregroundColor(Constant.backgroundColor.color)
-    )
+    .compositingGroup()
   }
 }
 
 extension StatusBadge {
   @ViewBuilder
   private var icon: some View {
-    if self.configuration.isDoNotDisturb {
+    if self.configuration.doNotDisturb {
       BezierIcon.moonFilled.image
     } else {
       Circle()
@@ -50,60 +45,56 @@ extension StatusBadge {
 }
 
 #Preview("Light Mode") {
-  VStack {
-    HStack {
-      VStack {
-        StatusBadge(configuration: .init(isOnline: true, size: .medium, isDoNotDisturb: false))
-        StatusBadge(configuration: .init(isOnline: true, size: .large, isDoNotDisturb: false))
-      }
-      VStack {
-        StatusBadge(configuration: .init(isOnline: false, size: .medium, isDoNotDisturb: false))
-        StatusBadge(configuration: .init(isOnline: false, size: .large, isDoNotDisturb: false))
-      }
-      VStack {
-        StatusBadge(configuration: .init(isOnline: true, size: .medium, isDoNotDisturb: true))
-        StatusBadge(configuration: .init(isOnline: true, size: .large, isDoNotDisturb: true))
-      }
-      VStack {
-        StatusBadge(configuration: .init(isOnline: false, size: .medium, isDoNotDisturb: true))
-        StatusBadge(configuration: .init(isOnline: false, size: .large, isDoNotDisturb: true))
-      }
+  HStack {
+    VStack {
+      StatusBadge(configuration: .init(online: true, size: .medium, doNotDisturb: false))
+      StatusBadge(configuration: .init(online: true, size: .large, doNotDisturb: false))
+    }
+    VStack {
+      StatusBadge(configuration: .init(online: false, size: .medium, doNotDisturb: false))
+      StatusBadge(configuration: .init(online: false, size: .large, doNotDisturb: false))
+    }
+    VStack {
+      StatusBadge(configuration: .init(online: true, size: .medium, doNotDisturb: true))
+      StatusBadge(configuration: .init(online: true, size: .large, doNotDisturb: true))
+    }
+    VStack {
+      StatusBadge(configuration: .init(online: false, size: .medium, doNotDisturb: true))
+      StatusBadge(configuration: .init(online: false, size: .large, doNotDisturb: true))
     }
   }
   .frame(maxWidth: .infinity, maxHeight: .infinity)
   .background(
     Rectangle()
-      .foregroundColor(BezierColor.bgBlackDark.color)
+      .fill(BezierColor.bgBlackDark.color)
   )
   .ignoresSafeArea()
   .preferredColorScheme(.light)
 }
 
 #Preview("Dark Mode") {
-  VStack {
-    HStack {
-      VStack {
-        StatusBadge(configuration: .init(isOnline: true, size: .medium, isDoNotDisturb: false))
-        StatusBadge(configuration: .init(isOnline: true, size: .large, isDoNotDisturb: false))
-      }
-      VStack {
-        StatusBadge(configuration: .init(isOnline: false, size: .medium, isDoNotDisturb: false))
-        StatusBadge(configuration: .init(isOnline: false, size: .large, isDoNotDisturb: false))
-      }
-      VStack {
-        StatusBadge(configuration: .init(isOnline: true, size: .medium, isDoNotDisturb: true))
-        StatusBadge(configuration: .init(isOnline: true, size: .large, isDoNotDisturb: true))
-      }
-      VStack {
-        StatusBadge(configuration: .init(isOnline: false, size: .medium, isDoNotDisturb: true))
-        StatusBadge(configuration: .init(isOnline: false, size: .large, isDoNotDisturb: true))
-      }
+  HStack {
+    VStack {
+      StatusBadge(configuration: .init(online: true, size: .medium, doNotDisturb: false))
+      StatusBadge(configuration: .init(online: true, size: .large, doNotDisturb: false))
+    }
+    VStack {
+      StatusBadge(configuration: .init(online: false, size: .medium, doNotDisturb: false))
+      StatusBadge(configuration: .init(online: false, size: .large, doNotDisturb: false))
+    }
+    VStack {
+      StatusBadge(configuration: .init(online: true, size: .medium, doNotDisturb: true))
+      StatusBadge(configuration: .init(online: true, size: .large, doNotDisturb: true))
+    }
+    VStack {
+      StatusBadge(configuration: .init(online: false, size: .medium, doNotDisturb: true))
+      StatusBadge(configuration: .init(online: false, size: .large, doNotDisturb: true))
     }
   }
   .frame(maxWidth: .infinity, maxHeight: .infinity)
   .background(
     Rectangle()
-      .foregroundColor(BezierColor.bgBlackDark.color)
+      .fill(BezierColor.bgBlackDark.color)
   )
   .ignoresSafeArea()
   .preferredColorScheme(.dark)

--- a/BezierSwift/Sources/Components/Badges/StatusBadge.swift
+++ b/BezierSwift/Sources/Components/Badges/StatusBadge.swift
@@ -1,0 +1,110 @@
+//
+//  StatusBadge.swift
+//
+//
+//  Created by 구본욱 on 8/9/24.
+//
+
+import SwiftUI
+
+private enum Constant {
+  static let backgroundColor: BezierColor = .bgWhiteHighest
+}
+
+/// StatusBadge는 Avatar와 함께 사용되며 Root(Avatar)의 상태를 아이콘이나 이미지를 사용해 직관적으로 알려줍니다.
+public struct StatusBadge: View {
+  private let configuration: StatusBadgeConfiguration
+  
+  /// 주어진 StatusBadgeConfiguration에 따른 StatusBadge 뷰를 생성합니다.
+  /// - Parameter configuration: StatusBadge의 사이즈와 아이콘 형태를 결정짓는 configuration 객체입니다.
+  public init(configuration: StatusBadgeConfiguration) {
+    self.configuration = configuration
+  }
+
+  public var body: some View {
+    ZStack(alignment: .center) {
+      self.icon
+        .frame(
+          width: self.configuration.iconLength,
+          height: self.configuration.iconLength
+        )
+        .foregroundColor(self.configuration.iconColor.color)
+    }
+    .frame(width: self.configuration.length, height: self.configuration.length)
+    .background(
+      Circle()
+        .foregroundColor(Constant.backgroundColor.color)
+    )
+  }
+}
+
+extension StatusBadge {
+  @ViewBuilder
+  private var icon: some View {
+    if self.configuration.isDoNotDisturb {
+      BezierIcon.moonFilled.image
+    } else {
+      Circle()
+    }
+  }
+}
+
+#Preview("Light Mode") {
+  VStack {
+    HStack {
+      VStack {
+        StatusBadge(configuration: .init(isOnline: true, size: .medium, isDoNotDisturb: false))
+        StatusBadge(configuration: .init(isOnline: true, size: .large, isDoNotDisturb: false))
+      }
+      VStack {
+        StatusBadge(configuration: .init(isOnline: false, size: .medium, isDoNotDisturb: false))
+        StatusBadge(configuration: .init(isOnline: false, size: .large, isDoNotDisturb: false))
+      }
+      VStack {
+        StatusBadge(configuration: .init(isOnline: true, size: .medium, isDoNotDisturb: true))
+        StatusBadge(configuration: .init(isOnline: true, size: .large, isDoNotDisturb: true))
+      }
+      VStack {
+        StatusBadge(configuration: .init(isOnline: false, size: .medium, isDoNotDisturb: true))
+        StatusBadge(configuration: .init(isOnline: false, size: .large, isDoNotDisturb: true))
+      }
+    }
+  }
+  .frame(maxWidth: .infinity, maxHeight: .infinity)
+  .background(
+    Rectangle()
+      .foregroundColor(BezierColor.bgBlackDark.color)
+  )
+  .ignoresSafeArea()
+  .preferredColorScheme(.light)
+}
+
+#Preview("Dark Mode") {
+  VStack {
+    HStack {
+      VStack {
+        StatusBadge(configuration: .init(isOnline: true, size: .medium, isDoNotDisturb: false))
+        StatusBadge(configuration: .init(isOnline: true, size: .large, isDoNotDisturb: false))
+      }
+      VStack {
+        StatusBadge(configuration: .init(isOnline: false, size: .medium, isDoNotDisturb: false))
+        StatusBadge(configuration: .init(isOnline: false, size: .large, isDoNotDisturb: false))
+      }
+      VStack {
+        StatusBadge(configuration: .init(isOnline: true, size: .medium, isDoNotDisturb: true))
+        StatusBadge(configuration: .init(isOnline: true, size: .large, isDoNotDisturb: true))
+      }
+      VStack {
+        StatusBadge(configuration: .init(isOnline: false, size: .medium, isDoNotDisturb: true))
+        StatusBadge(configuration: .init(isOnline: false, size: .large, isDoNotDisturb: true))
+      }
+    }
+  }
+  .frame(maxWidth: .infinity, maxHeight: .infinity)
+  .background(
+    Rectangle()
+      .foregroundColor(BezierColor.bgBlackDark.color)
+  )
+  .ignoresSafeArea()
+  .preferredColorScheme(.dark)
+}

--- a/BezierSwift/Sources/Components/Badges/StatusBadge.swift
+++ b/BezierSwift/Sources/Components/Badges/StatusBadge.swift
@@ -25,7 +25,6 @@ public struct StatusBadge: View {
       self.icon
         // TODO: BezierButton 병합후 View.frame(length:) 로 변경합니다. - by Finn 2024.08.09
         .frame(width: self.configuration.iconLength, height: self.configuration.iconLength)
-        .foregroundColor(self.configuration.iconColor.color)
     }
     // TODO: BezierButton 병합후 View.frame(length:) 로 변경합니다. - by Finn 2024.08.09
     .frame(width: self.configuration.length, height: self.configuration.length)
@@ -38,8 +37,10 @@ extension StatusBadge {
   private var icon: some View {
     if self.configuration.doNotDisturb {
       BezierIcon.moonFilled.image
+        .foregroundColor(self.configuration.iconColor.color)
     } else {
       Circle()
+        .fill(self.configuration.iconColor.color)
     }
   }
 }

--- a/BezierSwift/Sources/Components/Badges/StatusBadge.swift
+++ b/BezierSwift/Sources/Components/Badges/StatusBadge.swift
@@ -25,6 +25,7 @@ public struct StatusBadge: View {
       self.icon
         // TODO: BezierButton 병합후 View.frame(length:) 로 변경합니다. - by Finn 2024.08.09
         .frame(width: self.configuration.iconLength, height: self.configuration.iconLength)
+        .foregroundColor(self.configuration.iconColor.color)
     }
     // TODO: BezierButton 병합후 View.frame(length:) 로 변경합니다. - by Finn 2024.08.09
     .frame(width: self.configuration.length, height: self.configuration.length)
@@ -37,10 +38,9 @@ extension StatusBadge {
   private var icon: some View {
     if self.configuration.doNotDisturb {
       BezierIcon.moonFilled.image
-        .foregroundColor(self.configuration.iconColor.color)
     } else {
       Circle()
-        .fill(self.configuration.iconColor.color)
+        .fill()
     }
   }
 }

--- a/BezierSwift/Sources/Components/Badges/StatusBadgeConfiguration.swift
+++ b/BezierSwift/Sources/Components/Badges/StatusBadgeConfiguration.swift
@@ -14,9 +14,9 @@ public struct StatusBadgeConfiguration: Sendable, Equatable {
     case medium
   }
 
-  let isOnline: Bool
+  let online: Bool
   let size: Size
-  let isDoNotDisturb: Bool
+  let doNotDisturb: Bool
 
   var length: CGFloat {
     switch self.size {
@@ -28,15 +28,15 @@ public struct StatusBadgeConfiguration: Sendable, Equatable {
   var iconLength: CGFloat {
     switch self.size {
     case .large:
-      return self.isDoNotDisturb ? 16 : 14
+      return self.doNotDisturb ? 16 : 14
     case .medium:
-      return self.isDoNotDisturb ? 10 : 8
+      return self.doNotDisturb ? 10 : 8
     }
   }
 
   var iconColor: BezierColor {
-    guard self.isOnline else {
-      return self.isDoNotDisturb ? .fgYellowNormal : .bgGreyDark
+    guard self.online else {
+      return self.doNotDisturb ? .fgYellowNormal : .bgGreyDark
     }
 
     return .fgGreenNormal
@@ -44,12 +44,12 @@ public struct StatusBadgeConfiguration: Sendable, Equatable {
   
   /// StatusBadge의 사이즈와 아이콘 형태를 결정짓는 configuration 객체를 생성합니다.
   /// - Parameters:
-  ///   - isOnline: StatusBadge와 함께 사용되는 Avatar의 대상이 현재 온라인 상태인지를 표현하는 값입니다.
+  ///   - online: StatusBadge와 함께 사용되는 Avatar의 대상이 현재 온라인 상태인지를 표현하는 값입니다.
   ///   - size: 일반적으로 medium 이 쓰이며, Root(Avatar)가 일정 사이즈 이상인 경우 large를 사용합니다.
-  ///   - isDoNotDisturb: StatusBadge와 함께 사용되는 Avatar의 대상이 Do Not Disturb(방해 금지 모드) 상태인지를 표현하는 값입니다.
-  public init(isOnline: Bool, size: Size, isDoNotDisturb: Bool) {
-    self.isOnline = isOnline
+  ///   - doNotDisturb: StatusBadge와 함께 사용되는 Avatar의 대상이 Do Not Disturb(방해 금지 모드) 상태인지를 표현하는 값입니다.
+  public init(online: Bool, size: Size, doNotDisturb: Bool) {
+    self.online = online
     self.size = size
-    self.isDoNotDisturb = isDoNotDisturb
+    self.doNotDisturb = doNotDisturb
   }
 }

--- a/BezierSwift/Sources/Components/Badges/StatusBadgeConfiguration.swift
+++ b/BezierSwift/Sources/Components/Badges/StatusBadgeConfiguration.swift
@@ -1,0 +1,55 @@
+//
+//  StatusBadgeConfiguration.swift
+//
+//
+//  Created by 구본욱 on 8/9/24.
+//
+
+import Foundation
+
+/// StatusBadge의 사이즈와 아이콘 형태를 결정짓는 configuration 객체입니다.
+public struct StatusBadgeConfiguration: Sendable, Equatable {
+  public enum Size: Sendable {
+    case large
+    case medium
+  }
+
+  let isOnline: Bool
+  let size: Size
+  let isDoNotDisturb: Bool
+
+  var length: CGFloat {
+    switch self.size {
+    case .large: return 20
+    case .medium: return 12
+    }
+  }
+
+  var iconLength: CGFloat {
+    switch self.size {
+    case .large:
+      return self.isDoNotDisturb ? 16 : 14
+    case .medium:
+      return self.isDoNotDisturb ? 10 : 8
+    }
+  }
+
+  var iconColor: BezierColor {
+    guard self.isOnline else {
+      return self.isDoNotDisturb ? .fgYellowNormal : .bgGreyDark
+    }
+
+    return .fgGreenNormal
+  }
+  
+  /// StatusBadge의 사이즈와 아이콘 형태를 결정짓는 configuration 객체를 생성합니다.
+  /// - Parameters:
+  ///   - isOnline: StatusBadge와 함께 사용되는 Avatar의 대상이 현재 온라인 상태인지를 표현하는 값입니다.
+  ///   - size: 일반적으로 medium 이 쓰이며, Root(Avatar)가 일정 사이즈 이상인 경우 large를 사용합니다.
+  ///   - isDoNotDisturb: StatusBadge와 함께 사용되는 Avatar의 대상이 Do Not Disturb(방해 금지 모드) 상태인지를 표현하는 값입니다.
+  public init(isOnline: Bool, size: Size, isDoNotDisturb: Bool) {
+    self.isOnline = isOnline
+    self.size = size
+    self.isDoNotDisturb = isDoNotDisturb
+  }
+}


### PR DESCRIPTION
## 어떤 PR인가요?

베지어 컴포넌트중 StatusBadge, ChatBadge를 구현하는 PR입니다.

## 작업 내용

- StatusBadge와 그에 대응하는 StatusBadgeConfiguration을 구현합니다.
- ChatBadge와 그에 대응하는 ChatBadgeConfiguration을 구현합니다.

### 미비된 작업

- ExampleView가 아직 준비되지 않았습니다. #57 PR이 병합되면 해당 PR의 방식에 따라 비슷한 형태의 ExampleView를 추가할 예정입니다.
- 이 PR에서는 아직 fgYellowNormal이 fgOliveNormal을 바라보고 있기 때문에 #63 PR이 병합되어야 뷰의 색상이 제대로 보이게 됩니다

## 스크린샷

| | StatusBadge | ChatBadge|
|---|---|---|
| LightMode | <img width="474" alt="스크린샷 2024-08-09 오전 11 07 48" src="https://github.com/user-attachments/assets/a8335a71-8aa9-4f09-afbc-e8cde952a35b"> | <img width="188" alt="스크린샷 2024-08-09 오전 11 07 30" src="https://github.com/user-attachments/assets/dd764dc8-9b8a-462c-bd31-526cff62941b"> |
| DarkMode | <img width="468" alt="스크린샷 2024-08-09 오전 11 08 10" src="https://github.com/user-attachments/assets/1af79368-3412-41da-8184-219f9c164182"> | <img width="305" alt="스크린샷 2024-08-09 오전 11 08 03" src="https://github.com/user-attachments/assets/0fc7319a-cce9-480c-b0ab-58f697e42ccf"> | 
