### PR TITLE
[MOBTECH-787] Semantic Token 변경사항 반영

### DIFF
--- a/Sources/BezierSwift/Foundation/Color/V3/BCSemanticToken.swift
+++ b/Sources/BezierSwift/Foundation/Color/V3/BCSemanticToken.swift
@@ -141,10 +141,10 @@ public enum BCSemanticToken: Equatable {
   case fillGrey
   case fillGreyHeavier
   case fillGreyHeavy
+  case fillGreyLight
 
   // MARK: - Gradient
   case gradientAccentGreen
-  case gradientAccentGreenHeavy
   case gradientAccentGreenLight
 
   // MARK: - Icon
@@ -180,17 +180,6 @@ public enum BCSemanticToken: Equatable {
 
   // MARK: - Surface
   case surface
-  case surfaceAccentBlue
-  case surfaceAccentCobalt
-  case surfaceAccentGreen
-  case surfaceAccentNavy
-  case surfaceAccentOlive
-  case surfaceAccentOrange
-  case surfaceAccentPink
-  case surfaceAccentPurple
-  case surfaceAccentRed
-  case surfaceAccentTeal
-  case surfaceAccentYellow
   case surfaceGlass
   case surfaceGlassHigh
   case surfaceGlassHigher
@@ -484,12 +473,12 @@ extension BCSemanticToken {
       return (light: BCGlobalToken.grey200.value, dark: BCGlobalToken.grey750.value)
     case .fillGreyHeavy:
       return (light: BCGlobalToken.grey100.value, dark: BCGlobalToken.grey800.value)
+    case .fillGreyLight:
+      return (light: BCGlobalToken.grey25.value, dark: BCGlobalToken.grey900.value)
 
     // MARK: - Gradient
     case .gradientAccentGreen:
       return (light: BCGlobalToken.green400.value, dark: BCGlobalToken.green400.value)
-    case .gradientAccentGreenHeavy:
-      return (light: BCGlobalToken.green500.value, dark: BCGlobalToken.green300.value)
     case .gradientAccentGreenLight:
       return (light: BCGlobalToken.green300.value, dark: BCGlobalToken.green300.value)
 
@@ -554,28 +543,6 @@ extension BCSemanticToken {
     // MARK: - Surface
     case .surface:
       return (light: BCGlobalToken.white100.value, dark: BCGlobalToken.grey900.value)
-    case .surfaceAccentBlue:
-      return (light: BCGlobalToken.blue400.value, dark: BCGlobalToken.blue300.value)
-    case .surfaceAccentCobalt:
-      return (light: BCGlobalToken.cobalt400.value, dark: BCGlobalToken.cobalt300.value)
-    case .surfaceAccentGreen:
-      return (light: BCGlobalToken.green400.value, dark: BCGlobalToken.green300.value)
-    case .surfaceAccentNavy:
-      return (light: BCGlobalToken.navy400.value, dark: BCGlobalToken.navy300.value)
-    case .surfaceAccentOlive:
-      return (light: BCGlobalToken.olive400.value, dark: BCGlobalToken.olive300.value)
-    case .surfaceAccentOrange:
-      return (light: BCGlobalToken.orange400.value, dark: BCGlobalToken.orange300.value)
-    case .surfaceAccentPink:
-      return (light: BCGlobalToken.pink400.value, dark: BCGlobalToken.pink300.value)
-    case .surfaceAccentPurple:
-      return (light: BCGlobalToken.purple400.value, dark: BCGlobalToken.purple300.value)
-    case .surfaceAccentRed:
-      return (light: BCGlobalToken.red400.value, dark: BCGlobalToken.red300.value)
-    case .surfaceAccentTeal:
-      return (light: BCGlobalToken.teal400.value, dark: BCGlobalToken.teal300.value)
-    case .surfaceAccentYellow:
-      return (light: BCGlobalToken.yellow400.value, dark: BCGlobalToken.yellow300.value)
     case .surfaceGlass:
       return (light: BCGlobalToken.white90.value, dark: BCGlobalToken.grey800_90.value)
     case .surfaceGlassHigh:

--- a/Sources/BezierSwift/Foundation/Typography/Typography.swift
+++ b/Sources/BezierSwift/Foundation/Typography/Typography.swift
@@ -11,7 +11,7 @@ extension BezierFont {
   public func attributedString(
     _ component: BezierComponentable,
     text: String,
-    semanticColor: SemanticColor = .txtBlackDarkest,
+    semanticColor: SemanticColor,
     alignment: NSTextAlignment = .left,
     lineBreakMode: NSLineBreakMode = .byWordWrapping,
     hasTagProperty: Bool = false


### PR DESCRIPTION
## 기한
<!-- 이 PR이 병합되거나 리뷰가 완료되어야 하는 기한을 명시합니다 -->
- exp머지:
- 배포일:
- 리뷰 종료 시점 : 1/16(금)
- 하드 듀 : 따로 없음

## 요약
- 피그마 베지어 v3 Color 테이블에 맞춰서 변경사항 적용
- `fillGreyLight` 토큰 추가 (Light: grey25, Dark: grey900)
- 피그마 베지어 v3 Color 테이블에 없는 12개 토큰 제거 (`gradientAccentGreenHeavy`, `surfaceAccent*` 11개)

## 세부적인 작업 내용
### 추가된 토큰 (1개)
- `fillGreyLight`: Light → `grey25`, Dark → `grey900`

### 제거된 토큰 (12개)
- `gradientAccentGreenHeavy`
- `surfaceAccentBlue`
- `surfaceAccentCobalt`
- `surfaceAccentGreen`
- `surfaceAccentNavy`
- `surfaceAccentOlive`
- `surfaceAccentOrange`
- `surfaceAccentPink`
- `surfaceAccentPurple`
- `surfaceAccentRed`
- `surfaceAccentTeal`
- `surfaceAccentYellow`

## 참고 링크
- 리니어: 
- 노션: 
- 피그마: 
- 채널톡: 

## 셀프 체크
- [x] 리니어 티켓을 첨부하였습니다
- [x] [코딩 컨벤션](https://github.com/channel-io/ios-convention-guide) 에 맞춰서 작성했습니다
- [x] 리뷰 리퀘스트 전에 셀프 리뷰를 진행했습니다
- [x] 기한을 작성하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 새로운 라이트 그레이 색상이 디자인 시스템에 추가되었습니다.

* **변경 사항**
  * 여러 서피스 악센트 색상(파랑, 코발트, 초록, 네이비, 올리브, 주황, 핑크, 보라, 빨강, 틸, 노랑)과 그린 그래디언트가 팔레트에서 제거되었습니다.
  * 텍스트 스타일 지정 시 색상을 명시적으로 지정해야 합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->