### PR TITLE
[MOB-4878] V3 BezierBadge 추가 (SwiftUI/UIKit) + Figma SSOT 정합

### DIFF
--- a/Examples/SwiftUIExample/SwiftUIExample.xcodeproj/project.pbxproj
+++ b/Examples/SwiftUIExample/SwiftUIExample.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		A1B2C3D42A737BD700C99C9E /* TypographyTokenCatalogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D32A737BD700C99C9E /* TypographyTokenCatalogView.swift */; };
 		BB48760B2B11FE0100000001 /* BezierButtonTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB48760A2B11FE0100000001 /* BezierButtonTestView.swift */; };
+		BB48760D2B11FE0100000003 /* BezierBadgeTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB48760C2B11FE0100000003 /* BezierBadgeTestView.swift */; };
 		E2789E4D2A737BC700B98B8D /* BezierElevationTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2789E4C2A737BC700B98B8D /* BezierElevationTestView.swift */; };
 		E28212322A4B32F700018327 /* SwiftUIExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28212312A4B32F700018327 /* SwiftUIExampleApp.swift */; };
 		E28212342A4B32F700018327 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28212332A4B32F700018327 /* ContentView.swift */; };
@@ -20,6 +21,7 @@
 /* Begin PBXFileReference section */
 		A1B2C3D32A737BD700C99C9E /* TypographyTokenCatalogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypographyTokenCatalogView.swift; sourceTree = "<group>"; };
 		BB48760A2B11FE0100000001 /* BezierButtonTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierButtonTestView.swift; sourceTree = "<group>"; };
+		BB48760C2B11FE0100000003 /* BezierBadgeTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierBadgeTestView.swift; sourceTree = "<group>"; };
 		E2789E4C2A737BC700B98B8D /* BezierElevationTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierElevationTestView.swift; sourceTree = "<group>"; };
 		E282122E2A4B32F700018327 /* SwiftUIExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftUIExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E28212312A4B32F700018327 /* SwiftUIExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIExampleApp.swift; sourceTree = "<group>"; };
@@ -46,6 +48,7 @@
 				E2789E4C2A737BC700B98B8D /* BezierElevationTestView.swift */,
 				A1B2C3D32A737BD700C99C9E /* TypographyTokenCatalogView.swift */,
 				BB48760A2B11FE0100000001 /* BezierButtonTestView.swift */,
+				BB48760C2B11FE0100000003 /* BezierBadgeTestView.swift */,
 			);
 			path = TestViews;
 			sourceTree = "<group>";
@@ -171,6 +174,7 @@
 				E2789E4D2A737BC700B98B8D /* BezierElevationTestView.swift in Sources */,
 				A1B2C3D42A737BD700C99C9E /* TypographyTokenCatalogView.swift in Sources */,
 				BB48760B2B11FE0100000001 /* BezierButtonTestView.swift in Sources */,
+				BB48760D2B11FE0100000003 /* BezierBadgeTestView.swift in Sources */,
 				E28212322A4B32F700018327 /* SwiftUIExampleApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Examples/SwiftUIExample/SwiftUIExample/ContentView.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/ContentView.swift
@@ -20,6 +20,9 @@ struct ContentView: View, Themeable {
         NavigationLink("Button") {
           BezierButtonTestView()
         }
+        NavigationLink("Badge") {
+          BezierBadgeTestView()
+        }
         NavigationLink("Elevation Test") {
           BezierElevationTestView()
         }

--- a/Examples/SwiftUIExample/SwiftUIExample/TestViews/BezierBadgeTestView.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/TestViews/BezierBadgeTestView.swift
@@ -7,52 +7,20 @@ import SwiftUI
 import BezierSwift
 
 struct BezierBadgeTestView: View {
-  private enum ShapeKind: String, CaseIterable {
-    case dot
-    case numeric
-    case text
-  }
-
   @State private var size: BezierBadgeSize = .small
   @State private var variant: BezierBadgeVariant = .default
-  @State private var shapeKind: ShapeKind = .text
-  @State private var textValue: String = "Badge"
-  @State private var numericValue: Double = 7
+  @State private var labelText: String = ""
   @State private var hasLeadingIcon: Bool = false
-
-  private var resolvedShape: BezierBadgeShape {
-    switch self.shapeKind {
-    case .dot:
-      return .dot
-    case .numeric:
-      return .numeric(Int(self.numericValue))
-    case .text:
-      return .text(self.textValue.isEmpty ? "Badge" : self.textValue)
-    }
-  }
 
   var body: some View {
     Form {
       Section("Preview") {
-        VStack(spacing: 16) {
-          SUBezierBadge(
-            size: self.size,
-            variant: self.variant,
-            shape: self.resolvedShape,
-            leadingIcon: self.hasLeadingIcon ? Image(systemName: "plus") : nil
-          )
-
-          Image(systemName: "bell.fill")
-            .resizable()
-            .scaledToFit()
-            .frame(width: 36, height: 36)
-            .bezierBadge(
-              self.resolvedShape,
-              size: self.size,
-              variant: self.variant,
-              leadingIcon: self.hasLeadingIcon ? Image(systemName: "plus") : nil
-            )
-        }
+        SUBezierBadge(
+          size: self.size,
+          variant: self.variant,
+          label: self.labelText.isEmpty ? nil : self.labelText,
+          leadingIcon: self.hasLeadingIcon ? Image(systemName: "plus") : nil
+        )
         .frame(maxWidth: .infinity)
         .padding(.vertical, 8)
       }
@@ -74,26 +42,8 @@ struct BezierBadgeTestView: View {
         }
       }
 
-      Section("Shape") {
-        Picker("Shape", selection: self.$shapeKind) {
-          ForEach(ShapeKind.allCases, id: \.self) { kind in
-            Text(kind.rawValue).tag(kind)
-          }
-        }
-        .pickerStyle(.segmented)
-
-        switch self.shapeKind {
-        case .dot:
-          EmptyView()
-        case .numeric:
-          HStack {
-            Text("Value: \(Int(self.numericValue))")
-              .frame(width: 100, alignment: .leading)
-            Slider(value: self.$numericValue, in: 0...150, step: 1)
-          }
-        case .text:
-          TextField("Text", text: self.$textValue)
-        }
+      Section("Label") {
+        TextField("Label", text: self.$labelText)
       }
 
       Section("Content") {
@@ -108,10 +58,8 @@ struct BezierBadgeTestView: View {
                 Text(size.rawValue)
                   .font(.caption.weight(.semibold))
                   .foregroundColor(.secondary)
-                self.row(size: size, shape: .text("Badge"))
-                self.row(size: size, shape: .numeric(7))
-                self.row(size: size, shape: .numeric(150))
-                self.row(size: size, shape: .dot)
+                self.row(size: size, leadingIcon: nil)
+                self.row(size: size, leadingIcon: Image(systemName: "plus"))
               }
             }
           }
@@ -123,11 +71,11 @@ struct BezierBadgeTestView: View {
     .navigationTitle("Badge (SwiftUI)")
   }
 
-  private func row(size: BezierBadgeSize, shape: BezierBadgeShape) -> some View {
+  private func row(size: BezierBadgeSize, leadingIcon: Image?) -> some View {
     ScrollView(.horizontal, showsIndicators: false) {
       HStack(spacing: 8) {
         ForEach(BezierBadgeVariant.allCases, id: \.self) { variant in
-          SUBezierBadge(size: size, variant: variant, shape: shape)
+          SUBezierBadge(size: size, variant: variant, label: "Badge", leadingIcon: leadingIcon)
         }
       }
     }

--- a/Examples/SwiftUIExample/SwiftUIExample/TestViews/BezierBadgeTestView.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/TestViews/BezierBadgeTestView.swift
@@ -1,0 +1,143 @@
+//
+//  BezierBadgeTestView.swift
+//  SwiftUIExample
+//
+
+import SwiftUI
+import BezierSwift
+
+struct BezierBadgeTestView: View {
+  private enum ShapeKind: String, CaseIterable {
+    case dot
+    case numeric
+    case text
+  }
+
+  @State private var size: BezierBadgeSize = .small
+  @State private var variant: BezierBadgeVariant = .default
+  @State private var shapeKind: ShapeKind = .text
+  @State private var textValue: String = "Badge"
+  @State private var numericValue: Double = 7
+  @State private var hasLeadingIcon: Bool = false
+
+  private var resolvedShape: BezierBadgeShape {
+    switch self.shapeKind {
+    case .dot:
+      return .dot
+    case .numeric:
+      return .numeric(Int(self.numericValue))
+    case .text:
+      return .text(self.textValue.isEmpty ? "Badge" : self.textValue)
+    }
+  }
+
+  var body: some View {
+    Form {
+      Section("Preview") {
+        VStack(spacing: 16) {
+          SUBezierBadge(
+            size: self.size,
+            variant: self.variant,
+            shape: self.resolvedShape,
+            leadingIcon: self.hasLeadingIcon ? Image(systemName: "plus") : nil
+          )
+
+          Image(systemName: "bell.fill")
+            .resizable()
+            .scaledToFit()
+            .frame(width: 36, height: 36)
+            .bezierBadge(
+              self.resolvedShape,
+              size: self.size,
+              variant: self.variant,
+              leadingIcon: self.hasLeadingIcon ? Image(systemName: "plus") : nil
+            )
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 8)
+      }
+
+      Section("Size") {
+        Picker("Size", selection: self.$size) {
+          ForEach(BezierBadgeSize.allCases, id: \.self) { size in
+            Text(size.rawValue).tag(size)
+          }
+        }
+        .pickerStyle(.segmented)
+      }
+
+      Section("Variant") {
+        Picker("Variant", selection: self.$variant) {
+          ForEach(BezierBadgeVariant.allCases, id: \.self) { variant in
+            Text(variant.rawValue).tag(variant)
+          }
+        }
+      }
+
+      Section("Shape") {
+        Picker("Shape", selection: self.$shapeKind) {
+          ForEach(ShapeKind.allCases, id: \.self) { kind in
+            Text(kind.rawValue).tag(kind)
+          }
+        }
+        .pickerStyle(.segmented)
+
+        switch self.shapeKind {
+        case .dot:
+          EmptyView()
+        case .numeric:
+          HStack {
+            Text("Value: \(Int(self.numericValue))")
+              .frame(width: 100, alignment: .leading)
+            Slider(value: self.$numericValue, in: 0...150, step: 1)
+          }
+        case .text:
+          TextField("Text", text: self.$textValue)
+        }
+      }
+
+      Section("Content") {
+        Toggle("Leading Icon", isOn: self.$hasLeadingIcon)
+      }
+
+      Section("Catalog") {
+        ScrollView(.vertical) {
+          VStack(alignment: .leading, spacing: 16) {
+            ForEach(BezierBadgeSize.allCases, id: \.self) { size in
+              VStack(alignment: .leading, spacing: 8) {
+                Text(size.rawValue)
+                  .font(.caption.weight(.semibold))
+                  .foregroundColor(.secondary)
+                self.row(size: size, shape: .text("Badge"))
+                self.row(size: size, shape: .numeric(7))
+                self.row(size: size, shape: .numeric(150))
+                self.row(size: size, shape: .dot)
+              }
+            }
+          }
+          .padding(.vertical, 8)
+        }
+        .frame(height: 400)
+      }
+    }
+    .navigationTitle("Badge (SwiftUI)")
+  }
+
+  private func row(size: BezierBadgeSize, shape: BezierBadgeShape) -> some View {
+    ScrollView(.horizontal, showsIndicators: false) {
+      HStack(spacing: 8) {
+        ForEach(BezierBadgeVariant.allCases, id: \.self) { variant in
+          SUBezierBadge(size: size, variant: variant, shape: shape)
+        }
+      }
+    }
+  }
+}
+
+struct BezierBadgeTestView_Previews: PreviewProvider {
+  static var previews: some View {
+    NavigationView {
+      BezierBadgeTestView()
+    }
+  }
+}

--- a/Examples/UIKitExample/UIKitExample.xcodeproj/project.pbxproj
+++ b/Examples/UIKitExample/UIKitExample.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		E28212242A4B31BD00018327 /* BezierSwift in Frameworks */ = {isa = PBXBuildFile; productRef = E28212232A4B31BD00018327 /* BezierSwift */; };
 		BB48761A2B11FE0200000002 /* BezierButtonTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB48761B2B11FE0200000002 /* BezierButtonTestViewController.swift */; };
