### PR TITLE
[MOBTECH-723] V3 Color Token 수정사항 반영

### DIFF
--- a/Sources/BezierSwift/Foundation/Color/V3/BCGlobalToken.swift
+++ b/Sources/BezierSwift/Foundation/Color/V3/BCGlobalToken.swift
@@ -87,13 +87,16 @@ public enum BCGlobalToken {
   case grey900_90
   case grey100
   case grey200
+  case grey25
   case grey300
   case grey400
   case grey50
   case grey500
   case grey600
+  case grey650
   case grey700
   case grey750
+  case grey750_90
   case grey800
   case grey850
   case grey900
@@ -278,17 +281,17 @@ public enum BCGlobalToken {
     case .blue200:
       return ColorComponentsWithAlpha(red: 0x8D, green: 0x93, blue: 0xFF, alpha: 1)
     case .blue300:
-      return ColorComponentsWithAlpha(red: 0x6B, green: 0x6E, blue: 0xFF, alpha: 1)
+      return ColorComponentsWithAlpha(red: 0x80, green: 0x82, blue: 0xFF, alpha: 1)
     case .blue300_0:
-      return ColorComponentsWithAlpha(red: 0x6B, green: 0x6E, blue: 0xFF, alpha: 0)
+      return ColorComponentsWithAlpha(red: 0x80, green: 0x82, blue: 0xFF, alpha: 0)
     case .blue300_10:
-      return ColorComponentsWithAlpha(red: 0x6B, green: 0x6E, blue: 0xFF, alpha: 0.10)
+      return ColorComponentsWithAlpha(red: 0x80, green: 0x82, blue: 0xFF, alpha: 0.10)
     case .blue300_18:
-      return ColorComponentsWithAlpha(red: 0x6B, green: 0x6E, blue: 0xFF, alpha: 0.18)
+      return ColorComponentsWithAlpha(red: 0x80, green: 0x82, blue: 0xFF, alpha: 0.18)
     case .blue300_30:
-      return ColorComponentsWithAlpha(red: 0x6B, green: 0x6E, blue: 0xFF, alpha: 0.30)
+      return ColorComponentsWithAlpha(red: 0x80, green: 0x82, blue: 0xFF, alpha: 0.30)
     case .blue300_45:
-      return ColorComponentsWithAlpha(red: 0x6B, green: 0x6E, blue: 0xFF, alpha: 0.45)
+      return ColorComponentsWithAlpha(red: 0x80, green: 0x82, blue: 0xFF, alpha: 0.45)
     case .blue400:
       return ColorComponentsWithAlpha(red: 0x61, green: 0x57, blue: 0xEA, alpha: 1)
     case .blue400_0:
@@ -342,17 +345,17 @@ public enum BCGlobalToken {
     case .green200:
       return ColorComponentsWithAlpha(red: 0x7C, green: 0xD9, blue: 0x85, alpha: 1)
     case .green300:
-      return ColorComponentsWithAlpha(red: 0x4B, green: 0xC1, blue: 0x6C, alpha: 1)
+      return ColorComponentsWithAlpha(red: 0x51, green: 0xC3, blue: 0x71, alpha: 1)
     case .green300_0:
-      return ColorComponentsWithAlpha(red: 0x4B, green: 0xC1, blue: 0x6C, alpha: 0)
+      return ColorComponentsWithAlpha(red: 0x51, green: 0xC3, blue: 0x71, alpha: 0)
     case .green300_10:
-      return ColorComponentsWithAlpha(red: 0x4B, green: 0xC1, blue: 0x6C, alpha: 0.10)
+      return ColorComponentsWithAlpha(red: 0x51, green: 0xC3, blue: 0x71, alpha: 0.10)
     case .green300_18:
-      return ColorComponentsWithAlpha(red: 0x4B, green: 0xC1, blue: 0x6C, alpha: 0.18)
+      return ColorComponentsWithAlpha(red: 0x51, green: 0xC3, blue: 0x71, alpha: 0.18)
     case .green300_30:
-      return ColorComponentsWithAlpha(red: 0x4B, green: 0xC1, blue: 0x6C, alpha: 0.30)
+      return ColorComponentsWithAlpha(red: 0x51, green: 0xC3, blue: 0x71, alpha: 0.30)
     case .green300_45:
-      return ColorComponentsWithAlpha(red: 0x4B, green: 0xC1, blue: 0x6C, alpha: 0.45)
+      return ColorComponentsWithAlpha(red: 0x51, green: 0xC3, blue: 0x71, alpha: 0.45)
     case .green400:
       return ColorComponentsWithAlpha(red: 0x20, green: 0xAB, blue: 0x55, alpha: 1)
     case .green400_0:
@@ -380,25 +383,27 @@ public enum BCGlobalToken {
     case .grey50_80:
       return ColorComponentsWithAlpha(red: 0xFB, green: 0xFB, blue: 0xFB, alpha: 0.80)
     case .grey700_80:
-      return ColorComponentsWithAlpha(red: 0x45, green: 0x45, blue: 0x49, alpha: 0.80)
+      return ColorComponentsWithAlpha(red: 0x3B, green: 0x3B, blue: 0x3F, alpha: 0.80)
     case .grey700_90:
-      return ColorComponentsWithAlpha(red: 0x45, green: 0x45, blue: 0x49, alpha: 0.90)
+      return ColorComponentsWithAlpha(red: 0x3B, green: 0x3B, blue: 0x3F, alpha: 0.90)
     case .grey800_80:
-      return ColorComponentsWithAlpha(red: 0x30, green: 0x30, blue: 0x35, alpha: 0.80)
+      return ColorComponentsWithAlpha(red: 0x29, green: 0x29, blue: 0x2D, alpha: 0.80)
     case .grey800_90:
-      return ColorComponentsWithAlpha(red: 0x30, green: 0x30, blue: 0x35, alpha: 0.90)
+      return ColorComponentsWithAlpha(red: 0x29, green: 0x29, blue: 0x2D, alpha: 0.90)
     case .grey850_80:
-      return ColorComponentsWithAlpha(red: 0x2A, green: 0x2A, blue: 0x2D, alpha: 0.80)
+      return ColorComponentsWithAlpha(red: 0x24, green: 0x24, blue: 0x26, alpha: 0.80)
     case .grey850_90:
-      return ColorComponentsWithAlpha(red: 0x2A, green: 0x2A, blue: 0x2D, alpha: 0.90)
+      return ColorComponentsWithAlpha(red: 0x24, green: 0x24, blue: 0x26, alpha: 0.90)
     case .grey900_0:
-      return ColorComponentsWithAlpha(red: 0x24, green: 0x24, blue: 0x28, alpha: 0)
+      return ColorComponentsWithAlpha(red: 0x1D, green: 0x1D, blue: 0x20, alpha: 0)
     case .grey900_90:
-      return ColorComponentsWithAlpha(red: 0x24, green: 0x24, blue: 0x28, alpha: 0.90)
+      return ColorComponentsWithAlpha(red: 0x1D, green: 0x1D, blue: 0x20, alpha: 0.90)
     case .grey100:
       return ColorComponentsWithAlpha(red: 0xF7, green: 0xF7, blue: 0xF8, alpha: 1)
     case .grey200:
       return ColorComponentsWithAlpha(red: 0xEF, green: 0xEF, blue: 0xF0, alpha: 1)
+    case .grey25:
+      return ColorComponentsWithAlpha(red: 0xFD, green: 0xFD, blue: 0xFD, alpha: 1)
     case .grey300:
       return ColorComponentsWithAlpha(red: 0xE2, green: 0xE2, blue: 0xE4, alpha: 1)
     case .grey400:
@@ -409,16 +414,20 @@ public enum BCGlobalToken {
       return ColorComponentsWithAlpha(red: 0xA7, green: 0xA7, blue: 0xAA, alpha: 1)
     case .grey600:
       return ColorComponentsWithAlpha(red: 0x79, green: 0x79, blue: 0x7E, alpha: 1)
+    case .grey650:
+      return ColorComponentsWithAlpha(red: 0x5A, green: 0x5A, blue: 0x5F, alpha: 1)
     case .grey700:
-      return ColorComponentsWithAlpha(red: 0x45, green: 0x45, blue: 0x49, alpha: 1)
+      return ColorComponentsWithAlpha(red: 0x3B, green: 0x3B, blue: 0x3F, alpha: 1)
     case .grey750:
-      return ColorComponentsWithAlpha(red: 0x37, green: 0x37, blue: 0x3C, alpha: 1)
+      return ColorComponentsWithAlpha(red: 0x31, green: 0x31, blue: 0x35, alpha: 1)
+    case .grey750_90:
+      return ColorComponentsWithAlpha(red: 0x31, green: 0x31, blue: 0x35, alpha: 0.90)
     case .grey800:
-      return ColorComponentsWithAlpha(red: 0x30, green: 0x30, blue: 0x35, alpha: 1)
+      return ColorComponentsWithAlpha(red: 0x29, green: 0x29, blue: 0x2D, alpha: 1)
     case .grey850:
-      return ColorComponentsWithAlpha(red: 0x2A, green: 0x2A, blue: 0x2D, alpha: 1)
+      return ColorComponentsWithAlpha(red: 0x24, green: 0x24, blue: 0x26, alpha: 1)
     case .grey900:
-      return ColorComponentsWithAlpha(red: 0x24, green: 0x24, blue: 0x28, alpha: 1)
+      return ColorComponentsWithAlpha(red: 0x1D, green: 0x1D, blue: 0x20, alpha: 1)
     case .grey950:
       return ColorComponentsWithAlpha(red: 0x1A, green: 0x1A, blue: 0x1C, alpha: 1)
     case .navy100:
@@ -426,17 +435,17 @@ public enum BCGlobalToken {
     case .navy200:
       return ColorComponentsWithAlpha(red: 0x8B, green: 0x99, blue: 0xD9, alpha: 1)
     case .navy300:
-      return ColorComponentsWithAlpha(red: 0x6F, green: 0x7B, blue: 0xC8, alpha: 1)
+      return ColorComponentsWithAlpha(red: 0x7E, green: 0x89, blue: 0xCD, alpha: 1)
     case .navy300_0:
-      return ColorComponentsWithAlpha(red: 0x6F, green: 0x7B, blue: 0xC8, alpha: 0)
+      return ColorComponentsWithAlpha(red: 0x7E, green: 0x89, blue: 0xCD, alpha: 0)
     case .navy300_10:
-      return ColorComponentsWithAlpha(red: 0x6F, green: 0x7B, blue: 0xC8, alpha: 0.10)
+      return ColorComponentsWithAlpha(red: 0x7E, green: 0x89, blue: 0xCD, alpha: 0.10)
     case .navy300_18:
-      return ColorComponentsWithAlpha(red: 0x6F, green: 0x7B, blue: 0xC8, alpha: 0.18)
+      return ColorComponentsWithAlpha(red: 0x7E, green: 0x89, blue: 0xCD, alpha: 0.18)
     case .navy300_30:
-      return ColorComponentsWithAlpha(red: 0x6F, green: 0x7B, blue: 0xC8, alpha: 0.30)
+      return ColorComponentsWithAlpha(red: 0x7E, green: 0x89, blue: 0xCD, alpha: 0.30)
     case .navy300_45:
-      return ColorComponentsWithAlpha(red: 0x6F, green: 0x7B, blue: 0xC8, alpha: 0.45)
+      return ColorComponentsWithAlpha(red: 0x7E, green: 0x89, blue: 0xCD, alpha: 0.45)
     case .navy400:
       return ColorComponentsWithAlpha(red: 0x42, green: 0x4F, blue: 0xAB, alpha: 1)
     case .navy400_0:
@@ -586,17 +595,17 @@ public enum BCGlobalToken {
     case .red200:
       return ColorComponentsWithAlpha(red: 0xFF, green: 0x86, blue: 0x83, alpha: 1)
     case .red300:
-      return ColorComponentsWithAlpha(red: 0xF2, green: 0x60, blue: 0x60, alpha: 1)
+      return ColorComponentsWithAlpha(red: 0xF3, green: 0x68, blue: 0x68, alpha: 1)
     case .red300_0:
-      return ColorComponentsWithAlpha(red: 0xF2, green: 0x60, blue: 0x60, alpha: 0)
+      return ColorComponentsWithAlpha(red: 0xF3, green: 0x68, blue: 0x68, alpha: 0)
     case .red300_10:
-      return ColorComponentsWithAlpha(red: 0xF2, green: 0x60, blue: 0x60, alpha: 0.10)
+      return ColorComponentsWithAlpha(red: 0xF3, green: 0x68, blue: 0x68, alpha: 0.10)
     case .red300_18:
-      return ColorComponentsWithAlpha(red: 0xF2, green: 0x60, blue: 0x60, alpha: 0.18)
+      return ColorComponentsWithAlpha(red: 0xF3, green: 0x68, blue: 0x68, alpha: 0.18)
     case .red300_30:
-      return ColorComponentsWithAlpha(red: 0xF2, green: 0x60, blue: 0x60, alpha: 0.30)
+      return ColorComponentsWithAlpha(red: 0xF3, green: 0x68, blue: 0x68, alpha: 0.30)
     case .red300_45:
-      return ColorComponentsWithAlpha(red: 0xF2, green: 0x60, blue: 0x60, alpha: 0.45)
+      return ColorComponentsWithAlpha(red: 0xF3, green: 0x68, blue: 0x68, alpha: 0.45)
     case .red400:
       return ColorComponentsWithAlpha(red: 0xE1, green: 0x53, blue: 0x5D, alpha: 1)
     case .red400_0:

--- a/Sources/BezierSwift/Foundation/Color/V3/BCSemanticToken.swift
+++ b/Sources/BezierSwift/Foundation/Color/V3/BCSemanticToken.swift
@@ -137,6 +137,7 @@ public enum BCSemanticToken: Equatable {
   case fillWarningTransparent
 
   // MARK: - Fill Grey
+  case fillBright
   case fillGrey
   case fillGreyHeavier
   case fillGreyHeavy
@@ -168,6 +169,7 @@ public enum BCSemanticToken: Equatable {
   case iconNeutralHeavy
   case iconSuccess
   case iconWarning
+  case iconInverseHeavier
 
   // MARK: - State
   case stateAction
@@ -221,7 +223,8 @@ public enum BCSemanticToken: Equatable {
   case textNeutralLighter
   case textSuccess
   case textWarning
-  
+  case textInverse
+
   case custom(light: ColorComponentsWithAlpha, dark: ColorComponentsWithAlpha)
 }
 
@@ -258,7 +261,7 @@ extension BCSemanticToken {
     case .borderDetachHigher:
       return (light: BCGlobalToken.white100.value, dark: BCGlobalToken.grey800.value)
     case .borderDetachHighest:
-      return (light: BCGlobalToken.white100.value, dark: BCGlobalToken.grey700.value)
+      return (light: BCGlobalToken.white100.value, dark: BCGlobalToken.grey750.value)
     case .borderDetachLow:
       return (light: BCGlobalToken.grey50.value, dark: BCGlobalToken.grey950.value)
     case .borderNeutral:
@@ -444,7 +447,7 @@ extension BCSemanticToken {
     case .fillNeutralHeavier:
       return (light: BCGlobalToken.black40.value, dark: BCGlobalToken.white40.value)
     case .fillNeutralHeaviest:
-      return (light: BCGlobalToken.black85.value, dark: BCGlobalToken.white90.value)
+      return (light: BCGlobalToken.black85.value, dark: BCGlobalToken.white100.value)
     case .fillNeutralHeavy:
       return (light: BCGlobalToken.black15.value, dark: BCGlobalToken.white20.value)
     case .fillNeutralLight:
@@ -473,6 +476,8 @@ extension BCSemanticToken {
       return (light: BCGlobalToken.orange400_0.value, dark: BCGlobalToken.orange300_0.value)
 
     // MARK: - Fill Grey
+    case .fillBright:
+      return (light: BCGlobalToken.grey25.value, dark: BCGlobalToken.grey650.value)
     case .fillGrey:
       return (light: BCGlobalToken.grey50.value, dark: BCGlobalToken.grey850.value)
     case .fillGreyHeavier:
@@ -531,6 +536,8 @@ extension BCSemanticToken {
       return (light: BCGlobalToken.green400.value, dark: BCGlobalToken.green300.value)
     case .iconWarning:
       return (light: BCGlobalToken.orange400.value, dark: BCGlobalToken.orange300.value)
+    case .iconInverseHeavier:
+      return (light: BCGlobalToken.white100.value, dark: BCGlobalToken.black85.value)
 
     // MARK: - State
     case .stateAction:
@@ -576,7 +583,7 @@ extension BCSemanticToken {
     case .surfaceGlassHigher:
       return (light: BCGlobalToken.grey100_90.value, dark: BCGlobalToken.grey800_90.value)
     case .surfaceGlassHighest:
-      return (light: BCGlobalToken.grey200_90.value, dark: BCGlobalToken.grey700_90.value)
+      return (light: BCGlobalToken.grey200_90.value, dark: BCGlobalToken.grey750_90.value)
     case .surfaceHigh:
       return (light: BCGlobalToken.white100.value, dark: BCGlobalToken.grey850.value)
     case .surfaceHigher:
@@ -631,6 +638,8 @@ extension BCSemanticToken {
       return (light: BCGlobalToken.green400.value, dark: BCGlobalToken.green300.value)
     case .textWarning:
       return (light: BCGlobalToken.orange400.value, dark: BCGlobalToken.orange300.value)
+    case .textInverse:
+      return (light: BCGlobalToken.white100.value, dark: BCGlobalToken.black85.value)
     case .custom(let light, let dark):
       return (light: light, dark: dark)
     }


### PR DESCRIPTION
## 기한
<!-- 이 PR이 병합되거나 리뷰가 완료되어야 하는 기한을 명시합니다 -->
- exp머지:
- 배포일:
- 리뷰 종료 시점 : 1/9(ASAP)
- 하드 듀 : 1/13

## 요약
- 피그마 변수 테이블 기준으로 BCGlobalToken, BCSemanticToken 변경사항 반영(플러그인으로 CSS뽑아서 자동으로 반영함)
- 신규 토큰 추가 및 기존 색상값 수정

## 세부적인 작업 내용

### BCGlobalToken 변경사항

#### 신규 추가된 토큰
- `grey25` (#FDFDFDFF)
- `grey650` (#5A5A5FFF)
- `grey750_90` 기존 grey750에 alpha 90% 값 추가

#### 색상값 변경
| 토큰 | 기존값 | 변경값 |
|:-----|:-------|:-------|
| blue300 계열 | #6B6EFF | #8082FF |
| green300 계열 | #4BC16C | #51C371 |
| navy300 계열 | #6F7BC8 | #7E89CD |
| red300 계열 | #F26060 | #F36868 |
| grey 700 계열 | #454549 | #3b3b3f |
| grey 750 계열 | #37373C | #313135 |
| grey 800 계열 | #303035 | #29292d |
| grey 850 계열 | #2a2a2d | #242426 |
| grey 900 계열 | #242428 | #1d1d20 |

### BCSemanticToken 변경사항

#### 신규 추가된 토큰
- `fillBright` (light: grey25, dark: grey650)
- `textInverse`, `iconInverseHeavier`, (light: white100, dark: black85)
- 

#### 값 변경
| 토큰 | 변경 내용 |
|:-----|:----------|
| fillNeutralHeaviest | dark: white90 → white100 |
| surfaceGlassHighest | dark: grey700_90 → grey750_90 |

## 테스트 방법
- 빌드 성공 확인

## 참고 링크
- 리니어: https://linear.app/channel/issue/MOBTECH-723
- 노션: 
- 피그마: [변수 테이블 링크](https://www.figma.com/design/LIxRAsKKyGx3fdgvm2knL9/%F0%9F%93%8C-Foundation?node-id=45485-5038&p=f&view=variables&var-set-id=46118-232&m=dev)
- 채널톡
  - [쓰레드1](https://desk.channel.io/root/groups/CTBezierRedesignv3-244958/695dc9d83213254c2051)
  - [쓰레드2](https://desk.channel.io/root/groups/CTBezierRedesignv3-244958/695f8320b4dbe8a3a44f)

## 셀프 체크
- [x] 리니어 티켓을 첨부하였습니다
- [x] [코딩 컨벤션](https://github.com/channel-io/ios-convention-guide) 에 맞춰서 작성했습니다
- [x] 리뷰 리퀘스트 전에 셀프 리뷰를 진행했습니다
- [x] 기한을 작성하였습니다.