### PR TITLE
[Improvement] BezierColor V1 마이그레이션 코드 적용

### DIFF
--- a/BezierSwift/Sources/Foundation/Color/BezierColor.swift
+++ b/BezierSwift/Sources/Foundation/Color/BezierColor.swift
@@ -378,7 +378,7 @@ extension BezierColor {
   public static var successFgDark: BezierColor { BezierColor(semanticToken: .successFgDark) }
 }
 
-// MARK: - Legacy SemanticColor Support
+// MARK: - Bezier V1 SemanticColor Support
 extension BezierColor {
   // MARK: - Background
   @available(*, deprecated, renamed: "bgWhiteAlphaTransparent", message: "Use `bgWhiteAlphaTransparent` instead.")
@@ -389,49 +389,13 @@ extension BezierColor {
   
   @available(*, deprecated, renamed: "bgWhiteHigher", message: "Use `bgWhiteHigher` instead.")
   public static var bgWhiteLow: BezierColor { BezierColor(functionalColorToken: .bgWhiteHigher) }
-  
-//  @available(*, deprecated, renamed: "bgWhiteNormal", message: "Use `bgWhiteNormal` instead.")
-//  public static var bgWhiteNormal: BezierColor { BezierColor(functionalColorToken: .bgWhiteNormal) }
-  
+
   @available(*, deprecated, renamed: "bgWhiteAlphaLighter", message: "Use `bgWhiteAlphaLighter` instead.")
   public static var bgWhiteDimDark: BezierColor { BezierColor(functionalColorToken: .bgWhiteAlphaLighter) }
   
   @available(*, deprecated, renamed: "bgWhiteAlphaLight", message: "Use `bgWhiteAlphaLight` instead.")
   public static var bgWhiteDimLight: BezierColor { BezierColor(functionalColorToken: .bgWhiteAlphaLight) }
-  
-//  @available(*, deprecated, renamed: "bgBlackDark", message: "Use `bgBlackDark` instead.")
-//  public static var bgBlackDark: BezierColor { BezierColor(functionalColorToken: .bgBlackDark) }
-  
-//  @available(*, deprecated, renamed: "bgBlackDarker", message: "Use `bgBlackDarker` instead.")
-//  public static var bgBlackDarker: BezierColor { BezierColor(functionalColorToken: .bgBlackDarker) }
-  
-//  @available(*, deprecated, renamed: "bgBlackDarkest", message: "Use `bgBlackDarkest` instead.")
-//  public static var bgBlackDarkest: BezierColor { BezierColor(functionalColorToken: .bgBlackDarkest) }
-  
-//  @available(*, deprecated, renamed: "bgBlackLight", message: "Use `bgBlackLight` instead.")
-//  public static var bgBlackLight: BezierColor { BezierColor(functionalColorToken: .bgBlackLight) }
-  
-//  @available(*, deprecated, renamed: "bgBlackLighter", message: "Use `bgBlackLighter` instead.")
-//  public static var bgBlackLighter: BezierColor { BezierColor(functionalColorToken: .bgBlackLighter) }
-  
-//  @available(*, deprecated, renamed: "bgBlackLightest", message: "Use `bgBlackLightest` instead.")
-//  public static var bgBlackLightest: BezierColor { BezierColor(functionalColorToken: .bgBlackLightest) }
-  
-//  @available(*, deprecated, renamed: "bgGreyDarkest", message: "Use `bgGreyDarkest` instead.")
-//  public static var bgGreyDarkest: BezierColor { BezierColor(functionalColorToken: .bgGreyDarkest) }
-  
-//  @available(*, deprecated, renamed: "bgGreyDark", message: "Use `bgGreyDark` instead.")
-//  public static var bgGreyDark: BezierColor { BezierColor(functionalColorToken: .bgGreyDark) }
-  
-//  @available(*, deprecated, renamed: "bgGreyLight", message: "Use `bgGreyLight` instead.")
-//  public static var bgGreyLight: BezierColor { BezierColor(functionalColorToken: .bgGreyLight) }
-  
-//  @available(*, deprecated, renamed: "bgGreyLighter", message: "Use `bgGreyLighter` instead.")
-//  public static var bgGreyLighter: BezierColor { BezierColor(functionalColorToken: .bgGreyLighter) }
-  
-//  @available(*, deprecated, renamed: "bgGreyLightest", message: "Use `bgGreyLightest` instead.")
-//  public static var bgGreyLightest: BezierColor { BezierColor(functionalColorToken: .bgGreyLightest) }
-  
+
   @available(*, deprecated, renamed: "bgGreyAlphaLight", message: "Use `bgGreyAlphaLight` instead.")
   public static var bgGreyDimLightest: BezierColor { BezierColor(functionalColorToken: .bgGreyAlphaLight) }
   

--- a/BezierSwift/Sources/Foundation/Color/BezierColor.swift
+++ b/BezierSwift/Sources/Foundation/Color/BezierColor.swift
@@ -377,3 +377,334 @@ extension BezierColor {
   public static var successFgLight: BezierColor { BezierColor(semanticToken: .successFgLight) }
   public static var successFgDark: BezierColor { BezierColor(semanticToken: .successFgDark) }
 }
+
+// MARK: - Legacy SemanticColor Support
+extension BezierColor {
+  // MARK: - Background
+  @available(*, deprecated, renamed: "bgWhiteAlphaTransparent", message: "Use `bgWhiteAlphaTransparent` instead.")
+  public static var bgTransparent: BezierColor { BezierColor(functionalColorToken: .bgWhiteAlphaTransparent) }
+  
+  @available(*, deprecated, renamed: "bgWhiteHighest", message: "Use `bgWhiteHighest` instead.")
+  public static var bgWhiteHigh: BezierColor { BezierColor(functionalColorToken: .bgWhiteHighest) }
+  
+  @available(*, deprecated, renamed: "bgWhiteHigher", message: "Use `bgWhiteHigher` instead.")
+  public static var bgWhiteLow: BezierColor { BezierColor(functionalColorToken: .bgWhiteHigher) }
+  
+//  @available(*, deprecated, renamed: "bgWhiteNormal", message: "Use `bgWhiteNormal` instead.")
+//  public static var bgWhiteNormal: BezierColor { BezierColor(functionalColorToken: .bgWhiteNormal) }
+  
+  @available(*, deprecated, renamed: "bgWhiteAlphaLighter", message: "Use `bgWhiteAlphaLighter` instead.")
+  public static var bgWhiteDimDark: BezierColor { BezierColor(functionalColorToken: .bgWhiteAlphaLighter) }
+  
+  @available(*, deprecated, renamed: "bgWhiteAlphaLight", message: "Use `bgWhiteAlphaLight` instead.")
+  public static var bgWhiteDimLight: BezierColor { BezierColor(functionalColorToken: .bgWhiteAlphaLight) }
+  
+//  @available(*, deprecated, renamed: "bgBlackDark", message: "Use `bgBlackDark` instead.")
+//  public static var bgBlackDark: BezierColor { BezierColor(functionalColorToken: .bgBlackDark) }
+  
+//  @available(*, deprecated, renamed: "bgBlackDarker", message: "Use `bgBlackDarker` instead.")
+//  public static var bgBlackDarker: BezierColor { BezierColor(functionalColorToken: .bgBlackDarker) }
+  
+//  @available(*, deprecated, renamed: "bgBlackDarkest", message: "Use `bgBlackDarkest` instead.")
+//  public static var bgBlackDarkest: BezierColor { BezierColor(functionalColorToken: .bgBlackDarkest) }
+  
+//  @available(*, deprecated, renamed: "bgBlackLight", message: "Use `bgBlackLight` instead.")
+//  public static var bgBlackLight: BezierColor { BezierColor(functionalColorToken: .bgBlackLight) }
+  
+//  @available(*, deprecated, renamed: "bgBlackLighter", message: "Use `bgBlackLighter` instead.")
+//  public static var bgBlackLighter: BezierColor { BezierColor(functionalColorToken: .bgBlackLighter) }
+  
+//  @available(*, deprecated, renamed: "bgBlackLightest", message: "Use `bgBlackLightest` instead.")
+//  public static var bgBlackLightest: BezierColor { BezierColor(functionalColorToken: .bgBlackLightest) }
+  
+//  @available(*, deprecated, renamed: "bgGreyDarkest", message: "Use `bgGreyDarkest` instead.")
+//  public static var bgGreyDarkest: BezierColor { BezierColor(functionalColorToken: .bgGreyDarkest) }
+  
+//  @available(*, deprecated, renamed: "bgGreyDark", message: "Use `bgGreyDark` instead.")
+//  public static var bgGreyDark: BezierColor { BezierColor(functionalColorToken: .bgGreyDark) }
+  
+//  @available(*, deprecated, renamed: "bgGreyLight", message: "Use `bgGreyLight` instead.")
+//  public static var bgGreyLight: BezierColor { BezierColor(functionalColorToken: .bgGreyLight) }
+  
+//  @available(*, deprecated, renamed: "bgGreyLighter", message: "Use `bgGreyLighter` instead.")
+//  public static var bgGreyLighter: BezierColor { BezierColor(functionalColorToken: .bgGreyLighter) }
+  
+//  @available(*, deprecated, renamed: "bgGreyLightest", message: "Use `bgGreyLightest` instead.")
+//  public static var bgGreyLightest: BezierColor { BezierColor(functionalColorToken: .bgGreyLightest) }
+  
+  @available(*, deprecated, renamed: "bgGreyAlphaLight", message: "Use `bgGreyAlphaLight` instead.")
+  public static var bgGreyDimLightest: BezierColor { BezierColor(functionalColorToken: .bgGreyAlphaLight) }
+  
+  @available(*, deprecated, renamed: "bgGreyAlphaDarkest", message: "Use `bgGreyAlphaDarkest` instead.")
+  public static var bgGnb: BezierColor { BezierColor(functionalColorToken: .bgGreyAlphaDarkest) }
+  
+  @available(*, deprecated, renamed: "bgGreyAlphaDark", message: "Use `bgGreyAlphaDark` instead.")
+  public static var bgNavi: BezierColor { BezierColor(functionalColorToken: .bgGreyAlphaDark) }
+  
+  @available(*, deprecated, renamed: "bgWhiteAlphaLightest", message: "Use `bgWhiteAlphaLightest` instead.")
+  public static var bgHeaderFloat: BezierColor { BezierColor(functionalColorToken: .bgWhiteAlphaLightest) }
+  
+  @available(*, deprecated, renamed: "bgWhiteHigher", message: "Use `bgWhiteHigher` instead.")
+  public static var bgHeader: BezierColor { BezierColor(functionalColorToken: .bgWhiteHigher) }
+  
+  @available(*, deprecated, renamed: "bgGreyAlphaDarker", message: "Use `bgGreyAlphaDarker` instead.")
+  public static var bgLounge: BezierColor { BezierColor(functionalColorToken: .bgGreyAlphaDarker) }
+  
+  // MARK: - Text
+  @available(*, deprecated, renamed: "fgBlackDarkest", message: "Use `fgBlackDarkest` instead.")
+  public static var txtBlackDarkest: BezierColor { BezierColor(functionalColorToken: .fgBlackDarkest) }
+  
+  @available(*, deprecated, renamed: "fgBlackDarker", message: "Use `fgBlackDarker` instead.")
+  public static var txtBlackDarker: BezierColor { BezierColor(functionalColorToken: .fgBlackDarker) }
+  
+  @available(*, deprecated, renamed: "fgBlackDark", message: "Use `fgBlackDark` instead.")
+  public static var txtBlackDark: BezierColor { BezierColor(functionalColorToken: .fgBlackDark) }
+  
+  @available(*, deprecated, renamed: "fgWhiteNormal", message: "Use `fgWhiteNormal` instead.")
+  public static var txtWhiteNormal: BezierColor { BezierColor(functionalColorToken: .fgWhiteNormal) }
+  
+  @available(*, deprecated, renamed: "fgBlackPure", message: "Use `fgBlackPure` instead.")
+  public static var txtBlackPure: BezierColor { BezierColor(functionalColorToken: .fgBlackPure) }
+  
+  // MARK: - Background & Text - Absolute
+  @available(*, deprecated, renamed: "bgAbsoluteBlackDark", message: "Use `bgAbsoluteBlackDark` instead.")
+  public static var bgtxtAbsoluteBlackDark: BezierColor { BezierColor(functionalColorToken: .bgAbsoluteBlackDark) }
+  
+  @available(*, deprecated, renamed: "bgAbsoluteBlackNormal", message: "Use `bgAbsoluteBlackNormal` instead.")
+  public static var bgtxtAbsoluteBlackNormal: BezierColor { BezierColor(functionalColorToken: .bgAbsoluteBlackNormal) }
+  
+  @available(*, deprecated, renamed: "bgAbsoluteBlackLight", message: "Use `bgAbsoluteBlackLight` instead.")
+  public static var bgtxtAbsoluteBlackLight: BezierColor { BezierColor(functionalColorToken: .bgAbsoluteBlackLight) }
+  
+  @available(*, deprecated, renamed: "bgAbsoluteBlackLighter", message: "Use `bgAbsoluteBlackLighter` instead.")
+  public static var bgtxtAbsoluteBlackLighter: BezierColor { BezierColor(functionalColorToken: .bgAbsoluteBlackLighter) }
+  
+  @available(*, deprecated, renamed: "bgAbsoluteBlackLightest", message: "Use `bgAbsoluteBlackLightest` instead.")
+  public static var bgtxtAbsoluteBlackLightest: BezierColor { BezierColor(functionalColorToken: .bgAbsoluteBlackLightest) }
+  
+  @available(*, deprecated, renamed: "bgAbsoluteWhiteDark", message: "Use `bgAbsoluteWhiteDark` instead.")
+  public static var bgtxtAbsoluteWhiteDark: BezierColor { BezierColor(functionalColorToken: .bgAbsoluteWhiteDark) }
+  
+  @available(*, deprecated, renamed: "bgAbsoluteWhiteNormal", message: "Use `bgAbsoluteWhiteNormal` instead.")
+  public static var bgtxtAbsoluteWhiteNormal: BezierColor { BezierColor(functionalColorToken: .bgAbsoluteWhiteNormal) }
+  
+  @available(*, deprecated, renamed: "bgAbsoluteWhiteLight", message: "Use `bgAbsoluteWhiteLight` instead.")
+  public static var bgtxtAbsoluteWhiteLight: BezierColor { BezierColor(functionalColorToken: .bgAbsoluteWhiteLight) }
+  
+  @available(*, deprecated, renamed: "bgAbsoluteWhiteLighter", message: "Use `bgAbsoluteWhiteLighter` instead.")
+  public static var bgtxtAbsoluteWhiteLighter: BezierColor { BezierColor(functionalColorToken: .bgAbsoluteWhiteLighter) }
+  
+  @available(*, deprecated, renamed: "bgAbsoluteWhiteLightest", message: "Use `bgAbsoluteWhiteLightest` instead.")
+  public static var bgtxtAbsoluteWhiteLightest: BezierColor { BezierColor(functionalColorToken: .bgAbsoluteWhiteLightest) }
+  
+  // MARK: - Shadow for elevation
+  @available(*, deprecated, renamed: "shadowXlarge", message: "Use `shadowXlarge` instead.")
+  public static var shdwXlarge: BezierColor { BezierColor(functionalColorToken: .shadowXlarge) }
+  
+  @available(*, deprecated, renamed: "shadowLarge", message: "Use `shadowLarge` instead.")
+  public static var shdwLarge: BezierColor { BezierColor(functionalColorToken: .shadowLarge) }
+  
+  @available(*, deprecated, renamed: "shadowMedium", message: "Use `shadowMedium` instead.")
+  public static var shdwMedium: BezierColor { BezierColor(functionalColorToken: .shadowMedium) }
+  
+  @available(*, deprecated, renamed: "shadowSmall", message: "Use `shadowSmall` instead.")
+  public static var shdwSmall: BezierColor { BezierColor(functionalColorToken: .shadowSmall) }
+  
+  @available(*, deprecated, renamed: "shadowBase", message: "Use `shadowBase` instead.")
+  public static var shdwBase: BezierColor { BezierColor(functionalColorToken: .shadowBase) }
+  
+  @available(*, deprecated, renamed: "shadowBaseInner", message: "Use `shadowBaseInner` instead.")
+  public static var shdwBaseInner: BezierColor { BezierColor(functionalColorToken: .shadowBaseInner) }
+  
+  // MARK: - Border & Divider
+  @available(*, deprecated, renamed: "bgBlackDark", message: "Use `bgBlackDark` instead.")
+  public static var bdrBlackDark: BezierColor { BezierColor(functionalColorToken: .bgBlackDark) }
+  
+  @available(*, deprecated, renamed: "bgBlackLight", message: "Use `bgBlackLight` instead.")
+  public static var bdrBlackLight: BezierColor { BezierColor(functionalColorToken: .bgBlackLight) }
+  
+  @available(*, deprecated, renamed: "bgBlackLightest", message: "Use `bgBlackLightest` instead.")
+  public static var bdrBlackLightest: BezierColor { BezierColor(functionalColorToken: .bgBlackLightest) }
+  
+  @available(*, deprecated, renamed: "bgGreyLight", message: "Use `bgGreyLight` instead.")
+  public static var bdrGreyLight: BezierColor { BezierColor(functionalColorToken: .bgGreyLight) }
+  
+  @available(*, deprecated, renamed: "bgWhiteHighest", message: "Use `bgWhiteHighest` instead.")
+  public static var bdrWhite: BezierColor { BezierColor(functionalColorToken: .bgWhiteHighest) }
+  
+  // MARK: - Appendix, Blue
+  @available(*, deprecated, renamed: "bgBlueLightest", message: "Use `bgBlueLightest` instead.")
+  public static var bgtxtBlueLightest: BezierColor { BezierColor(functionalColorToken: .bgBlueLightest) }
+  
+  @available(*, deprecated, renamed: "bgBlueLighter", message: "Use `bgBlueLighter` instead.")
+  public static var bgtxtBlueLighter: BezierColor { BezierColor(functionalColorToken: .bgBlueLighter) }
+  
+  @available(*, deprecated, renamed: "bgBlueLight", message: "Use `bgBlueLight` instead.")
+  public static var bgtxtBlueLight: BezierColor { BezierColor(functionalColorToken: .bgBlueLight) }
+  
+  @available(*, deprecated, renamed: "bgBlueNormal", message: "Use `bgBlueNormal` instead.")
+  public static var bgtxtBlueNormal: BezierColor { BezierColor(functionalColorToken: .bgBlueNormal) }
+  
+  @available(*, deprecated, renamed: "bgBlueDark", message: "Use `bgBlueDark` instead.")
+  public static var bgtxtBlueDark: BezierColor { BezierColor(functionalColorToken: .bgBlueDark) }
+  
+  // MARK: - Appendix, Cobalt
+  @available(*, deprecated, renamed: "bgCobaltLightest", message: "Use `bgCobaltLightest` instead.")
+  public static var bgtxtCobaltLightest: BezierColor { BezierColor(functionalColorToken: .bgCobaltLightest) }
+  
+  @available(*, deprecated, renamed: "bgCobaltLighter", message: "Use `bgCobaltLighter` instead.")
+  public static var bgtxtCobaltLighter: BezierColor { BezierColor(functionalColorToken: .bgCobaltLighter) }
+  
+  @available(*, deprecated, renamed: "bgCobaltLight", message: "Use `bgCobaltLight` instead.")
+  public static var bgtxtCobaltLight: BezierColor { BezierColor(functionalColorToken: .bgCobaltLight) }
+  
+  @available(*, deprecated, renamed: "bgCobaltNormal", message: "Use `bgCobaltNormal` instead.")
+  public static var bgtxtCobaltNormal: BezierColor { BezierColor(functionalColorToken: .bgCobaltNormal) }
+  
+  @available(*, deprecated, renamed: "bgCobaltDark", message: "Use `bgCobaltDark` instead.")
+  public static var bgtxtCobaltDark: BezierColor { BezierColor(functionalColorToken: .bgCobaltDark) }
+  
+  // MARK: - Appendix, Teal
+  @available(*, deprecated, renamed: "bgTealLightest", message: "Use `bgTealLightest` instead.")
+  public static var bgtxtTealLightest: BezierColor { BezierColor(functionalColorToken: .bgTealLightest) }
+  
+  @available(*, deprecated, renamed: "bgTealLighter", message: "Use `bgTealLighter` instead.")
+  public static var bgtxtTealLighter: BezierColor { BezierColor(functionalColorToken: .bgTealLighter) }
+  
+  @available(*, deprecated, renamed: "bgTealLight", message: "Use `bgTealLight` instead.")
+  public static var bgtxtTealLight: BezierColor { BezierColor(functionalColorToken: .bgTealLight) }
+  
+  @available(*, deprecated, renamed: "bgTealNormal", message: "Use `bgTealNormal` instead.")
+  public static var bgtxtTealNormal: BezierColor { BezierColor(functionalColorToken: .bgTealNormal) }
+  
+  @available(*, deprecated, renamed: "bgTealDark", message: "Use `bgTealDark` instead.")
+  public static var bgtxtTealDark: BezierColor { BezierColor(functionalColorToken: .bgTealDark) }
+  
+  // MARK: - Appendix, Green
+  @available(*, deprecated, renamed: "bgGreenLightest", message: "Use `bgGreenLightest` instead.")
+  public static var bgtxtGreenLightest: BezierColor { BezierColor(functionalColorToken: .bgGreenLightest) }
+  
+  @available(*, deprecated, renamed: "bgGreenLighter", message: "Use `bgGreenLighter` instead.")
+  public static var bgtxtGreenLighter: BezierColor { BezierColor(functionalColorToken: .bgGreenLighter) }
+  
+  @available(*, deprecated, renamed: "bgGreenLight", message: "Use `bgGreenLight` instead.")
+  public static var bgtxtGreenLight: BezierColor { BezierColor(functionalColorToken: .bgGreenLight) }
+  
+  @available(*, deprecated, renamed: "bgGreenNormal", message: "Use `bgGreenNormal` instead.")
+  public static var bgtxtGreenNormal: BezierColor { BezierColor(functionalColorToken: .bgGreenNormal) }
+  
+  @available(*, deprecated, renamed: "bgGreenDark", message: "Use `bgGreenDark` instead.")
+  public static var bgtxtGreenDark: BezierColor { BezierColor(functionalColorToken: .bgGreenDark) }
+  
+  // MARK: - Appendix, Olive
+  @available(*, deprecated, renamed: "bgOliveLightest", message: "Use `bgOliveLightest` instead.")
+  public static var bgtxtOliveLightest: BezierColor { BezierColor(functionalColorToken: .bgOliveLightest) }
+  
+  @available(*, deprecated, renamed: "bgOliveLighter", message: "Use `bgOliveLighter` instead.")
+  public static var bgtxtOliveLighter: BezierColor { BezierColor(functionalColorToken: .bgOliveLighter) }
+  
+  @available(*, deprecated, renamed: "bgOliveLight", message: "Use `bgOliveLight` instead.")
+  public static var bgtxtOliveLight: BezierColor { BezierColor(functionalColorToken: .bgOliveLight) }
+  
+  @available(*, deprecated, renamed: "bgOliveNormal", message: "Use `bgOliveNormal` instead.")
+  public static var bgtxtOliveNormal: BezierColor { BezierColor(functionalColorToken: .bgOliveNormal) }
+  
+  @available(*, deprecated, renamed: "bgOliveDark", message: "Use `bgOliveDark` instead.")
+  public static var bgtxtOliveDark: BezierColor { BezierColor(functionalColorToken: .bgOliveDark) }
+  
+  // MARK: - Appendix, Yellow
+  @available(*, deprecated, renamed: "bgYellowLightest", message: "Use `bgYellowLightest` instead.")
+  public static var bgtxtYellowLightest: BezierColor { BezierColor(functionalColorToken: .bgYellowLightest) }
+  
+  @available(*, deprecated, renamed: "bgYellowLighter", message: "Use `bgYellowLighter` instead.")
+  public static var bgtxtYellowLighter: BezierColor { BezierColor(functionalColorToken: .bgYellowLighter) }
+  
+  @available(*, deprecated, renamed: "bgYellowLight", message: "Use `bgYellowLight` instead.")
+  public static var bgtxtYellowLight: BezierColor { BezierColor(functionalColorToken: .bgYellowLight) }
+  
+  @available(*, deprecated, renamed: "bgYellowNormal", message: "Use `bgYellowNormal` instead.")
+  public static var bgtxtYellowNormal: BezierColor { BezierColor(functionalColorToken: .bgYellowNormal) }
+  
+  @available(*, deprecated, renamed: "bgYellowDark", message: "Use `bgYellowDark` instead.")
+  public static var bgtxtYellowDark: BezierColor { BezierColor(functionalColorToken: .bgYellowDark) }
+  
+  // MARK: - Appendix, Orange
+  @available(*, deprecated, renamed: "bgOrangeLightest", message: "Use `bgOrangeLightest` instead.")
+  public static var bgtxtOrangeLightest: BezierColor { BezierColor(functionalColorToken: .bgOrangeLightest) }
+  
+  @available(*, deprecated, renamed: "bgOrangeLighter", message: "Use `bgOrangeLighter` instead.")
+  public static var bgtxtOrangeLighter: BezierColor { BezierColor(functionalColorToken: .bgOrangeLighter) }
+  
+  @available(*, deprecated, renamed: "bgOrangeLight", message: "Use `bgOrangeLight` instead.")
+  public static var bgtxtOrangeLight: BezierColor { BezierColor(functionalColorToken: .bgOrangeLight) }
+  
+  @available(*, deprecated, renamed: "bgOrangeNormal", message: "Use `bgOrangeNormal` instead.")
+  public static var bgtxtOrangeNormal: BezierColor { BezierColor(functionalColorToken: .bgOrangeNormal) }
+  
+  @available(*, deprecated, renamed: "bgOrangeDark", message: "Use `bgOrangeDark` instead.")
+  public static var bgtxtOrangeDark: BezierColor { BezierColor(functionalColorToken: .bgOrangeDark) }
+  
+  // MARK: - Appendix, Red
+  @available(*, deprecated, renamed: "bgRedLightest", message: "Use `bgRedLightest` instead.")
+  public static var bgtxtRedLightest: BezierColor { BezierColor(functionalColorToken: .bgRedLightest) }
+  
+  @available(*, deprecated, renamed: "bgRedLighter", message: "Use `bgRedLighter` instead.")
+  public static var bgtxtRedLighter: BezierColor { BezierColor(functionalColorToken: .bgRedLighter) }
+  
+  @available(*, deprecated, renamed: "bgRedLight", message: "Use `bgRedLight` instead.")
+  public static var bgtxtRedLight: BezierColor { BezierColor(functionalColorToken: .bgRedLight) }
+  
+  @available(*, deprecated, renamed: "bgRedNormal", message: "Use `bgRedNormal` instead.")
+  public static var bgtxtRedNormal: BezierColor { BezierColor(functionalColorToken: .bgRedNormal) }
+  
+  @available(*, deprecated, renamed: "bgRedDark", message: "Use `bgRedDark` instead.")
+  public static var bgtxtRedDark: BezierColor { BezierColor(functionalColorToken: .bgRedDark) }
+  
+  // MARK: - Appendix, Pink
+  @available(*, deprecated, renamed: "bgPinkLightest", message: "Use `bgPinkLightest` instead.")
+  public static var bgtxtPinkLightest: BezierColor { BezierColor(functionalColorToken: .bgPinkLightest) }
+  
+  @available(*, deprecated, renamed: "bgPinkLighter", message: "Use `bgPinkLighter` instead.")
+  public static var bgtxtPinkLighter: BezierColor { BezierColor(functionalColorToken: .bgPinkLighter) }
+  
+  @available(*, deprecated, renamed: "bgPinkLight", message: "Use `bgPinkLight` instead.")
+  public static var bgtxtPinkLight: BezierColor { BezierColor(functionalColorToken: .bgPinkLight) }
+  
+  @available(*, deprecated, renamed: "bgPinkNormal", message: "Use `bgPinkNormal` instead.")
+  public static var bgtxtPinkNormal: BezierColor { BezierColor(functionalColorToken: .bgPinkNormal) }
+  
+  @available(*, deprecated, renamed: "bgPinkDark", message: "Use `bgPinkDark` instead.")
+  public static var bgtxtPinkDark: BezierColor { BezierColor(functionalColorToken: .bgPinkDark) }
+  
+  // MARK: - Appendix, Purple
+  @available(*, deprecated, renamed: "bgPurpleLightest", message: "Use `bgPurpleLightest` instead.")
+  public static var bgtxtPurpleLightest: BezierColor { BezierColor(functionalColorToken: .bgPurpleLightest) }
+  
+  @available(*, deprecated, renamed: "bgPurpleLighter", message: "Use `bgPurpleLighter` instead.")
+  public static var bgtxtPurpleLighter: BezierColor { BezierColor(functionalColorToken: .bgPurpleLighter) }
+  
+  @available(*, deprecated, renamed: "bgPurpleLight", message: "Use `bgPurpleLight` instead.")
+  public static var bgtxtPurpleLight: BezierColor { BezierColor(functionalColorToken: .bgPurpleLight) }
+  
+  @available(*, deprecated, renamed: "bgPurpleNormal", message: "Use `bgPurpleNormal` instead.")
+  public static var bgtxtPurpleNormal: BezierColor { BezierColor(functionalColorToken: .bgPurpleNormal) }
+  
+  @available(*, deprecated, renamed: "bgPurpleDark", message: "Use `bgPurpleDark` instead.")
+  public static var bgtxtPurpleDark: BezierColor { BezierColor(functionalColorToken: .bgPurpleDark) }
+  
+  // MARK: - Appendix, Navy
+  @available(*, deprecated, renamed: "bgNavyLightest", message: "Use `bgNavyLightest` instead.")
+  public static var bgtxtNavyLightest: BezierColor { BezierColor(functionalColorToken: .bgNavyLightest) }
+  
+  @available(*, deprecated, renamed: "bgNavyLighter", message: "Use `bgNavyLighter` instead.")
+  public static var bgtxtNavyLighter: BezierColor { BezierColor(functionalColorToken: .bgNavyLighter) }
+  
+  @available(*, deprecated, renamed: "bgNavyLight", message: "Use `bgNavyLight` instead.")
+  public static var bgtxtNavyLight: BezierColor { BezierColor(functionalColorToken: .bgNavyLight) }
+  
+  @available(*, deprecated, renamed: "bgNavyNormal", message: "Use `bgNavyNormal` instead.")
+  public static var bgtxtNavyNormal: BezierColor { BezierColor(functionalColorToken: .bgNavyNormal) }
+  
+  @available(*, deprecated, renamed: "bgNavyDark", message: "Use `bgNavyDark` instead.")
+  public static var bgtxtNavyDark: BezierColor { BezierColor(functionalColorToken: .bgNavyDark) }
+}


### PR DESCRIPTION
# 개요
[Color 마이그레이션 스펙 문서](https://www.notion.so/channelio/Color-15874b55ec7c800c93e1f0ce27e262d5)에 따른 Bezier V1의 SemanticColor를 V2에서 사용할 수 있도록 하는 마이그레이션 PR입니다.

# 작업 내용

- Bezier V1의 SemanticColor case에 대해 마이그레이션 스펙 문서에 의해 대체되는 V2 색상으로 적용되도록 처리
- V1 마이그레이션 색상에 deprecate 정보를 알려주는 attribute 추가
- 중복(+ 동일)한 색상 제거