+		BB48761C2B11FE0200000004 /* BezierBadgeTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB48761D2B11FE0200000004 /* BezierBadgeTestViewController.swift */; };
 		E28212432A4B3C0900018327 /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28212422A4B3C0900018327 /* BaseViewController.swift */; };
 		E2C2C3D32A4B2DE700A7E5E6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2C2C3D22A4B2DE700A7E5E6 /* AppDelegate.swift */; };
 		E2C2C3D52A4B2DE700A7E5E6 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2C2C3D42A4B2DE700A7E5E6 /* SceneDelegate.swift */; };
@@ -19,6 +20,7 @@
 
 /* Begin PBXFileReference section */
 		BB48761B2B11FE0200000002 /* BezierButtonTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierButtonTestViewController.swift; sourceTree = "<group>"; };
+		BB48761D2B11FE0200000004 /* BezierBadgeTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierBadgeTestViewController.swift; sourceTree = "<group>"; };
 		E28212422A4B3C0900018327 /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
 		E2C2C3CF2A4B2DE700A7E5E6 /* UIKitExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = UIKitExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E2C2C3D22A4B2DE700A7E5E6 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -73,6 +75,7 @@
 				E2C2C3D62A4B2DE700A7E5E6 /* ViewController.swift */,
 				E28212422A4B3C0900018327 /* BaseViewController.swift */,
 				BB48761B2B11FE0200000002 /* BezierButtonTestViewController.swift */,
+				BB48761D2B11FE0200000004 /* BezierBadgeTestViewController.swift */,
 				E2C2C3DB2A4B2DE800A7E5E6 /* Assets.xcassets */,
 				E2C2C3DD2A4B2DE800A7E5E6 /* LaunchScreen.storyboard */,
 				E2C2C3E02A4B2DE800A7E5E6 /* Info.plist */,
@@ -156,6 +159,7 @@
 				E2C2C3D72A4B2DE700A7E5E6 /* ViewController.swift in Sources */,
 				E28212432A4B3C0900018327 /* BaseViewController.swift in Sources */,
 				BB48761A2B11FE0200000002 /* BezierButtonTestViewController.swift in Sources */,
+				BB48761C2B11FE0200000004 /* BezierBadgeTestViewController.swift in Sources */,
 				E2C2C3D32A4B2DE700A7E5E6 /* AppDelegate.swift in Sources */,
 				E2C2C3D52A4B2DE700A7E5E6 /* SceneDelegate.swift in Sources */,
 			);

