### PR TITLE
[Fix]  iOS 26에서 BezierWindow hitTest 이슈 수정

### DIFF
--- a/Sources/BezierSwift/BezierWindow.swift
+++ b/Sources/BezierSwift/BezierWindow.swift
@@ -33,11 +33,16 @@ final class BezierWindow: UIWindow {
       let rootView = rootViewController?.view
     else { return nil }
     
-    // NOTE: iOS 18, Xcode 16 이상 버전을 사용할 때, hitTest 결과가 다르게 나옵니다.
-    // view -> subView 로 이어지는 hitTest 플로우가 역으로 다시 UIHostingViewController 의 hitTest로 가는 상황이 생깁니다.
-    // https://forums.developer.apple.com/forums/thread/762292
-    // by Tom 25.01.08
-    if #available(iOS 18, *) {
+    if #available(iOS 26, *) {
+      // NOTE: iOS 26, Xcode 26 이상 버전을 사용할 때, 결과가 nil로 나오는 문제가 있어서 name 유무를 보고 결정합니다.
+      // https://stackoverflow.com/questions/79768526/passthrough-uiwindow-using-swiftui-in-ios-26
+      // by Tom 25.11.14
+      return rootView.layer.hitTest(point)?.name == nil ? rootView : nil
+    } else if #available(iOS 18, *) {
+      // NOTE: iOS 18, Xcode 16 이상 버전을 사용할 때, hitTest 결과가 다르게 나옵니다.
+      // view -> subView 로 이어지는 hitTest 플로우가 역으로 다시 UIHostingViewController 의 hitTest로 가는 상황이 생깁니다.
+      // https://forums.developer.apple.com/forums/thread/762292
+      // by Tom 25.01.08
       for subview in rootView.subviews.reversed() {
         let convertedPoint = subview.convert(point, from: rootView)
         if subview.hitTest(convertedPoint, with: event) != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 개선 사항

* iOS 26 이상 기기에서 터치 입력 감지 방식을 최적화했습니다. 사용자 인터페이스와의 상호작용 성능이 개선되었습니다. iOS 18 이상 기기에서의 기존 동작은 유지되어 호환성이 보장됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->