--- a/Examples/UIKitExample/UIKitExample/BezierBadgeTestViewController.swift
+++ b/Examples/UIKitExample/UIKitExample/BezierBadgeTestViewController.swift
@@ -125,7 +125,7 @@ final class BezierBadgeTestViewController: BaseViewController {
     let container = UIStackView()
     container.axis = .vertical
     container.spacing = 16
-    container.alignment = .leading
+    container.alignment = .fill
 
     for size in BezierBadgeSize.allCases {
       let title = UILabel()

--- a/Examples/UIKitExample/UIKitExample/BezierBadgeTestViewController.swift
+++ b/Examples/UIKitExample/UIKitExample/BezierBadgeTestViewController.swift
@@ -7,36 +7,12 @@ import UIKit
 import BezierSwift
 
 final class BezierBadgeTestViewController: BaseViewController {
-  private enum ShapeKind: Int, CaseIterable {
-    case dot
-    case numeric
-    case text
-
-    var title: String {
-      switch self {
-      case .dot:     return "dot"
-      case .numeric: return "numeric"
-      case .text:    return "text"
-      }
-    }
-  }
-
   // MARK: - State
 
   private var size: BezierBadgeSize = .small
   private var variant: BezierBadgeVariant = .default
-  private var shapeKind: ShapeKind = .text
-  private var textValue: String = "Badge"
-  private var numericValue: Int = 7
+  private var labelText: String = "Badge"
   private var hasLeadingIcon: Bool = false
-
-  private var resolvedShape: BezierBadgeShape {
-    switch self.shapeKind {
-    case .dot:     return .dot
-    case .numeric: return .numeric(self.numericValue)
-    case .text:    return .text(self.textValue.isEmpty ? "Badge" : self.textValue)
-    }
-  }
 
   // MARK: - Subviews
 
@@ -66,7 +42,8 @@ final class BezierBadgeTestViewController: BaseViewController {
   }()
 
   private lazy var previewBadge: BezierBadge = {
-    let badge = BezierBadge(size: self.size, variant: self.variant, shape: self.resolvedShape)
+    let badge = BezierBadge(size: self.size, variant: self.variant)
+    badge.label = self.labelText
     return badge
   }()
 
@@ -85,39 +62,15 @@ final class BezierBadgeTestViewController: BaseViewController {
     return picker
   }()
 
-  private lazy var shapeControl: UISegmentedControl = {
-    let control = UISegmentedControl(items: ShapeKind.allCases.map { $0.title })
-    control.selectedSegmentIndex = self.shapeKind.rawValue
-    control.addTarget(self, action: #selector(self.onShapeChanged(_:)), for: .valueChanged)
-    return control
-  }()
-
-  private lazy var textField: UITextField = {
+  private lazy var labelTextField: UITextField = {
     let field = UITextField()
     field.borderStyle = .roundedRect
-    field.text = self.textValue
-    field.placeholder = "Text"
+    field.text = self.labelText
+    field.placeholder = "Label"
     field.autocorrectionType = .no
     field.autocapitalizationType = .none
-    field.addTarget(self, action: #selector(self.onTextChanged(_:)), for: .editingChanged)
+    field.addTarget(self, action: #selector(self.onLabelChanged(_:)), for: .editingChanged)
     return field
-  }()
-
-  private lazy var numericStepper: UIStepper = {
-    let stepper = UIStepper()
-    stepper.minimumValue = 0
-    stepper.maximumValue = 150
-    stepper.stepValue = 1
-    stepper.value = Double(self.numericValue)
-    stepper.addTarget(self, action: #selector(self.onNumericChanged(_:)), for: .valueChanged)
-    return stepper
-  }()
-
-  private lazy var numericValueLabel: UILabel = {
-    let label = UILabel()
-    label.text = "\(self.numericValue)"
-    label.font = .preferredFont(forTextStyle: .body)
-    return label
   }()
 
   private lazy var leadingIconSwitch: UISwitch = {
@@ -127,9 +80,6 @@ final class BezierBadgeTestViewController: BaseViewController {
     return toggle
   }()
 
-  private lazy var numericRow: UIView = self.makeStepperRow()
-  private lazy var textRow: UIView = self.textField
-
   // MARK: - Lifecycle
 
   override func viewDidLoad() {
@@ -138,7 +88,6 @@ final class BezierBadgeTestViewController: BaseViewController {
     self.view.backgroundColor = .systemBackground
     self.setUpLayout()
     self.refreshPreview()
-    self.refreshShapeRow()
   }
 
   private func setUpLayout() {
@@ -164,10 +113,8 @@ final class BezierBadgeTestViewController: BaseViewController {
     self.containerStackView.addArrangedSubview(self.sizeControl)
     self.containerStackView.addArrangedSubview(self.makeSectionTitle("Variant"))
     self.containerStackView.addArrangedSubview(self.variantPicker)
-    self.containerStackView.addArrangedSubview(self.makeSectionTitle("Shape"))
-    self.containerStackView.addArrangedSubview(self.shapeControl)
-    self.containerStackView.addArrangedSubview(self.textRow)
-    self.containerStackView.addArrangedSubview(self.numericRow)
+    self.containerStackView.addArrangedSubview(self.makeSectionTitle("Label"))
+    self.containerStackView.addArrangedSubview(self.labelTextField)
     self.containerStackView.addArrangedSubview(self.makeSectionTitle("Content"))
     self.containerStackView.addArrangedSubview(self.makeRow(label: "Leading Icon", control: self.leadingIconSwitch))
     self.containerStackView.addArrangedSubview(self.makeSectionTitle("Catalog"))
@@ -187,14 +134,13 @@ final class BezierBadgeTestViewController: BaseViewController {
       title.textColor = .secondaryLabel
       container.addArrangedSubview(title)
 
-      for shape in [BezierBadgeShape.text("Badge"), .numeric(7), .numeric(150), .dot] {
-        container.addArrangedSubview(self.makeCatalogRow(size: size, shape: shape))
-      }
+      container.addArrangedSubview(self.makeCatalogRow(size: size, leadingIcon: nil))
+      container.addArrangedSubview(self.makeCatalogRow(size: size, leadingIcon: UIImage(systemName: "plus")))
     }
     return container
   }
 
-  private func makeCatalogRow(size: BezierBadgeSize, shape: BezierBadgeShape) -> UIView {
+  private func makeCatalogRow(size: BezierBadgeSize, leadingIcon: UIImage?) -> UIView {
     let scroll = UIScrollView()
     scroll.showsHorizontalScrollIndicator = false
     scroll.translatesAutoresizingMaskIntoConstraints = false
@@ -206,7 +152,10 @@ final class BezierBadgeTestViewController: BaseViewController {
     row.translatesAutoresizingMaskIntoConstraints = false
 
     for variant in BezierBadgeVariant.allCases {
-      row.addArrangedSubview(BezierBadge(size: size, variant: variant, shape: shape))
+      let badge = BezierBadge(size: size, variant: variant)
+      badge.label = "Badge"
+      badge.leadingIcon = leadingIcon
+      row.addArrangedSubview(badge)
     }
 
     scroll.addSubview(row)
@@ -216,7 +165,7 @@ final class BezierBadgeTestViewController: BaseViewController {
       row.trailingAnchor.constraint(equalTo: scroll.contentLayoutGuide.trailingAnchor),
       row.bottomAnchor.constraint(equalTo: scroll.contentLayoutGuide.bottomAnchor),
       row.heightAnchor.constraint(equalTo: scroll.frameLayoutGuide.heightAnchor),
-      scroll.heightAnchor.constraint(equalToConstant: max(size.height, size.dotLength) + 4),
+      scroll.heightAnchor.constraint(equalToConstant: size.height + 4),
     ])
     return scroll
   }
@@ -252,25 +201,6 @@ final class BezierBadgeTestViewController: BaseViewController {
     return self.previewContainer
   }
 
-  private func makeStepperRow() -> UIView {
-    let container = UIStackView()
-    container.axis = .horizontal
-    container.alignment = .center
-    container.spacing = 12
-
-    let title = UILabel()
-    title.text = "Numeric"
-    title.font = .preferredFont(forTextStyle: .body)
-
-    container.addArrangedSubview(title)
-    let spacer = UIView()
-    spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
-    container.addArrangedSubview(spacer)
-    container.addArrangedSubview(self.numericValueLabel)
-    container.addArrangedSubview(self.numericStepper)
-    return container
-  }
-
   private func makeSectionTitle(_ text: String) -> UILabel {
     let label = UILabel()
     label.text = text
@@ -303,13 +233,8 @@ final class BezierBadgeTestViewController: BaseViewController {
   private func refreshPreview() {
     self.previewBadge.size = self.size
     self.previewBadge.variant = self.variant
-    self.previewBadge.shape = self.resolvedShape
+    self.previewBadge.label = self.labelText.isEmpty ? nil : self.labelText
     self.previewBadge.leadingIcon = self.hasLeadingIcon ? UIImage(systemName: "plus") : nil
-  }
-
-  private func refreshShapeRow() {
-    self.textRow.isHidden = self.shapeKind != .text
-    self.numericRow.isHidden = self.shapeKind != .numeric
   }
 
   // MARK: - Actions
@@ -319,20 +244,8 @@ final class BezierBadgeTestViewController: BaseViewController {
     self.refreshPreview()
   }
 
-  @objc private func onShapeChanged(_ sender: UISegmentedControl) {
-    self.shapeKind = ShapeKind.allCases[sender.selectedSegmentIndex]
-    self.refreshShapeRow()
-    self.refreshPreview()
-  }
-
-  @objc private func onTextChanged(_ sender: UITextField) {
-    self.textValue = sender.text ?? ""
-    self.refreshPreview()
-  }
-
-  @objc private func onNumericChanged(_ sender: UIStepper) {
-    self.numericValue = Int(sender.value)
-    self.numericValueLabel.text = "\(self.numericValue)"
+  @objc private func onLabelChanged(_ sender: UITextField) {
+    self.labelText = sender.text ?? ""
     self.refreshPreview()
   }
 

--- a/Examples/UIKitExample/UIKitExample/BezierBadgeTestViewController.swift
+++ b/Examples/UIKitExample/UIKitExample/BezierBadgeTestViewController.swift
@@ -1,0 +1,311 @@
+//
+//  BezierBadgeTestViewController.swift
+//  UIKitExample
+//
+
+import UIKit
+import BezierSwift
+
+final class BezierBadgeTestViewController: BaseViewController {
+  private enum ShapeKind: Int, CaseIterable {
+    case dot
+    case numeric
+    case text
+
+    var title: String {
+      switch self {
+      case .dot:     return "dot"
+      case .numeric: return "numeric"
+      case .text:    return "text"
+      }
+    }
+  }
+
+  // MARK: - State
+
+  private var size: BezierBadgeSize = .small
+  private var variant: BezierBadgeVariant = .default
+  private var shapeKind: ShapeKind = .text
+  private var textValue: String = "Badge"
+  private var numericValue: Int = 7
+  private var hasLeadingIcon: Bool = false
+
+  private var resolvedShape: BezierBadgeShape {
+    switch self.shapeKind {
+    case .dot:     return .dot
+    case .numeric: return .numeric(self.numericValue)
+    case .text:    return .text(self.textValue.isEmpty ? "Badge" : self.textValue)
+    }
+  }
+
+  // MARK: - Subviews
+
+  private let scrollView: UIScrollView = {
+    let scrollView = UIScrollView()
+    scrollView.translatesAutoresizingMaskIntoConstraints = false
+    return scrollView
+  }()
+
+  private let containerStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    stackView.spacing = 16
+    stackView.alignment = .fill
+    stackView.layoutMargins = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+    stackView.isLayoutMarginsRelativeArrangement = true
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    return stackView
+  }()
+
+  private let previewContainer: UIView = {
+    let view = UIView()
+    view.backgroundColor = .secondarySystemBackground
+    view.layer.cornerRadius = 12
+    view.translatesAutoresizingMaskIntoConstraints = false
+    return view
+  }()
+
+  private lazy var previewBadge: BezierBadge = {
+    let badge = BezierBadge(size: self.size, variant: self.variant, shape: self.resolvedShape)
+    return badge
+  }()
+
+  private lazy var sizeControl: UISegmentedControl = {
+    let control = UISegmentedControl(items: BezierBadgeSize.allCases.map { $0.rawValue })
+    control.selectedSegmentIndex = BezierBadgeSize.allCases.firstIndex(of: self.size) ?? 0
+    control.addTarget(self, action: #selector(self.onSizeChanged(_:)), for: .valueChanged)
+    return control
+  }()
+
+  private lazy var variantPicker: UIPickerView = {
+    let picker = UIPickerView()
+    picker.dataSource = self
+    picker.delegate = self
+    picker.selectRow(BezierBadgeVariant.allCases.firstIndex(of: self.variant) ?? 0, inComponent: 0, animated: false)
+    return picker
+  }()
+
+  private lazy var shapeControl: UISegmentedControl = {
+    let control = UISegmentedControl(items: ShapeKind.allCases.map { $0.title })
+    control.selectedSegmentIndex = self.shapeKind.rawValue
+    control.addTarget(self, action: #selector(self.onShapeChanged(_:)), for: .valueChanged)
+    return control
+  }()
+
+  private lazy var textField: UITextField = {
+    let field = UITextField()
+    field.borderStyle = .roundedRect
+    field.text = self.textValue
+    field.placeholder = "Text"
+    field.autocorrectionType = .no
+    field.autocapitalizationType = .none
+    field.addTarget(self, action: #selector(self.onTextChanged(_:)), for: .editingChanged)
+    return field
+  }()
+
+  private lazy var numericStepper: UIStepper = {
+    let stepper = UIStepper()
+    stepper.minimumValue = 0
+    stepper.maximumValue = 150
+    stepper.stepValue = 1
+    stepper.value = Double(self.numericValue)
+    stepper.addTarget(self, action: #selector(self.onNumericChanged(_:)), for: .valueChanged)
+    return stepper
+  }()
+
+  private lazy var numericValueLabel: UILabel = {
+    let label = UILabel()
+    label.text = "\(self.numericValue)"
+    label.font = .preferredFont(forTextStyle: .body)
+    return label
+  }()
+
+  private lazy var leadingIconSwitch: UISwitch = {
+    let toggle = UISwitch()
+    toggle.isOn = self.hasLeadingIcon
+    toggle.addTarget(self, action: #selector(self.onLeadingIconToggled(_:)), for: .valueChanged)
+    return toggle
+  }()
+
+  // MARK: - Lifecycle
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    self.title = "Badge (UIKit)"
+    self.view.backgroundColor = .systemBackground
+    self.setUpLayout()
+    self.refreshPreview()
+    self.refreshShapeRow()
+  }
+
+  private func setUpLayout() {
+    self.view.addSubview(self.scrollView)
+    self.scrollView.addSubview(self.containerStackView)
+
+    NSLayoutConstraint.activate([
+      self.scrollView.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor),
+      self.scrollView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+      self.scrollView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+      self.scrollView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor),
+
+      self.containerStackView.topAnchor.constraint(equalTo: self.scrollView.contentLayoutGuide.topAnchor),
+      self.containerStackView.leadingAnchor.constraint(equalTo: self.scrollView.contentLayoutGuide.leadingAnchor),
+      self.containerStackView.trailingAnchor.constraint(equalTo: self.scrollView.contentLayoutGuide.trailingAnchor),
+      self.containerStackView.bottomAnchor.constraint(equalTo: self.scrollView.contentLayoutGuide.bottomAnchor),
+      self.containerStackView.widthAnchor.constraint(equalTo: self.scrollView.frameLayoutGuide.widthAnchor),
+    ])
+
+    self.containerStackView.addArrangedSubview(self.makeSectionTitle("Preview"))
+    self.containerStackView.addArrangedSubview(self.makePreviewSection())
+    self.containerStackView.addArrangedSubview(self.makeSectionTitle("Size"))
+    self.containerStackView.addArrangedSubview(self.sizeControl)
+    self.containerStackView.addArrangedSubview(self.makeSectionTitle("Variant"))
+    self.containerStackView.addArrangedSubview(self.variantPicker)
+    self.containerStackView.addArrangedSubview(self.makeSectionTitle("Shape"))
+    self.containerStackView.addArrangedSubview(self.shapeControl)
+    self.containerStackView.addArrangedSubview(self.textField)
+    self.containerStackView.addArrangedSubview(self.makeStepperRow())
+    self.containerStackView.addArrangedSubview(self.makeSectionTitle("Content"))
+    self.containerStackView.addArrangedSubview(self.makeRow(label: "Leading Icon", control: self.leadingIconSwitch))
+  }
+
+  private func makePreviewSection() -> UIView {
+    let stack = UIStackView()
+    stack.axis = .vertical
+    stack.alignment = .center
+    stack.spacing = 12
+    stack.isLayoutMarginsRelativeArrangement = true
+    stack.layoutMargins = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+    stack.translatesAutoresizingMaskIntoConstraints = false
+
+    self.previewContainer.addSubview(stack)
+    NSLayoutConstraint.activate([
+      stack.topAnchor.constraint(equalTo: self.previewContainer.topAnchor),
+      stack.leadingAnchor.constraint(equalTo: self.previewContainer.leadingAnchor),
+      stack.trailingAnchor.constraint(equalTo: self.previewContainer.trailingAnchor),
+      stack.bottomAnchor.constraint(equalTo: self.previewContainer.bottomAnchor),
+    ])
+
+    let badgeRow = UIView()
+    badgeRow.translatesAutoresizingMaskIntoConstraints = false
+    badgeRow.addSubview(self.previewBadge)
+    NSLayoutConstraint.activate([
+      badgeRow.leadingAnchor.constraint(equalTo: self.previewBadge.leadingAnchor),
+      badgeRow.trailingAnchor.constraint(equalTo: self.previewBadge.trailingAnchor),
+      badgeRow.topAnchor.constraint(equalTo: self.previewBadge.topAnchor),
+      badgeRow.bottomAnchor.constraint(equalTo: self.previewBadge.bottomAnchor),
+    ])
+
+    stack.addArrangedSubview(badgeRow)
+    return self.previewContainer
+  }
+
+  private func makeStepperRow() -> UIView {
+    let container = UIStackView()
+    container.axis = .horizontal
+    container.alignment = .center
+    container.spacing = 12
+
+    let title = UILabel()
+    title.text = "Numeric"
+    title.font = .preferredFont(forTextStyle: .body)
+
+    container.addArrangedSubview(title)
+    let spacer = UIView()
+    spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+    container.addArrangedSubview(spacer)
+    container.addArrangedSubview(self.numericValueLabel)
+    container.addArrangedSubview(self.numericStepper)
+    return container
+  }
+
+  private func makeSectionTitle(_ text: String) -> UILabel {
+    let label = UILabel()
+    label.text = text
+    label.font = .preferredFont(forTextStyle: .footnote)
+    label.textColor = .secondaryLabel
+    return label
+  }
+
+  private func makeRow(label text: String, control: UIView) -> UIView {
+    let container = UIStackView()
+    container.axis = .horizontal
+    container.distribution = .fill
+    container.alignment = .center
+    container.spacing = 12
+
+    let titleLabel = UILabel()
+    titleLabel.text = text
+    titleLabel.font = .preferredFont(forTextStyle: .body)
+
+    container.addArrangedSubview(titleLabel)
+    let spacer = UIView()
+    spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+    container.addArrangedSubview(spacer)
+    container.addArrangedSubview(control)
+    return container
+  }
+
+  // MARK: - Refresh
+
+  private func refreshPreview() {
+    self.previewBadge.size = self.size
+    self.previewBadge.variant = self.variant
+    self.previewBadge.shape = self.resolvedShape
+    self.previewBadge.leadingIcon = self.hasLeadingIcon ? UIImage(systemName: "plus") : nil
+  }
+
+  private func refreshShapeRow() {
+    self.textField.isHidden = self.shapeKind != .text
+    self.numericStepper.isHidden = self.shapeKind != .numeric
+    self.numericValueLabel.isHidden = self.shapeKind != .numeric
+  }
+
+  // MARK: - Actions
+
+  @objc private func onSizeChanged(_ sender: UISegmentedControl) {
+    self.size = BezierBadgeSize.allCases[sender.selectedSegmentIndex]
+    self.refreshPreview()
+  }
+
+  @objc private func onShapeChanged(_ sender: UISegmentedControl) {
+    self.shapeKind = ShapeKind.allCases[sender.selectedSegmentIndex]
+    self.refreshShapeRow()
+    self.refreshPreview()
+  }
+
+  @objc private func onTextChanged(_ sender: UITextField) {
+    self.textValue = sender.text ?? ""
+    self.refreshPreview()
+  }
+
+  @objc private func onNumericChanged(_ sender: UIStepper) {
+    self.numericValue = Int(sender.value)
+    self.numericValueLabel.text = "\(self.numericValue)"
+    self.refreshPreview()
+  }
+
+  @objc private func onLeadingIconToggled(_ sender: UISwitch) {
+    self.hasLeadingIcon = sender.isOn
+    self.refreshPreview()
+  }
+}
+
+// MARK: - UIPickerView
+
+extension BezierBadgeTestViewController: UIPickerViewDataSource, UIPickerViewDelegate {
+  func numberOfComponents(in pickerView: UIPickerView) -> Int { 1 }
+
+  func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+    BezierBadgeVariant.allCases.count
+  }
+
+  func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
+    BezierBadgeVariant.allCases[row].rawValue
+  }
+
+  func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+    self.variant = BezierBadgeVariant.allCases[row]
+    self.refreshPreview()
+  }
+}

--- a/Examples/UIKitExample/UIKitExample/BezierBadgeTestViewController.swift
+++ b/Examples/UIKitExample/UIKitExample/BezierBadgeTestViewController.swift
@@ -127,6 +127,9 @@ final class BezierBadgeTestViewController: BaseViewController {
     return toggle
   }()
 
+  private lazy var numericRow: UIView = self.makeStepperRow()
+  private lazy var textRow: UIView = self.textField
+
   // MARK: - Lifecycle
 
   override func viewDidLoad() {
@@ -163,10 +166,59 @@ final class BezierBadgeTestViewController: BaseViewController {
     self.containerStackView.addArrangedSubview(self.variantPicker)
     self.containerStackView.addArrangedSubview(self.makeSectionTitle("Shape"))
     self.containerStackView.addArrangedSubview(self.shapeControl)
-    self.containerStackView.addArrangedSubview(self.textField)
-    self.containerStackView.addArrangedSubview(self.makeStepperRow())
+    self.containerStackView.addArrangedSubview(self.textRow)
+    self.containerStackView.addArrangedSubview(self.numericRow)
     self.containerStackView.addArrangedSubview(self.makeSectionTitle("Content"))
     self.containerStackView.addArrangedSubview(self.makeRow(label: "Leading Icon", control: self.leadingIconSwitch))
+    self.containerStackView.addArrangedSubview(self.makeSectionTitle("Catalog"))
+    self.containerStackView.addArrangedSubview(self.makeCatalogSection())
+  }
+
+  private func makeCatalogSection() -> UIView {
+    let container = UIStackView()
+    container.axis = .vertical
+    container.spacing = 16
+    container.alignment = .leading
+
+    for size in BezierBadgeSize.allCases {
+      let title = UILabel()
+      title.text = size.rawValue
+      title.font = .preferredFont(forTextStyle: .footnote)
+      title.textColor = .secondaryLabel
+      container.addArrangedSubview(title)
+
+      for shape in [BezierBadgeShape.text("Badge"), .numeric(7), .numeric(150), .dot] {
+        container.addArrangedSubview(self.makeCatalogRow(size: size, shape: shape))
+      }
+    }
+    return container
+  }
+
+  private func makeCatalogRow(size: BezierBadgeSize, shape: BezierBadgeShape) -> UIView {
+    let scroll = UIScrollView()
+    scroll.showsHorizontalScrollIndicator = false
+    scroll.translatesAutoresizingMaskIntoConstraints = false
+
+    let row = UIStackView()
+    row.axis = .horizontal
+    row.spacing = 8
+    row.alignment = .center
+    row.translatesAutoresizingMaskIntoConstraints = false
+
+    for variant in BezierBadgeVariant.allCases {
+      row.addArrangedSubview(BezierBadge(size: size, variant: variant, shape: shape))
+    }
+
+    scroll.addSubview(row)
+    NSLayoutConstraint.activate([
+      row.topAnchor.constraint(equalTo: scroll.contentLayoutGuide.topAnchor),
+      row.leadingAnchor.constraint(equalTo: scroll.contentLayoutGuide.leadingAnchor),
+      row.trailingAnchor.constraint(equalTo: scroll.contentLayoutGuide.trailingAnchor),
+      row.bottomAnchor.constraint(equalTo: scroll.contentLayoutGuide.bottomAnchor),
+      row.heightAnchor.constraint(equalTo: scroll.frameLayoutGuide.heightAnchor),
+      scroll.heightAnchor.constraint(equalToConstant: max(size.height, size.dotLength) + 4),
+    ])
+    return scroll
   }
 
   private func makePreviewSection() -> UIView {
@@ -256,9 +308,8 @@ final class BezierBadgeTestViewController: BaseViewController {
   }
 
   private func refreshShapeRow() {
-    self.textField.isHidden = self.shapeKind != .text
-    self.numericStepper.isHidden = self.shapeKind != .numeric
-    self.numericValueLabel.isHidden = self.shapeKind != .numeric
+    self.textRow.isHidden = self.shapeKind != .text
+    self.numericRow.isHidden = self.shapeKind != .numeric
   }
 
   // MARK: - Actions

--- a/Examples/UIKitExample/UIKitExample/ViewController.swift
+++ b/Examples/UIKitExample/UIKitExample/ViewController.swift
@@ -11,10 +11,12 @@ import BezierSwift
 final class ViewController: BaseViewController {
   private enum Row: Int, CaseIterable {
     case bezierButton
+    case bezierBadge
 
     var title: String {
       switch self {
       case .bezierButton: return "Button"
+      case .bezierBadge:  return "Badge"
       }
     }
   }
@@ -65,6 +67,8 @@ extension ViewController: UITableViewDelegate {
     switch row {
     case .bezierButton:
       self.navigationController?.pushViewController(BezierButtonTestViewController(), animated: true)
+    case .bezierBadge:
+      self.navigationController?.pushViewController(BezierBadgeTestViewController(), animated: true)
     }
   }
 }

--- a/Sources/BezierSwift/MasterComponent/BezierBadge/BezierBadge.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBadge/BezierBadge.swift
@@ -102,11 +102,11 @@ public final class BezierBadge: UIView, BezierComponentable {
     let leadingImageWidthConstraint = self.leadingImageView.widthAnchor.constraint(equalToConstant: self.size.iconLength)
     let leadingImageHeightConstraint = self.leadingImageView.heightAnchor.constraint(equalToConstant: self.size.iconLength)
     let contentLeadingConstraint = self.contentStackView.leadingAnchor.constraint(
-      greaterThanOrEqualTo: self.leadingAnchor,
+      equalTo: self.leadingAnchor,
       constant: self.size.horizontalPadding
     )
     let contentTrailingConstraint = self.contentStackView.trailingAnchor.constraint(
-      lessThanOrEqualTo: self.trailingAnchor,
+      equalTo: self.trailingAnchor,
       constant: -self.size.horizontalPadding
     )
 
@@ -116,7 +116,6 @@ public final class BezierBadge: UIView, BezierComponentable {
       leadingImageHeightConstraint,
       contentLeadingConstraint,
       contentTrailingConstraint,
-      self.contentStackView.centerXAnchor.constraint(equalTo: self.centerXAnchor),
       self.contentStackView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
     ])
 
@@ -171,10 +170,16 @@ public final class BezierBadge: UIView, BezierComponentable {
     self.leadingImageView.tintColor = foregroundToken.palette(self)
 
     if let label = self.label, !label.isEmpty {
-      self.titleLabel.attributedText = self.size.typography.attributedString(
-        self,
-        text: label,
-        semanticColorToken: foregroundToken,
+      // TYPO-MIGRATION: Figma raw 값을 직접 사용. 추후 BTSemanticToken으로 통합 예정 (BezierBadgeSpec.swift 참고).
+      let font = UIFont.systemFont(
+        ofSize: self.size.fontSize,
+        weight: self.size.fontWeight.uiKitWeight
+      )
+      self.titleLabel.attributedText = label.applyBezierFont(
+        height: self.size.lineHeight,
+        font: font,
+        color: foregroundToken.palette(self),
+        letterSpacing: self.size.letterSpacing,
         alignment: .center
       )
       self.titleLabel.isHidden = false

--- a/Sources/BezierSwift/MasterComponent/BezierBadge/BezierBadge.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBadge/BezierBadge.swift
@@ -1,0 +1,239 @@
+//
+//  BezierBadge.swift
+//  BezierSwift
+//
+
+import UIKit
+
+public final class BezierBadge: UIView, BezierComponentable {
+  // MARK: - BezierComponentable
+
+  public var colorTheme: BezierColorTheme { .systemBezierColorTheme() }
+  public var componentTheme: BezierComponentTheme = .normal {
+    didSet { self.refreshAppearance() }
+  }
+
+  // MARK: - Public Properties
+
+  public var size: BezierBadgeSize = .small {
+    didSet { if oldValue != self.size { self.refreshLayout() } }
+  }
+
+  public var variant: BezierBadgeVariant = .default {
+    didSet { if oldValue != self.variant { self.refreshAppearance() } }
+  }
+
+  public var shape: BezierBadgeShape = .text("Badge") {
+    didSet { if oldValue != self.shape { self.refreshShape() } }
+  }
+
+  public var leadingIcon: UIImage? {
+    didSet { self.refreshContent() }
+  }
+
+  // MARK: - Subviews
+
+  private let contentStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .horizontal
+    stackView.alignment = .center
+    stackView.distribution = .fill
+    stackView.spacing = 0
+    stackView.isUserInteractionEnabled = false
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    return stackView
+  }()
+
+  private let leadingImageView: UIImageView = {
+    let imageView = UIImageView()
+    imageView.contentMode = .scaleAspectFit
+    imageView.isHidden = true
+    imageView.translatesAutoresizingMaskIntoConstraints = false
+    return imageView
+  }()
+
+  private let titleLabel: BezierBadgePaddedLabel = {
+    let label = BezierBadgePaddedLabel()
+    label.numberOfLines = 1
+    label.textAlignment = .center
+    return label
+  }()
+
+  // MARK: - Layout Constraints
+
+  private var heightConstraint: NSLayoutConstraint?
+  private var minWidthConstraint: NSLayoutConstraint?
+  private var leadingImageWidthConstraint: NSLayoutConstraint?
+  private var leadingImageHeightConstraint: NSLayoutConstraint?
+  private var contentLeadingConstraint: NSLayoutConstraint?
+  private var contentTrailingConstraint: NSLayoutConstraint?
+
+  // MARK: - Init
+
+  public init(
+    size: BezierBadgeSize = .small,
+    variant: BezierBadgeVariant = .default,
+    shape: BezierBadgeShape = .text("Badge")
+  ) {
+    self.size = size
+    self.variant = variant
+    self.shape = shape
+    super.init(frame: .zero)
+    self.setUp()
+  }
+
+  public required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    self.setUp()
+  }
+
+  // MARK: - Setup
+
+  private func setUp() {
+    self.translatesAutoresizingMaskIntoConstraints = false
+    self.isUserInteractionEnabled = false
+
+    self.layer.masksToBounds = true
+    self.layer.borderWidth = 0
+
+    self.contentStackView.addArrangedSubview(self.leadingImageView)
+    self.contentStackView.addArrangedSubview(self.titleLabel)
+
+    self.addSubview(self.contentStackView)
+
+    let heightConstraint = self.heightAnchor.constraint(equalToConstant: self.size.height)
+    let minWidthConstraint = self.widthAnchor.constraint(greaterThanOrEqualToConstant: self.size.height)
+    let leadingImageWidthConstraint = self.leadingImageView.widthAnchor.constraint(equalToConstant: self.size.iconLength)
+    let leadingImageHeightConstraint = self.leadingImageView.heightAnchor.constraint(equalToConstant: self.size.iconLength)
+    let contentLeadingConstraint = self.contentStackView.leadingAnchor.constraint(
+      greaterThanOrEqualTo: self.leadingAnchor,
+      constant: self.size.horizontalPadding
+    )
+    let contentTrailingConstraint = self.contentStackView.trailingAnchor.constraint(
+      lessThanOrEqualTo: self.trailingAnchor,
+      constant: -self.size.horizontalPadding
+    )
+
+    NSLayoutConstraint.activate([
+      heightConstraint,
+      minWidthConstraint,
+      leadingImageWidthConstraint,
+      leadingImageHeightConstraint,
+      contentLeadingConstraint,
+      contentTrailingConstraint,
+      self.contentStackView.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+      self.contentStackView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+    ])
+
+    self.heightConstraint = heightConstraint
+    self.minWidthConstraint = minWidthConstraint
+    self.leadingImageWidthConstraint = leadingImageWidthConstraint
+    self.leadingImageHeightConstraint = leadingImageHeightConstraint
+    self.contentLeadingConstraint = contentLeadingConstraint
+    self.contentTrailingConstraint = contentTrailingConstraint
+
+    self.refreshLayout()
+    self.refreshShape()
+    self.refreshAppearance()
+  }
+
+  // MARK: - Layout Update
+
+  public override func layoutSubviews() {
+    super.layoutSubviews()
+    self.layer.cornerRadius = self.bounds.height / 2
+  }
+
+  public override var intrinsicContentSize: CGSize {
+    if self.shape.isDot {
+      return CGSize(width: self.size.dotLength, height: self.size.dotLength)
+    }
+    return super.intrinsicContentSize
+  }
+
+  public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    self.refreshAppearance()
+  }
+
+  // MARK: - Refresh
+
+  private func refreshLayout() {
+    self.heightConstraint?.constant = self.shape.isDot ? self.size.dotLength : self.size.height
+    self.minWidthConstraint?.constant = self.shape.isDot ? self.size.dotLength : self.size.height
+    self.leadingImageWidthConstraint?.constant = self.size.iconLength
+    self.leadingImageHeightConstraint?.constant = self.size.iconLength
+    self.contentLeadingConstraint?.constant = self.size.horizontalPadding
+    self.contentTrailingConstraint?.constant = -self.size.horizontalPadding
+
+    self.titleLabel.contentInsets = UIEdgeInsets(
+      top: 0,
+      left: self.size.textHorizontalPadding,
+      bottom: 0,
+      right: self.size.textHorizontalPadding
+    )
+
+    self.refreshContent()
+    self.invalidateIntrinsicContentSize()
+    self.setNeedsLayout()
+  }
+
+  private func refreshShape() {
+    self.contentStackView.isHidden = self.shape.isDot
+    self.heightConstraint?.constant = self.shape.isDot ? self.size.dotLength : self.size.height
+    self.minWidthConstraint?.constant = self.shape.isDot ? self.size.dotLength : self.size.height
+    self.refreshContent()
+    self.invalidateIntrinsicContentSize()
+    self.setNeedsLayout()
+  }
+
+  private func refreshContent() {
+    self.leadingImageView.image = self.leadingIcon?.withRenderingMode(.alwaysTemplate)
+    self.leadingImageView.isHidden = self.leadingIcon == nil || self.shape.isDot
+
+    let foregroundToken = self.variant.foregroundToken
+    self.leadingImageView.tintColor = foregroundToken.palette(self)
+
+    if let text = self.shape.displayText, !text.isEmpty {
+      self.titleLabel.attributedText = self.size.typography.attributedString(
+        self,
+        text: text,
+        semanticColorToken: foregroundToken,
+        alignment: .center
+      )
+      self.titleLabel.isHidden = false
+    } else {
+      self.titleLabel.attributedText = nil
+      self.titleLabel.isHidden = true
+    }
+  }
+
+  private func refreshAppearance() {
+    self.backgroundColor = self.variant.backgroundToken.palette(self)
+    self.leadingImageView.tintColor = self.variant.foregroundToken.palette(self)
+    self.refreshContent()
+  }
+}
+
+// MARK: - Padded Label
+
+final class BezierBadgePaddedLabel: UILabel {
+  var contentInsets: UIEdgeInsets = .zero {
+    didSet {
+      self.invalidateIntrinsicContentSize()
+      self.setNeedsDisplay()
+    }
+  }
+
+  override func drawText(in rect: CGRect) {
+    super.drawText(in: rect.inset(by: self.contentInsets))
+  }
+
+  override var intrinsicContentSize: CGSize {
+    let size = super.intrinsicContentSize
+    return CGSize(
+      width: size.width + self.contentInsets.left + self.contentInsets.right,
+      height: size.height + self.contentInsets.top + self.contentInsets.bottom
+    )
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierBadge/BezierBadge.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBadge/BezierBadge.swift
@@ -23,8 +23,8 @@ public final class BezierBadge: UIView, BezierComponentable {
     didSet { if oldValue != self.variant { self.refreshAppearance() } }
   }
 
-  public var shape: BezierBadgeShape = .text("Badge") {
-    didSet { if oldValue != self.shape { self.refreshShape() } }
+  public var label: String? {
+    didSet { if oldValue != self.label { self.refreshContent() } }
   }
 
   public var leadingIcon: UIImage? {
@@ -62,7 +62,6 @@ public final class BezierBadge: UIView, BezierComponentable {
   // MARK: - Layout Constraints
 
   private var heightConstraint: NSLayoutConstraint?
-  private var minWidthConstraint: NSLayoutConstraint?
   private var leadingImageWidthConstraint: NSLayoutConstraint?
   private var leadingImageHeightConstraint: NSLayoutConstraint?
   private var contentLeadingConstraint: NSLayoutConstraint?
@@ -72,12 +71,10 @@ public final class BezierBadge: UIView, BezierComponentable {
 
   public init(
     size: BezierBadgeSize = .small,
-    variant: BezierBadgeVariant = .default,
-    shape: BezierBadgeShape = .text("Badge")
+    variant: BezierBadgeVariant = .default
   ) {
     self.size = size
     self.variant = variant
-    self.shape = shape
     super.init(frame: .zero)
     self.setUp()
   }
@@ -102,7 +99,6 @@ public final class BezierBadge: UIView, BezierComponentable {
     self.addSubview(self.contentStackView)
 
     let heightConstraint = self.heightAnchor.constraint(equalToConstant: self.size.height)
-    let minWidthConstraint = self.widthAnchor.constraint(greaterThanOrEqualToConstant: self.size.height)
     let leadingImageWidthConstraint = self.leadingImageView.widthAnchor.constraint(equalToConstant: self.size.iconLength)
     let leadingImageHeightConstraint = self.leadingImageView.heightAnchor.constraint(equalToConstant: self.size.iconLength)
     let contentLeadingConstraint = self.contentStackView.leadingAnchor.constraint(
@@ -116,7 +112,6 @@ public final class BezierBadge: UIView, BezierComponentable {
 
     NSLayoutConstraint.activate([
       heightConstraint,
-      minWidthConstraint,
       leadingImageWidthConstraint,
       leadingImageHeightConstraint,
       contentLeadingConstraint,
@@ -126,14 +121,12 @@ public final class BezierBadge: UIView, BezierComponentable {
     ])
 
     self.heightConstraint = heightConstraint
-    self.minWidthConstraint = minWidthConstraint
     self.leadingImageWidthConstraint = leadingImageWidthConstraint
     self.leadingImageHeightConstraint = leadingImageHeightConstraint
     self.contentLeadingConstraint = contentLeadingConstraint
     self.contentTrailingConstraint = contentTrailingConstraint
 
     self.refreshLayout()
-    self.refreshShape()
     self.refreshAppearance()
   }
 
@@ -144,13 +137,6 @@ public final class BezierBadge: UIView, BezierComponentable {
     self.layer.cornerRadius = self.bounds.height / 2
   }
 
-  public override var intrinsicContentSize: CGSize {
-    if self.shape.isDot {
-      return CGSize(width: self.size.dotLength, height: self.size.dotLength)
-    }
-    return super.intrinsicContentSize
-  }
-
   public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
     super.traitCollectionDidChange(previousTraitCollection)
     self.refreshAppearance()
@@ -159,8 +145,7 @@ public final class BezierBadge: UIView, BezierComponentable {
   // MARK: - Refresh
 
   private func refreshLayout() {
-    self.heightConstraint?.constant = self.shape.isDot ? self.size.dotLength : self.size.height
-    self.minWidthConstraint?.constant = self.shape.isDot ? self.size.dotLength : self.size.height
+    self.heightConstraint?.constant = self.size.height
     self.leadingImageWidthConstraint?.constant = self.size.iconLength
     self.leadingImageHeightConstraint?.constant = self.size.iconLength
     self.contentLeadingConstraint?.constant = self.size.horizontalPadding
@@ -178,26 +163,17 @@ public final class BezierBadge: UIView, BezierComponentable {
     self.setNeedsLayout()
   }
 
-  private func refreshShape() {
-    self.contentStackView.isHidden = self.shape.isDot
-    self.heightConstraint?.constant = self.shape.isDot ? self.size.dotLength : self.size.height
-    self.minWidthConstraint?.constant = self.shape.isDot ? self.size.dotLength : self.size.height
-    self.refreshContent()
-    self.invalidateIntrinsicContentSize()
-    self.setNeedsLayout()
-  }
-
   private func refreshContent() {
     self.leadingImageView.image = self.leadingIcon?.withRenderingMode(.alwaysTemplate)
-    self.leadingImageView.isHidden = self.leadingIcon == nil || self.shape.isDot
+    self.leadingImageView.isHidden = self.leadingIcon == nil
 
     let foregroundToken = self.variant.foregroundToken
     self.leadingImageView.tintColor = foregroundToken.palette(self)
 
-    if let text = self.shape.displayText, !text.isEmpty {
+    if let label = self.label, !label.isEmpty {
       self.titleLabel.attributedText = self.size.typography.attributedString(
         self,
-        text: text,
+        text: label,
         semanticColorToken: foregroundToken,
         alignment: .center
       )

--- a/Sources/BezierSwift/MasterComponent/BezierBadge/BezierBadgeSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBadge/BezierBadgeSpec.swift
@@ -35,15 +35,6 @@ public enum BezierBadgeSize: String, CaseIterable {
 
   public var iconLength: CGFloat { 16 }
 
-  public var dotLength: CGFloat {
-    switch self {
-    case .xsmall: return 6
-    case .small:  return 6
-    case .medium: return 8
-    case .large:  return 10
-    }
-  }
-
   public var typography: BTSemanticToken {
     switch self {
     case .xsmall: return .textXSmall(weight: .regular)
@@ -69,16 +60,6 @@ public enum BezierBadgeVariant: String, CaseIterable {
   case orange
   case red
   case purple
-}
-
-public enum BezierBadgeShape: Equatable {
-  case dot
-  case numeric(Int)
-  case text(String)
-}
-
-public enum BezierBadgeConstant {
-  public static let numericCap: Int = 99
 }
 
 extension BezierBadgeVariant {
@@ -118,26 +99,5 @@ extension BezierBadgeVariant {
     case .red:             return .textAccentRed
     case .purple:          return .textAccentPurple
     }
-  }
-}
-
-extension BezierBadgeShape {
-  public var displayText: String? {
-    switch self {
-    case .dot:
-      return nil
-    case .numeric(let value):
-      let clamped = max(0, value)
-      return clamped > BezierBadgeConstant.numericCap
-        ? "\(BezierBadgeConstant.numericCap)+"
-        : "\(clamped)"
-    case .text(let text):
-      return text
-    }
-  }
-
-  public var isDot: Bool {
-    if case .dot = self { return true }
-    return false
   }
 }

--- a/Sources/BezierSwift/MasterComponent/BezierBadge/BezierBadgeSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBadge/BezierBadgeSpec.swift
@@ -4,6 +4,7 @@
 //
 
 import CoreGraphics
+import UIKit
 
 public enum BezierBadgeSize: String, CaseIterable {
   case xsmall
@@ -35,14 +36,51 @@ public enum BezierBadgeSize: String, CaseIterable {
 
   public var iconLength: CGFloat { 16 }
 
-  public var typography: BTSemanticToken {
+  // MARK: - Typography (Figma raw, see SPEC §3)
+  //
+  // TYPO-MIGRATION: Figma component description의 `📌 TYPO-MIGRATION: Text Style
+  // 미적용` 상태에 따라 raw 값을 직접 사용한다. xsmall/small은 BTSemanticToken
+  // (.textXSmall / .textMedium)과 정합하지만, medium/large는 lineHeight·letterSpacing
+  // 이 token(.textLarge / .textXLarge)과 일치하지 않으므로 token을 우회하고 raw 값을
+  // 적용한다. 디자인팀의 로컬 typography 스타일 일괄 바인딩이 끝나 raw가 token과
+  // 정합되면 BTSemanticToken 기반 API로 통합 예정.
+
+  public var fontSize: CGFloat {
     switch self {
-    case .xsmall: return .textXSmall(weight: .regular)
-    case .small:  return .textMedium(weight: .regular)
-    case .medium: return .textLarge(weight: .regular)
-    case .large:  return .textXLarge(weight: .regular)
+    case .xsmall: return 12
+    case .small:  return 14
+    case .medium: return 15
+    case .large:  return 16
     }
   }
+
+  public var lineHeight: CGFloat {
+    switch self {
+    case .xsmall: return 16
+    case .small:  return 18
+    case .medium: return 18
+    case .large:  return 20
+    }
+  }
+
+  public var letterSpacing: CGFloat {
+    switch self {
+    case .xsmall, .small, .medium: return 0
+    case .large: return -0.1
+    }
+  }
+
+  public var fontWeight: BTFontWeight { .regular }
+
+  /// SwiftUI `.lineSpacing` modifier에 전달할 값. UIFont의 line height와 spec의
+  /// lineHeight 차이를 보정한다.
+  public var lineSpacing: CGFloat {
+    let font = UIFont.systemFont(ofSize: self.fontSize, weight: self.fontWeight.uiKitWeight)
+    return max(0, self.lineHeight - font.lineHeight)
+  }
+
+  /// 상·하 line-box 보정을 균등하게 적용하기 위한 vertical padding.
+  public var verticalLineSpacing: CGFloat { self.lineSpacing / 2 }
 }
 
 public enum BezierBadgeVariant: String, CaseIterable {

--- a/Sources/BezierSwift/MasterComponent/BezierBadge/BezierBadgeSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBadge/BezierBadgeSpec.swift
@@ -1,0 +1,143 @@
+//
+//  BezierBadgeSpec.swift
+//  BezierSwift
+//
+
+import CoreGraphics
+
+public enum BezierBadgeSize: String, CaseIterable {
+  case xsmall
+  case small
+  case medium
+  case large
+
+  public var height: CGFloat {
+    switch self {
+    case .xsmall: return 18
+    case .small:  return 22
+    case .medium: return 22
+    case .large:  return 26
+    }
+  }
+
+  public var horizontalPadding: CGFloat { 4 }
+
+  public var textHorizontalPadding: CGFloat { 4 }
+
+  public var verticalPadding: CGFloat {
+    switch self {
+    case .xsmall: return 1
+    case .small:  return 2
+    case .medium: return 2
+    case .large:  return 3
+    }
+  }
+
+  public var iconLength: CGFloat { 16 }
+
+  public var dotLength: CGFloat {
+    switch self {
+    case .xsmall: return 6
+    case .small:  return 6
+    case .medium: return 8
+    case .large:  return 10
+    }
+  }
+
+  public var typography: BTSemanticToken {
+    switch self {
+    case .xsmall: return .textXSmall(weight: .regular)
+    case .small:  return .textMedium(weight: .regular)
+    case .medium: return .textLarge(weight: .regular)
+    case .large:  return .textXLarge(weight: .regular)
+    }
+  }
+}
+
+public enum BezierBadgeVariant: String, CaseIterable {
+  case `default`
+  case monochromeLight
+  case monochromeDark
+  case blue
+  case cobalt
+  case teal
+  case green
+  case olive
+  case pink
+  case navy
+  case yellow
+  case orange
+  case red
+  case purple
+}
+
+public enum BezierBadgeShape: Equatable {
+  case dot
+  case numeric(Int)
+  case text(String)
+}
+
+public enum BezierBadgeConstant {
+  public static let numericCap: Int = 99
+}
+
+extension BezierBadgeVariant {
+  public var backgroundToken: BCSemanticToken {
+    switch self {
+    case .default:         return .fillNeutralLight
+    case .monochromeLight: return .fillNeutralLight
+    case .monochromeDark:  return .fillNeutralHeavier
+    case .blue:            return .fillAccentBlueHeavy
+    case .cobalt:          return .fillAccentCobaltHeavy
+    case .teal:            return .fillAccentTealHeavy
+    case .green:           return .fillAccentGreenHeavy
+    case .olive:           return .fillAccentOliveHeavy
+    case .pink:            return .fillAccentPinkHeavy
+    case .navy:            return .fillAccentNavyHeavy
+    case .yellow:          return .fillAccentYellowHeavy
+    case .orange:          return .fillAccentOrangeHeavy
+    case .red:             return .fillAccentRedHeavy
+    case .purple:          return .fillAccentPurpleHeavy
+    }
+  }
+
+  public var foregroundToken: BCSemanticToken {
+    switch self {
+    case .default:         return .textNeutral
+    case .monochromeLight: return .textNeutralLighter
+    case .monochromeDark:  return .textAbsoluteWhite
+    case .blue:            return .textAccentBlue
+    case .cobalt:          return .textAccentCobalt
+    case .teal:            return .textAccentTeal
+    case .green:           return .textAccentGreen
+    case .olive:           return .textAccentOlive
+    case .pink:            return .textAccentPink
+    case .navy:            return .textAccentNavy
+    case .yellow:          return .textAccentYellow
+    case .orange:          return .textAccentOrange
+    case .red:             return .textAccentRed
+    case .purple:          return .textAccentPurple
+    }
+  }
+}
+
+extension BezierBadgeShape {
+  public var displayText: String? {
+    switch self {
+    case .dot:
+      return nil
+    case .numeric(let value):
+      let clamped = max(0, value)
+      return clamped > BezierBadgeConstant.numericCap
+        ? "\(BezierBadgeConstant.numericCap)+"
+        : "\(clamped)"
+    case .text(let text):
+      return text
+    }
+  }
+
+  public var isDot: Bool {
+    if case .dot = self { return true }
+    return false
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierBadge/SPEC.md
+++ b/Sources/BezierSwift/MasterComponent/BezierBadge/SPEC.md
@@ -142,7 +142,7 @@ Figma 컴포넌트가 정의하는 property와 옵션은 다음이 전부다.
 
 총 instance: `4 size × 14 color = 56개`
 
-```
+```text
 Size=xsmall, Color=default          = 1729:2
 Size=xsmall, Color=monochrome-light = 1729:41
 Size=xsmall, Color=monochrome-dark  = 1729:38

--- a/Sources/BezierSwift/MasterComponent/BezierBadge/SPEC.md
+++ b/Sources/BezierSwift/MasterComponent/BezierBadge/SPEC.md
@@ -123,14 +123,18 @@ Figma 컴포넌트가 정의하는 property와 옵션은 다음이 전부다.
 | 색상 토큰 (semantic) | `Sources/BezierSwift/Foundation/Color/V3/BCSemanticToken.swift` |
 | 타이포 토큰 (semantic) | `Sources/BezierSwift/Foundation/Typography/V3/BTSemanticToken.swift` |
 
-> ⚠️ **Typography 매핑 정책 (TYPO-MIGRATION 협의)**: SPEC §3의 Figma raw 값은 `BTSemanticToken`의 가장 가까운 case로 매핑한다. **font size는 정확히 일치**하지만 medium/large의 `lineHeight`는 토큰값(20/24)을 따르며 Figma raw(18/20)와 차이가 있다. 이는 로컬 타이포 스타일 일괄 바인딩 시 정합될 예정.
+> ⚠️ **Typography 매핑 정책 (TYPO-MIGRATION 진행 중 잠정 매핑)**: Figma component description의 `📌 TYPO-MIGRATION: Text Style 미적용 — 로컬 타이포 스타일 등록 시 일괄 바인딩 예정`에 따라, Figma는 현재 raw value를 직접 박아놓은 상태다.
 >
-> | Size | Figma raw (FS/LH/LS) | 매핑 case | 토큰 값 (FS/LH/LS) |
+> **현재 정책**: Figma SSOT를 우선시한다. `BTSemanticToken`의 case 중 Figma raw와 정확히 일치하는 것이 있더라도 일관성을 위해 **모든 size에서 raw 값을 직접 사용**한다. 일치하지 않는 medium/large는 token이 아닌 raw로 처리.
+>
+> | Size | Figma raw (FS/LH/LS) | 가장 가까운 token (참고용) | Token 정합성 |
 > |---|---|---|---|
-> | xsmall | 12 / 16 / 0 | `.textXSmall(.regular)` | 12 / 16 / 0 ✅ |
-> | small | 14 / 18 / 0 | `.textMedium(.regular)` | 14 / 18 / 0 ✅ |
-> | medium | 15 / 18 / 0 | `.textLarge(.regular)` | 15 / 20 / -0.1 ⚠️ |
-> | large | 16 / 20 / -0.1 | `.textXLarge(.regular)` | 16 / 24 / -0.1 ⚠️ |
+> | xsmall | 12 / 16 / 0 | `.textXSmall(.regular)` (12 / 16 / 0) | ✅ 일치 (참고) |
+> | small | 14 / 18 / 0 | `.textMedium(.regular)` (14 / 18 / 0) | ✅ 일치 (참고) |
+> | medium | 15 / 18 / 0 | `.textLarge(.regular)` (15 / 20 / -0.1) | ⚠️ lineHeight·spacing 불일치 |
+> | large | 16 / 20 / -0.1 | `.textXLarge(.regular)` (16 / 24 / -0.1) | ⚠️ lineHeight 불일치 |
+>
+> **TODO**: 디자인팀의 TYPO-MIGRATION (로컬 typography style 일괄 바인딩) 완료 후 raw 값과 token이 정합되면 `BTSemanticToken` 기반 API로 통합 예정.
 
 ---
 

--- a/Sources/BezierSwift/MasterComponent/BezierBadge/SPEC.md
+++ b/Sources/BezierSwift/MasterComponent/BezierBadge/SPEC.md
@@ -1,0 +1,171 @@
+# BezierBadge Spec
+
+> Figma: [🚧 Mobile Components — Badge](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=1729-170)
+> Design spec doc: [bezier-v3/component-spec/Badge-spec.md](https://github.com/channel-io/design-team/blob/main/docs/bezier-v3/component-spec/Badge-spec.md)
+
+목록·카드 UI에서 항목의 상태나 속성을 색상과 텍스트로 즉각 전달하는 인라인 레이블.
+
+- **모양**: Capsule (radius/32 = 32pt, 실제 높이가 32 미만이므로 capsule 형태로 렌더링)
+- **읽기 전용**: Badge는 항상 읽기 전용. 사용자가 제거할 수 있다면 Tag를 사용한다.
+- **인터랙션 없음**: state property 없음 (default/pressed/active/disabled 분기 없음)
+
+---
+
+## 1. Component Properties
+
+Figma 컴포넌트가 정의하는 property와 옵션은 다음이 전부다.
+
+| Property | 값 | 비고 |
+|---|---|---|
+| **Size** | `xsmall` / `small` / `medium` / `large` | 4단계 |
+| **Color** | `default` / `monochrome-light` / `monochrome-dark` / `blue` / `cobalt` / `teal` / `green` / `olive` / `pink` / `navy` / `yellow` / `orange` / `red` / `purple` | 14가지 |
+| **hasIcon** | `true` / `false` | 옵션. true 시 leading icon 표시 |
+| **iconSource** | slot (ReactNode) | leading icon 본체. `hasIcon = true`일 때 렌더. 사이즈 16×16 |
+| **label** | string | 디자인 시스템 콘텐츠 (placeholder default 없음). Figma의 `"Badge"`는 컴포넌트 preview용 placeholder이며 API default가 아님 |
+
+총 instance: `4 size × 14 color = 56개` (Figma 컴포넌트 인스턴스 수와 일치)
+
+---
+
+## 2. Size 별 Spec
+
+| Size | Height | Horizontal Padding | Vertical Padding | Text Horizontal Padding (BadgeText 내부) | Icon Length |
+|---|---|---|---|---|---|
+| `xsmall` | 18pt | 4pt | 1pt | 4pt | 16pt |
+| `small`  | 22pt | 4pt | 2pt | 4pt | 16pt |
+| `medium` | 22pt | 4pt | 2pt | 4pt | 16pt |
+| `large`  | 26pt | 4pt | 3pt | 4pt | 16pt |
+
+- **Corner radius**: `radius/32 = 32pt`. height < 32 이므로 capsule 형태로 보임.
+- **Min width**: container `justify-center`이며 padding 외 최소 폭 제약 없음. xsmall은 `min-h-[16px]` (Figma container에 직접 지정).
+- **Layout**: `flex items-center justify-center` — leading icon → BadgeText 순. content gap 0 (BadgeText가 자체 horizontal padding으로 간격을 만든다).
+
+---
+
+## 3. Size 별 Typography
+
+> 📌 **TYPO-MIGRATION** (Figma description 인용): Text Style 미적용 — 로컬 타이포 스타일 등록 시 일괄 바인딩 예정. Figma는 raw value 직접 지정 상태.
+
+| Size | Font Size | Line Height | Letter Spacing | Font Family |
+|---|---|---|---|---|
+| `xsmall` | 12pt | 16pt | 0 | `text/font-family` (Inter) |
+| `small`  | 14pt | 18pt | 0 | `label/font-family` (Inter) |
+| `medium` | 15pt | 18pt | 0 | `label/font-family` (Inter) |
+| `large`  | 16pt | 20pt | -0.1pt (`text/letter-spacing/tight`) | `font-family/sans-kr` (Inter) |
+
+- Weight: 전부 regular (400).
+- Italic: 전부 not-italic.
+
+---
+
+## 4. Color 별 컬러 토큰
+
+### Background
+
+| Variant | Figma Variable | Raw |
+|---|---|---|
+| `default` | `color/fill/neutral/light` | `#0000000D` (rgba(0,0,0,0.05)) |
+| `monochrome-light` | `color/fill/neutral/light` | `#0000000D` |
+| `monochrome-dark` | `color/fill/neutral/heavier` | `#00000066` (rgba(0,0,0,0.4)) |
+| `blue` | `color/fill/accent/blue/heavy` | `#6157EA33` |
+| `cobalt` | `color/fill/accent/cobalt/heavy` | `#3292E333` |
+| `teal` | `color/fill/accent/teal/heavy` | `#09B2AC33` |
+| `green` | `color/fill/accent/green/heavy` | `#20AB5533` |
+| `olive` | `color/fill/accent/olive/heavy` | `#A9B11033` |
+| `pink` | `color/fill/accent/pink/heavy` | `#D64BB533` |
+| `navy` | `color/fill/accent/navy/heavy` | `#424FAB33` |
+| `yellow` | `color/fill/accent/yellow/heavy` | `#EDAE0D33` |
+| `orange` | `color/fill/accent/orange/heavy` | `#E67F2B33` |
+| `red` | `color/fill/accent/red/heavy` | `#E1535D33` |
+| `purple` | `color/fill/accent/purple/heavy` | `#8E57E733` |
+
+### Foreground (text & icon)
+
+| Variant | Figma Variable | Raw |
+|---|---|---|
+| `default` | `color/text/neutral` | `#000000D9` (rgba(0,0,0,0.85)) |
+| `monochrome-light` | `color/text/neutral/lighter` | `#00000066` |
+| `monochrome-dark` | `color/text/absolute/white` | `#FFFFFF` |
+| `blue` | `color/text/accent/blue` | `#6157EA` |
+| `cobalt` | `color/text/accent/cobalt` | `#3292E3` |
+| `teal` | `color/text/accent/teal` | `#09B2AC` |
+| `green` | `color/text/accent/green` | `#20AB55` |
+| `olive` | `color/text/accent/olive` | `#A9B110` |
+| `pink` | `color/text/accent/pink` | `#D64BB5` |
+| `navy` | `color/text/accent/navy` | `#424FAB` |
+| `yellow` | `color/text/accent/yellow` | `#EDAE0D` |
+| `orange` | `color/text/accent/orange` | `#E67F2B` |
+| `red` | `color/text/accent/red` | `#E1535D` |
+| `purple` | `color/text/accent/purple` | `#8E57E7` |
+
+---
+
+## 5. State
+
+해당 없음. Badge는 항상 읽기 전용이며 default/pressed/active/disabled/loading state property가 존재하지 않는다.
+
+---
+
+## 6. 디자이너 가이드라인 (Figma component description 인용)
+
+- **상태 의미**: `green`=성공·활성 / `red`=오류·긴급 / `orange`=경고 / `blue`=정보·진행 / `monochrome-light`=비활성·초안
+- **읽기 전용**: 사용자가 제거할 수 있으면 Tag 사용. Badge는 항상 읽기 전용.
+
+---
+
+## 7. 매핑되는 코드 심볼
+
+| 정의 | 파일 |
+|---|---|
+| UIKit 구현 | `BezierBadge.swift` |
+| SwiftUI 구현 | `SUBezierBadge.swift` |
+| Size / Variant enum | `BezierBadgeSpec.swift` |
+| 색상 토큰 (semantic) | `Sources/BezierSwift/Foundation/Color/V3/BCSemanticToken.swift` |
+| 타이포 토큰 (semantic) | `Sources/BezierSwift/Foundation/Typography/V3/BTSemanticToken.swift` |
+
+> ⚠️ **Typography 매핑 정책 (TYPO-MIGRATION 협의)**: SPEC §3의 Figma raw 값은 `BTSemanticToken`의 가장 가까운 case로 매핑한다. **font size는 정확히 일치**하지만 medium/large의 `lineHeight`는 토큰값(20/24)을 따르며 Figma raw(18/20)와 차이가 있다. 이는 로컬 타이포 스타일 일괄 바인딩 시 정합될 예정.
+>
+> | Size | Figma raw (FS/LH/LS) | 매핑 case | 토큰 값 (FS/LH/LS) |
+> |---|---|---|---|
+> | xsmall | 12 / 16 / 0 | `.textXSmall(.regular)` | 12 / 16 / 0 ✅ |
+> | small | 14 / 18 / 0 | `.textMedium(.regular)` | 14 / 18 / 0 ✅ |
+> | medium | 15 / 18 / 0 | `.textLarge(.regular)` | 15 / 20 / -0.1 ⚠️ |
+> | large | 16 / 20 / -0.1 | `.textXLarge(.regular)` | 16 / 24 / -0.1 ⚠️ |
+
+---
+
+## 8. Variant 매트릭스
+
+총 instance: `4 size × 14 color = 56개`
+
+```
+Size=xsmall, Color=default          = 1729:2
+Size=xsmall, Color=monochrome-light = 1729:41
+Size=xsmall, Color=monochrome-dark  = 1729:38
+Size=xsmall, Color=blue             = 1729:5
+Size=xsmall, Color=cobalt           = 1729:8
+Size=xsmall, Color=teal             = 1729:11
+Size=xsmall, Color=green            = 1729:14
+Size=xsmall, Color=olive            = 1729:17
+Size=xsmall, Color=pink             = 1729:20
+Size=xsmall, Color=navy             = 1729:23
+Size=xsmall, Color=yellow           = 1729:26
+Size=xsmall, Color=orange           = 1729:29
+Size=xsmall, Color=red              = 1729:32
+Size=xsmall, Color=purple           = 1729:35
+
+Size=small, Color=default           = 1729:44
+... (각 색상별 14 instance, 동일 패턴)
+Size=small, Color=monochrome-light  = 1729:83
+Size=small, Color=monochrome-dark   = 1729:80
+
+Size=medium, Color=default          = 1729:86
+... (각 색상별 14 instance, 동일 패턴)
+Size=medium, Color=monochrome-light = 1729:125
+Size=medium, Color=monochrome-dark  = 1729:122
+
+Size=large, Color=default           = 1729:128
+... (각 색상별 14 instance, 동일 패턴)
+Size=large, Color=monochrome-light  = 1729:167
+Size=large, Color=monochrome-dark   = 1729:164
+```

--- a/Sources/BezierSwift/MasterComponent/BezierBadge/SUBezierBadge.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBadge/SUBezierBadge.swift
@@ -31,11 +31,13 @@ public struct SUBezierBadge: View, Themeable {
         self.iconView(leadingIcon)
       }
       if let label = self.label, !label.isEmpty {
+        // TYPO-MIGRATION: Figma raw 값을 직접 사용. 추후 BTSemanticToken으로 통합 예정 (BezierBadgeSpec.swift 참고).
         Text(label)
-          .applyBezierFontStyle(
-            self.size.typography,
-            semanticColorToken: self.variant.foregroundToken
-          )
+          .font(.system(size: self.size.fontSize, weight: self.size.fontWeight.swiftUIWeight))
+          .tracking(self.size.letterSpacing)
+          .lineSpacing(self.size.lineSpacing)
+          .padding(.vertical, self.size.verticalLineSpacing)
+          .foregroundColor(self.palette(self.variant.foregroundToken))
           .padding(.horizontal, self.size.textHorizontalPadding)
           .fixedSize(horizontal: true, vertical: false)
       }

--- a/Sources/BezierSwift/MasterComponent/BezierBadge/SUBezierBadge.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBadge/SUBezierBadge.swift
@@ -8,7 +8,7 @@ import SwiftUI
 public struct SUBezierBadge: View, Themeable {
   private let size: BezierBadgeSize
   private let variant: BezierBadgeVariant
-  private let shape: BezierBadgeShape
+  private let label: String?
   private let leadingIcon: Image?
 
   @Environment(\.colorScheme) public var colorScheme
@@ -16,41 +16,34 @@ public struct SUBezierBadge: View, Themeable {
   public init(
     size: BezierBadgeSize = .small,
     variant: BezierBadgeVariant = .default,
-    shape: BezierBadgeShape,
+    label: String? = nil,
     leadingIcon: Image? = nil
   ) {
     self.size = size
     self.variant = variant
-    self.shape = shape
+    self.label = label
     self.leadingIcon = leadingIcon
   }
 
   public var body: some View {
-    if self.shape.isDot {
-      Circle()
-        .fill(self.palette(self.variant.backgroundToken))
-        .frame(width: self.size.dotLength, height: self.size.dotLength)
-    } else {
-      HStack(spacing: 0) {
-        if let leadingIcon = self.leadingIcon {
-          self.iconView(leadingIcon)
-        }
-        if let text = self.shape.displayText, !text.isEmpty {
-          Text(text)
-            .applyBezierFontStyle(
-              self.size.typography,
-              semanticColorToken: self.variant.foregroundToken
-            )
-            .padding(.horizontal, self.size.textHorizontalPadding)
-            .fixedSize(horizontal: true, vertical: false)
-        }
+    HStack(spacing: 0) {
+      if let leadingIcon = self.leadingIcon {
+        self.iconView(leadingIcon)
       }
-      .padding(.horizontal, self.size.horizontalPadding)
-      .frame(minHeight: self.size.height, maxHeight: self.size.height)
-      .frame(minWidth: self.size.height)
-      .background(Capsule().fill(self.palette(self.variant.backgroundToken)))
-      .clipShape(Capsule())
+      if let label = self.label, !label.isEmpty {
+        Text(label)
+          .applyBezierFontStyle(
+            self.size.typography,
+            semanticColorToken: self.variant.foregroundToken
+          )
+          .padding(.horizontal, self.size.textHorizontalPadding)
+          .fixedSize(horizontal: true, vertical: false)
+      }
     }
+    .padding(.horizontal, self.size.horizontalPadding)
+    .frame(minHeight: self.size.height, maxHeight: self.size.height)
+    .background(Capsule().fill(self.palette(self.variant.backgroundToken)))
+    .clipShape(Capsule())
   }
 
   private func iconView(_ image: Image) -> some View {
@@ -63,25 +56,6 @@ public struct SUBezierBadge: View, Themeable {
   }
 }
 
-extension View {
-  public func bezierBadge(
-    _ shape: BezierBadgeShape,
-    size: BezierBadgeSize = .small,
-    variant: BezierBadgeVariant = .default,
-    leadingIcon: Image? = nil,
-    alignment: Alignment = .topTrailing
-  ) -> some View {
-    self.overlay(alignment: alignment) {
-      SUBezierBadge(
-        size: size,
-        variant: variant,
-        shape: shape,
-        leadingIcon: leadingIcon
-      )
-    }
-  }
-}
-
 struct SUBezierBadge_Previews: PreviewProvider {
   static var previews: some View {
     ScrollView {
@@ -91,34 +65,8 @@ struct SUBezierBadge_Previews: PreviewProvider {
             Text(size.rawValue)
               .font(.caption.weight(.semibold))
               .foregroundColor(.secondary)
-            VariantRow(size: size, shape: .text("Badge"))
-            VariantRow(size: size, shape: .text("Badge"), leadingIcon: Image(systemName: "plus"))
-            VariantRow(size: size, shape: .numeric(7))
-            VariantRow(size: size, shape: .numeric(150))
-            VariantRow(size: size, shape: .dot)
-          }
-        }
-
-        VStack(alignment: .leading, spacing: 8) {
-          Text("Overlay modifier")
-            .font(.caption.weight(.semibold))
-            .foregroundColor(.secondary)
-          HStack(spacing: 24) {
-            Image(systemName: "bell.fill")
-              .resizable()
-              .scaledToFit()
-              .frame(width: 40, height: 40)
-              .bezierBadge(.numeric(7), size: .small, variant: .red)
-            Image(systemName: "envelope.fill")
-              .resizable()
-              .scaledToFit()
-              .frame(width: 40, height: 40)
-              .bezierBadge(.dot, size: .small, variant: .red, alignment: .topTrailing)
-            Image(systemName: "person.crop.circle")
-              .resizable()
-              .scaledToFit()
-              .frame(width: 40, height: 40)
-              .bezierBadge(.text("NEW"), size: .xsmall, variant: .blue, alignment: .bottomTrailing)
+            VariantRow(size: size)
+            VariantRow(size: size, leadingIcon: Image(systemName: "plus"))
           }
         }
       }
@@ -128,14 +76,13 @@ struct SUBezierBadge_Previews: PreviewProvider {
 
   private struct VariantRow: View {
     let size: BezierBadgeSize
-    let shape: BezierBadgeShape
     var leadingIcon: Image? = nil
 
     var body: some View {
       ScrollView(.horizontal, showsIndicators: false) {
         HStack(spacing: 8) {
           ForEach(BezierBadgeVariant.allCases, id: \.self) { variant in
-            SUBezierBadge(size: size, variant: variant, shape: shape, leadingIcon: leadingIcon)
+            SUBezierBadge(size: size, variant: variant, label: "Badge", leadingIcon: leadingIcon)
           }
         }
       }

--- a/Sources/BezierSwift/MasterComponent/BezierBadge/SUBezierBadge.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBadge/SUBezierBadge.swift
@@ -35,7 +35,7 @@ public struct SUBezierBadge: View, Themeable {
         if let leadingIcon = self.leadingIcon {
           self.iconView(leadingIcon)
         }
-        if let text = self.shape.displayText {
+        if let text = self.shape.displayText, !text.isEmpty {
           Text(text)
             .applyBezierFontStyle(
               self.size.typography,

--- a/Sources/BezierSwift/MasterComponent/BezierBadge/SUBezierBadge.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBadge/SUBezierBadge.swift
@@ -1,0 +1,144 @@
+//
+//  SUBezierBadge.swift
+//  BezierSwift
+//
+
+import SwiftUI
+
+public struct SUBezierBadge: View, Themeable {
+  private let size: BezierBadgeSize
+  private let variant: BezierBadgeVariant
+  private let shape: BezierBadgeShape
+  private let leadingIcon: Image?
+
+  @Environment(\.colorScheme) public var colorScheme
+
+  public init(
+    size: BezierBadgeSize = .small,
+    variant: BezierBadgeVariant = .default,
+    shape: BezierBadgeShape,
+    leadingIcon: Image? = nil
+  ) {
+    self.size = size
+    self.variant = variant
+    self.shape = shape
+    self.leadingIcon = leadingIcon
+  }
+
+  public var body: some View {
+    if self.shape.isDot {
+      Circle()
+        .fill(self.palette(self.variant.backgroundToken))
+        .frame(width: self.size.dotLength, height: self.size.dotLength)
+    } else {
+      HStack(spacing: 0) {
+        if let leadingIcon = self.leadingIcon {
+          self.iconView(leadingIcon)
+        }
+        if let text = self.shape.displayText {
+          Text(text)
+            .applyBezierFontStyle(
+              self.size.typography,
+              semanticColorToken: self.variant.foregroundToken
+            )
+            .padding(.horizontal, self.size.textHorizontalPadding)
+            .fixedSize(horizontal: true, vertical: false)
+        }
+      }
+      .padding(.horizontal, self.size.horizontalPadding)
+      .frame(minHeight: self.size.height, maxHeight: self.size.height)
+      .frame(minWidth: self.size.height)
+      .background(Capsule().fill(self.palette(self.variant.backgroundToken)))
+      .clipShape(Capsule())
+    }
+  }
+
+  private func iconView(_ image: Image) -> some View {
+    image
+      .renderingMode(.template)
+      .resizable()
+      .scaledToFit()
+      .frame(width: self.size.iconLength, height: self.size.iconLength)
+      .foregroundColor(self.palette(self.variant.foregroundToken))
+  }
+}
+
+extension View {
+  public func bezierBadge(
+    _ shape: BezierBadgeShape,
+    size: BezierBadgeSize = .small,
+    variant: BezierBadgeVariant = .default,
+    leadingIcon: Image? = nil,
+    alignment: Alignment = .topTrailing
+  ) -> some View {
+    self.overlay(alignment: alignment) {
+      SUBezierBadge(
+        size: size,
+        variant: variant,
+        shape: shape,
+        leadingIcon: leadingIcon
+      )
+    }
+  }
+}
+
+struct SUBezierBadge_Previews: PreviewProvider {
+  static var previews: some View {
+    ScrollView {
+      VStack(alignment: .leading, spacing: 20) {
+        ForEach(BezierBadgeSize.allCases, id: \.self) { size in
+          VStack(alignment: .leading, spacing: 8) {
+            Text(size.rawValue)
+              .font(.caption.weight(.semibold))
+              .foregroundColor(.secondary)
+            VariantRow(size: size, shape: .text("Badge"))
+            VariantRow(size: size, shape: .text("Badge"), leadingIcon: Image(systemName: "plus"))
+            VariantRow(size: size, shape: .numeric(7))
+            VariantRow(size: size, shape: .numeric(150))
+            VariantRow(size: size, shape: .dot)
+          }
+        }
+
+        VStack(alignment: .leading, spacing: 8) {
+          Text("Overlay modifier")
+            .font(.caption.weight(.semibold))
+            .foregroundColor(.secondary)
+          HStack(spacing: 24) {
+            Image(systemName: "bell.fill")
+              .resizable()
+              .scaledToFit()
+              .frame(width: 40, height: 40)
+              .bezierBadge(.numeric(7), size: .small, variant: .red)
+            Image(systemName: "envelope.fill")
+              .resizable()
+              .scaledToFit()
+              .frame(width: 40, height: 40)
+              .bezierBadge(.dot, size: .small, variant: .red, alignment: .topTrailing)
+            Image(systemName: "person.crop.circle")
+              .resizable()
+              .scaledToFit()
+              .frame(width: 40, height: 40)
+              .bezierBadge(.text("NEW"), size: .xsmall, variant: .blue, alignment: .bottomTrailing)
+          }
+        }
+      }
+      .padding()
+    }
+  }
+
+  private struct VariantRow: View {
+    let size: BezierBadgeSize
+    let shape: BezierBadgeShape
+    var leadingIcon: Image? = nil
+
+    var body: some View {
+      ScrollView(.horizontal, showsIndicators: false) {
+        HStack(spacing: 8) {
+          ForEach(BezierBadgeVariant.allCases, id: \.self) { variant in
+            SUBezierBadge(size: size, variant: variant, shape: shape, leadingIcon: leadingIcon)
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- **V3 BezierBadge SwiftUI/UIKit 컴포넌트 신규 추가** — Capsule 형태의 인라인 레이블. size 4단계 × color 14가지 = 56 variant.
- **Figma SSOT 정합 보장** — `SPEC.md` 도입 후 Properties / Layout / Color / Typography 매트릭스를 Figma 컴포넌트(node `1729:170`)와 1:1 매핑. SSOT 외부 기능은 public API에 노출하지 않음.
- **Examples 카탈로그 + 인터랙티브 테스트 화면** — UIKit / SwiftUI 두 패러다임에서 size/variant/label/leading icon 4축 조작 가능.

## Figma

- 컴포넌트: https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/?node-id=1729-170 (node `1729:170`)
- 디자이너 설명: 목록·카드 UI에서 항목의 상태나 속성을 색상과 텍스트로 즉각 전달하는 인라인 레이블. **Badge는 항상 읽기 전용** (사용자가 제거할 수 있으면 Tag 사용).

## Public API

```swift
// UIKit
public init(size: BezierBadgeSize = .small, variant: BezierBadgeVariant = .default)
public var label: String?      // 콘텐츠 — placeholder default 없음
public var leadingIcon: UIImage?

// SwiftUI
public init(
  size: BezierBadgeSize = .small,
  variant: BezierBadgeVariant = .default,
  label: String? = nil,
  leadingIcon: Image? = nil
)
```

- 스타일 variant(`size`, `variant`)는 default 보유 — `BezierButton`과 동일 패턴
- 콘텐츠(`label`)는 `String?` Optional, default 없음. Figma의 `label = \"Badge\"` placeholder를 API default로 채택하지 않음
- SSOT에 존재하지 않는 dot / numeric badge 변형, overlay modifier 등은 의도적으로 제공하지 않음 (notification badge가 필요하면 별도 컴포넌트로 분리)

## 사용 토큰

### Color (Variant → background / foreground)

| Variant | background | foreground |
|---|---|---|
| `default` | `fillNeutralLight` | `textNeutral` |
| `monochromeLight` | `fillNeutralLight` | `textNeutralLighter` |
| `monochromeDark` | `fillNeutralHeavier` | `textAbsoluteWhite` |
| `blue` / `cobalt` / `teal` / `green` / `olive` / `pink` / `navy` / `yellow` / `orange` / `red` / `purple` | `fillAccent{Color}Heavy` | `textAccent{Color}` |

### Typography (TYPO-MIGRATION 진행 중 잠정 매핑)

Figma component description의 `📌 TYPO-MIGRATION: Text Style 미적용 — 로컬 타이포 스타일 등록 시 일괄 바인딩 예정` 상태를 반영하여, 현재는 `BTSemanticToken`을 우회하고 Figma raw font metrics를 직접 사용. medium/large는 token(.textLarge/.textXLarge)의 lineHeight가 raw와 다르므로 token 우회가 필요했고, 일관성 차원에서 모든 size에 동일 정책. 디자인팀의 일괄 바인딩 완료 후 token 통합 예정 (`BezierBadgeSpec.swift` 주석 + `SPEC.md` §7 참고).

| Size | Figma raw (FS/LH/LS) | 가장 가까운 token (참고용) |
|---|---|---|
| xsmall | 12 / 16 / 0 | `.textXSmall(.regular)` ✅ |
| small | 14 / 18 / 0 | `.textMedium(.regular)` ✅ |
| medium | 15 / 18 / 0 | `.textLarge(.regular)` ⚠️ LH/LS 차이 |
| large | 16 / 20 / -0.1 | `.textXLarge(.regular)` ⚠️ LH 차이 |

## SPEC

`Sources/BezierSwift/MasterComponent/BezierBadge/SPEC.md` 신규 도입 — Figma SSOT의 거울로 작성. 코드/협의를 SPEC 영역에 끌어들이지 않는 원칙으로 검증.

5개 specialized agent (Properties / Layout / Color / Noise / Implementation Reference) 병렬 검증을 거쳤고, 이후 UIKit / SwiftUI 두 Implementation Validator가 SPEC ↔ 구현 정합을 ✅ 확인.

## Test plan

- [x] `BezierSwift` 모듈 빌드 통과 (iOS Simulator)
- [x] `UIKitExample` 빌드 통과 + Badge 테스트 화면 동작 확인 (Catalog 56 variant 렌더)
- [x] `SwiftUIExample` 빌드 통과 + Badge 테스트 화면 동작 확인
- [x] Figma node `1729:170` 인스턴스 56개 (4 size × 14 color) 매트릭스 비교
- [ ] 디자인 리뷰: Figma 디자인과 일치 여부 확인 권장
- [ ] (선택) ch-desk-ios 등 외부 사용처에서 동작 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Badge 컴포넌트 추가 (UIKit 및 SwiftUI): 크기(size), 변형(variant), 선택적 라벨 및 선행 아이콘 지원, 공용 초기화 제공.

* **New UI Examples**
  * 앱 목록에 "Badge" 항목 추가 및 UIKit/SwiftUI 데모 화면 추가 — 프리뷰, 카탈로그, 크기/변형/라벨/아이콘 인터랙티브 컨트롤 포함.

* **Documentation**
  * Badge 디자인·사용 사양 문서(SPEC) 추가.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/channel-io/BezierSwift/pull/120?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->