### PR TITLE
[MOB-4914] BezierButton Figma SSOT 정렬 (Spec/Resizing/Spinner/Typography)

### DIFF
--- a/Examples/SwiftUIExample/SwiftUIExample/TestViews/BezierButtonTestView.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/TestViews/BezierButtonTestView.swift
@@ -10,7 +10,6 @@ struct BezierButtonTestView: View {
   @State private var size: BezierButtonSize = .medium
   @State private var variant: BezierButtonVariant = .filled
   @State private var semantic: BezierButtonSemantic = .primary
-  @State private var resizing: BezierButtonResizing = .hug
   @State private var title: String = "Label"
   @State private var hasLeadingIcon: Bool = false
   @State private var hasTrailingIcon: Bool = false
@@ -26,7 +25,6 @@ struct BezierButtonTestView: View {
             size: self.size,
             variant: self.variant,
             semantic: self.semantic,
-            resizing: self.resizing,
             title: self.title.isEmpty ? nil : self.title,
             leadingIcon: self.hasLeadingIcon ? Image(systemName: "star.fill") : nil,
             trailingIcon: self.hasTrailingIcon ? Image(systemName: "arrow.right") : nil,
@@ -65,15 +63,6 @@ struct BezierButtonTestView: View {
         Picker("Semantic", selection: self.$semantic) {
           ForEach(BezierButtonSemantic.allCases, id: \.self) { semantic in
             Text(semantic.rawValue).tag(semantic)
-          }
-        }
-        .pickerStyle(.segmented)
-      }
-
-      Section("Resizing") {
-        Picker("Resizing", selection: self.$resizing) {
-          ForEach(BezierButtonResizing.allCases, id: \.self) { resizing in
-            Text(resizing.rawValue).tag(resizing)
           }
         }
         .pickerStyle(.segmented)

--- a/Examples/UIKitExample/UIKitExample/BezierButtonTestViewController.swift
+++ b/Examples/UIKitExample/UIKitExample/BezierButtonTestViewController.swift
@@ -12,7 +12,6 @@ final class BezierButtonTestViewController: BaseViewController {
   private var size: BezierButtonSize = .medium
   private var variant: BezierButtonVariant = .filled
   private var semantic: BezierButtonSemantic = .primary
-  private var resizing: BezierButtonResizing = .hug
   private var titleText: String = "Label"
   private var hasLeadingIcon: Bool = false
   private var hasTrailingIcon: Bool = false
@@ -51,8 +50,7 @@ final class BezierButtonTestViewController: BaseViewController {
     let button = BezierButton(
       size: self.size,
       variant: self.variant,
-      semantic: self.semantic,
-      resizing: self.resizing
+      semantic: self.semantic
     )
     button.title = self.titleText
     button.addTarget(self, action: #selector(self.onPreviewTapped), for: .touchUpInside)
@@ -86,13 +84,6 @@ final class BezierButtonTestViewController: BaseViewController {
     let control = UISegmentedControl(items: BezierButtonSemantic.allCases.map { $0.rawValue })
     control.selectedSegmentIndex = BezierButtonSemantic.allCases.firstIndex(of: self.semantic) ?? 0
     control.addTarget(self, action: #selector(self.onSemanticChanged(_:)), for: .valueChanged)
-    return control
-  }()
-
-  private lazy var resizingControl: UISegmentedControl = {
-    let control = UISegmentedControl(items: BezierButtonResizing.allCases.map { $0.rawValue })
-    control.selectedSegmentIndex = BezierButtonResizing.allCases.firstIndex(of: self.resizing) ?? 0
-    control.addTarget(self, action: #selector(self.onResizingChanged(_:)), for: .valueChanged)
     return control
   }()
 
@@ -173,8 +164,6 @@ final class BezierButtonTestViewController: BaseViewController {
     self.containerStackView.addArrangedSubview(self.variantControl)
     self.containerStackView.addArrangedSubview(self.makeSectionTitle("Semantic"))
     self.containerStackView.addArrangedSubview(self.semanticControl)
-    self.containerStackView.addArrangedSubview(self.makeSectionTitle("Resizing"))
-    self.containerStackView.addArrangedSubview(self.resizingControl)
     self.containerStackView.addArrangedSubview(self.makeSectionTitle("Title"))
     self.containerStackView.addArrangedSubview(self.titleField)
     self.containerStackView.addArrangedSubview(self.makeRow(label: "Leading Icon", control: self.leadingIconSwitch))
@@ -253,18 +242,11 @@ final class BezierButtonTestViewController: BaseViewController {
     self.previewButton.size = self.size
     self.previewButton.variant = self.variant
     self.previewButton.semantic = self.semantic
-    self.previewButton.resizing = self.resizing
     self.previewButton.title = self.titleText.isEmpty ? nil : self.titleText
     self.previewButton.leadingIcon = self.hasLeadingIcon ? UIImage(systemName: "star.fill") : nil
     self.previewButton.trailingIcon = self.hasTrailingIcon ? UIImage(systemName: "arrow.right") : nil
     self.previewButton.isLoading = self.isLoadingState
     self.previewButton.isEnabled = self.isEnabledState
-
-    if self.resizing == .fill {
-      self.previewButton.setContentHuggingPriority(.defaultLow, for: .horizontal)
-    } else {
-      self.previewButton.setContentHuggingPriority(.defaultHigh, for: .horizontal)
-    }
   }
 
   private func refreshTapCount() {
@@ -290,11 +272,6 @@ final class BezierButtonTestViewController: BaseViewController {
 
   @objc private func onSemanticChanged(_ sender: UISegmentedControl) {
     self.semantic = BezierButtonSemantic.allCases[sender.selectedSegmentIndex]
-    self.refreshPreview()
-  }
-
-  @objc private func onResizingChanged(_ sender: UISegmentedControl) {
-    self.resizing = BezierButtonResizing.allCases[sender.selectedSegmentIndex]
     self.refreshPreview()
   }
 

--- a/Sources/BezierSwift/MasterComponent/BezierButton/BezierButton.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierButton/BezierButton.swift
@@ -27,10 +27,6 @@ public final class BezierButton: UIControl, BezierComponentable {
     didSet { if oldValue != self.semantic { self.refreshAppearance() } }
   }
 
-  public var resizing: BezierButtonResizing = .hug {
-    didSet { if oldValue != self.resizing { self.refreshResizing() } }
-  }
-
   public var title: String? {
     didSet { if oldValue != self.title { self.refreshContent() } }
   }
@@ -97,6 +93,9 @@ public final class BezierButton: UIControl, BezierComponentable {
     return indicator
   }()
 
+  // UIActivityIndicatorView(style: .medium) base size
+  private let activityIndicatorBaseLength: CGFloat = 20
+
   // MARK: - Layout Constraints (mutable)
 
   private var heightConstraint: NSLayoutConstraint?
@@ -111,13 +110,11 @@ public final class BezierButton: UIControl, BezierComponentable {
   public init(
     size: BezierButtonSize = .medium,
     variant: BezierButtonVariant = .filled,
-    semantic: BezierButtonSemantic = .primary,
-    resizing: BezierButtonResizing = .hug
+    semantic: BezierButtonSemantic = .primary
   ) {
     self.size = size
     self.variant = variant
     self.semantic = semantic
-    self.resizing = resizing
     super.init(frame: .zero)
     self.setUp()
   }
@@ -178,10 +175,12 @@ public final class BezierButton: UIControl, BezierComponentable {
     self.trailingImageWidthConstraint = trailingImageWidthConstraint
     self.trailingImageHeightConstraint = trailingImageHeightConstraint
 
+    self.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+    self.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+
     self.refreshLayout()
     self.refreshContent()
     self.refreshAppearance()
-    self.refreshResizing()
     self.refreshLoading()
     self.refreshEnabled()
   }
@@ -246,10 +245,14 @@ public final class BezierButton: UIControl, BezierComponentable {
     self.trailingImageView.tintColor = foregroundColor
 
     if let title = self.title, !title.isEmpty {
-      self.titleLabel.attributedText = self.size.typography.attributedString(
-        self,
-        text: title,
-        semanticColorToken: foregroundToken,
+      self.titleLabel.attributedText = title.applyBezierFont(
+        height: self.size.lineHeight,
+        font: BTGlobalToken.FontFamily.system.uiFont(
+          size: self.size.fontSize,
+          weight: self.size.fontWeight
+        ),
+        color: foregroundColor,
+        letterSpacing: 0,
         alignment: .center
       )
       self.titleLabel.isHidden = false
@@ -280,17 +283,6 @@ public final class BezierButton: UIControl, BezierComponentable {
     self.activityIndicator.color = foregroundColor
 
     self.refreshContent()
-  }
-
-  private func refreshResizing() {
-    switch self.resizing {
-    case .hug:
-      self.setContentHuggingPriority(.defaultHigh, for: .horizontal)
-      self.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
-    case .fill:
-      self.setContentHuggingPriority(.defaultLow, for: .horizontal)
-      self.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-    }
   }
 
   private func refreshLoading() {
@@ -326,10 +318,7 @@ public final class BezierButton: UIControl, BezierComponentable {
   // MARK: - Helpers
 
   private var activityIndicatorScale: CGFloat {
-    switch self.size {
-    case .xsmall, .small: return 0.6
-    case .medium, .large, .xlarge: return 0.8
-    }
+    self.size.spinnerLength / self.activityIndicatorBaseLength
   }
 }
 

--- a/Sources/BezierSwift/MasterComponent/BezierButton/BezierButtonSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierButton/BezierButtonSpec.swift
@@ -58,15 +58,34 @@ public enum BezierButtonSize: String, CaseIterable {
 
   public var iconLength: CGFloat { 16 }
 
-  public var typography: BTSemanticToken {
+  public var spinnerLength: CGFloat {
     switch self {
-    case .xsmall: return .labelMedium
-    case .small:  return .labelLarge
-    case .medium: return .headingXXSmall
-    case .large:  return .headingXSmall
-    case .xlarge: return .headingXSmall
+    case .xsmall: return 12
+    case .small:  return 14
+    case .medium: return 16
+    case .large:  return 18
+    case .xlarge: return 18
     }
   }
+
+  public var fontSize: CGFloat {
+    switch self {
+    case .xsmall: return 13
+    case .small:  return 14
+    case .medium: return 15
+    case .large, .xlarge: return 16
+    }
+  }
+
+  public var lineHeight: CGFloat {
+    switch self {
+    case .xsmall, .small: return 18
+    case .medium, .large, .xlarge: return 20
+    }
+  }
+
+  // Figma SemiBold(600) → iOS BTFontWeight binary system(`bold`) 매핑 (디자인 시스템 합의)
+  public var fontWeight: BTFontWeight { .bold }
 }
 
 public enum BezierButtonVariant: String, CaseIterable {
@@ -79,11 +98,6 @@ public enum BezierButtonSemantic: String, CaseIterable {
   case primary
   case secondary
   case destructive
-}
-
-public enum BezierButtonResizing: String, CaseIterable {
-  case hug
-  case fill
 }
 
 enum BezierButtonConstant {

--- a/Sources/BezierSwift/MasterComponent/BezierButton/SPEC.md
+++ b/Sources/BezierSwift/MasterComponent/BezierButton/SPEC.md
@@ -1,0 +1,123 @@
+# BezierButton SPEC
+
+> **SSOT**: [Figma · Mobile-Components / Button (1734:146)](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=1734-146)
+>
+> 이 문서는 Figma 디자인의 단일 진실 공급원(SSOT)을 코드 관점에서 정리한 것이다. 모든 수치/토큰은 Figma에 실재해야 한다.
+
+## 1. Component Overview
+
+- **이름**: Button
+- **설명**: 클릭·제출 등 단일 액션을 트리거하는 인터랙션 컴포넌트.
+- **가이드라인**:
+  - `semantic = primary` 버튼은 한 화면에 1개만 둔다.
+  - 아이콘 전용 버튼은 IconButton(별도 컴포넌트)을 사용한다.
+
+## 2. Component Properties (Figma variant 축)
+
+| 축 | 값 | 비고 |
+|---|---|---|
+| `size` | `xsmall`, `small`, `medium`, `large`, `xlarge` | 5 옵션 |
+| `variant` | `filled`, `outlined`, `ghost` | 3 옵션 |
+| `semantic` | `primary`, `secondary`, `destructive` | 3 옵션 |
+| `state` | `default`, `pressed`, `active`, `disabled`, `loading` | **Figma 설계용 축** — 시각 검토 목적, 런타임 API로 노출하지 않는다. |
+
+Figma 매트릭스 총량: 5 × 3 × 3 × 5 = **225 symbols** (전부 실재).
+
+### 2-1. State 축의 해석
+
+Figma 컴포넌트 설명에 명시:
+> "state 축: Figma 설계용 — disabled/loading/pressed 상태별 시각 확인에 사용"
+
+따라서 코드는 다음 런타임 상태만 노출한다:
+
+| 코드 상태 | Figma state 매핑 |
+|---|---|
+| `isEnabled = true`, 정상 | `default` |
+| `isHighlighted = true` (터치 중) | `pressed` |
+| `isEnabled = false` | `disabled` |
+| `isLoading = true` | `loading` |
+| (없음) | `active` — 토글/선택 상태를 위한 설계용. Button 컴포넌트는 sticky-toggled 상태를 노출하지 않는다. |
+
+## 3. Layout (size별)
+
+> Figma 좌표/크기 (변하지 않는 cell-level 수치). 모든 size에서 `border-radius: 9999px` (= 완전 capsule, 높이의 절반).
+
+| size | height | minWidth | horizontalPadding (px) | textHorizontalPadding (text px) | contentSpacing (gap) | iconLength |
+|---|---|---|---|---|---|---|
+| xsmall | 24 | 20 | 4 | 3 | 0 (no gap) | 16 |
+| small | 30 | 24 | 6 | 3 | 0 (no gap) | 16 |
+| medium | 40 | 36 | 10 | 4 | 2 | 16 |
+| large | 44 | 44 | 12 | 4 | 2 | 16 |
+| xlarge | 54 | 54 | 20 | 4 | 2 | 16 |
+
+- **border-radius**: 모든 size에서 height의 절반 (완전 capsule).
+- **icon**: leadingIcon / trailingIcon은 텍스트 좌우에 배치, 16×16 고정.
+
+## 4. Typography (size별, Custom)
+
+> **Typography 적용 방식: Custom (Token 미적용)**.
+> Figma Button 텍스트 노드는 Foundation의 typography token(`Typography/heading/*` text style 또는 `heading/size/*` / `heading/line-height/*` variable)에 연결되어 있지 않다. 5개 size 모두 `get_variable_defs` 결과가 `label/font-family` (= `"Inter"`) + `label/letter-spacing` (= `0`)만 노출하며, font-size 와 line-height 는 raw 값으로 직접 적용되어 있다.
+>
+> **Custom 사유**: Figma Mobile Components Button(`1734:146`)이 typography token 매핑을 보유하고 있지 않은 상태. (디자이너 의도 — 디자인 시스템 typography token 매핑은 별도 진행 예정으로 추정되며, 현 시점 Button 의 SSOT 는 raw 값 자체.)
+
+공통값 (5 size 동일):
+- `font-family`: `Inter` (variable: `label/font-family`)
+- `font-weight`: `SemiBold` (600)
+- `letter-spacing`: `0` (variable: `label/letter-spacing`)
+
+size 별 raw 값:
+
+| size | fontSize | lineHeight |
+|---|---|---|
+| xsmall | 13 | 18 |
+| small | 14 | 18 |
+| medium | 15 | 20 |
+| large | 16 | 20 |
+| xlarge | 16 | 20 |
+
+> ⚠️ iOS BezierSwift V3 Typography는 regular/bold 이진 weight 시스템(`BTFontWeight`)을 사용한다. Figma SemiBold(600)는 iOS에서 `bold`로 매핑된다 (디자인 시스템 합의 사항).
+
+## 5. Color (variant × semantic × variant 별, default state)
+
+> 키는 Figma variable 경로. 괄호 안은 raw 값.
+
+| variant × semantic | background | text/icon | border |
+|---|---|---|---|
+| `filled` × `primary` | `color/fill/neutral/heaviest` (`#000000d9`) | `color/text/inverse` (`#ffffff`) | — |
+| `filled` × `secondary` | `color/fill/neutral/light` (`#0000000d`) | `color/text/neutral` (`#000000d9`) | — |
+| `filled` × `destructive` | `color/fill/accent/red/heavier` (`#e1535d`) | `color/text/inverse` (`#ffffff`) | — |
+| `outlined` × `primary` | — | `color/text/neutral/heaviest` (`#000000`) | `color/border/neutral` (`#00000014`) |
+| `outlined` × `secondary` | — | `color/text/neutral/light` (`#00000099`) | `color/border/neutral` (`#00000014`) |
+| `outlined` × `destructive` | — | `color/text/accent/red` (`#e1535d`) | `color/border/neutral` (`#00000014`) |
+| `ghost` × `primary` | — | `color/text/neutral/light` (`#00000099`) | — |
+| `ghost` × `secondary` | — | `color/text/neutral/lighter` (`#00000066`) | — |
+| `ghost` × `destructive` | — | `color/text/accent/red` (`#e1535d`) | — |
+
+- **border-width**: outlined 1px (모든 size 공통).
+- **outlined / ghost** variant는 background fill 없음 (clear).
+
+## 6. State 별 시각 동작
+
+> `pressed` / `active` 시각은 Figma SSOT에 별도 컬러 토큰이 없고 opacity 기반으로 표현된다.
+
+| state | 시각 처리 |
+|---|---|
+| `default` | 위 §5 색상 그대로 |
+| `pressed` | 본체 opacity를 낮춤 (터치 중에만 일시적) |
+| `active` | 코드 미노출 (Button은 토글 상태를 가지지 않음) |
+| `disabled` | 본체 전체 `opacity: 0.4` (Figma `opacity-40` 일치) |
+| `loading` | 라벨/아이콘 숨김 + 가운데 ActivityIndicator 표시. 사용자 입력 무시 |
+
+## 7. Loading Spinner Size (size별)
+
+> Figma `ActivityIndicator` 노드 크기.
+
+| size | spinner size |
+|---|---|
+| xsmall | 12 |
+| small | 14 |
+| medium | 16 |
+| large | 18 |
+| xlarge | 18 |
+
+스피너 색은 해당 variant × semantic의 foreground (`text/icon`) 컬러와 동일.

--- a/Sources/BezierSwift/MasterComponent/BezierButton/SUBezierButton.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierButton/SUBezierButton.swift
@@ -9,7 +9,6 @@ public struct SUBezierButton: View, Themeable {
   private let size: BezierButtonSize
   private let variant: BezierButtonVariant
   private let semantic: BezierButtonSemantic
-  private let resizing: BezierButtonResizing
   private let title: String?
   private let leadingIcon: Image?
   private let trailingIcon: Image?
@@ -23,7 +22,6 @@ public struct SUBezierButton: View, Themeable {
     size: BezierButtonSize,
     variant: BezierButtonVariant,
     semantic: BezierButtonSemantic,
-    resizing: BezierButtonResizing = .hug,
     title: String? = nil,
     leadingIcon: Image? = nil,
     trailingIcon: Image? = nil,
@@ -33,7 +31,6 @@ public struct SUBezierButton: View, Themeable {
     self.size = size
     self.variant = variant
     self.semantic = semantic
-    self.resizing = resizing
     self.title = title
     self.leadingIcon = leadingIcon
     self.trailingIcon = trailingIcon
@@ -53,11 +50,11 @@ public struct SUBezierButton: View, Themeable {
       }
       .padding(.horizontal, self.size.horizontalPadding)
       .frame(
-        minWidth: self.resizing == .fill ? nil : self.size.minWidth,
-        maxWidth: self.resizing == .fill ? .infinity : nil,
+        minWidth: self.size.minWidth,
         minHeight: self.size.height,
         maxHeight: self.size.height
       )
+      .fixedSize(horizontal: true, vertical: false)
     }
     .buttonStyle(
       SUBezierButtonStyle(
@@ -77,11 +74,22 @@ public struct SUBezierButton: View, Themeable {
       }
 
       if let title = self.title, !title.isEmpty {
+        let uiFont = BTGlobalToken.FontFamily.system.uiFont(
+          size: self.size.fontSize,
+          weight: self.size.fontWeight
+        )
+        let lineSpacing = max(0, self.size.lineHeight - uiFont.lineHeight)
+
         Text(title)
-          .applyBezierFontStyle(
-            self.size.typography,
-            semanticColorToken: self.variant.foregroundToken(self.semantic)
+          .font(
+            BTGlobalToken.FontFamily.system.font(
+              size: self.size.fontSize,
+              weight: self.size.fontWeight
+            )
           )
+          .lineSpacing(lineSpacing)
+          .padding(.vertical, lineSpacing / 2)
+          .foregroundColor(self.palette(self.variant.foregroundToken(self.semantic)))
           .padding(.horizontal, self.size.textHorizontalPadding)
           .fixedSize(horizontal: true, vertical: false)
       }
@@ -105,15 +113,11 @@ public struct SUBezierButton: View, Themeable {
     ProgressView()
       .progressViewStyle(.circular)
       .tint(self.palette(self.variant.foregroundToken(self.semantic)))
-      .scaleEffect(self.loadingScale)
+      .scaleEffect(self.size.spinnerLength / Self.progressViewBaseLength)
   }
 
-  private var loadingScale: CGFloat {
-    switch self.size {
-    case .xsmall, .small: return 0.6
-    case .medium, .large, .xlarge: return 0.8
-    }
-  }
+  // ProgressView().progressViewStyle(.circular) base size on iOS
+  private static let progressViewBaseLength: CGFloat = 20
 }
 
 private struct SUBezierButtonStyle: ButtonStyle, Themeable {
@@ -160,7 +164,7 @@ struct SUBezierButton_Previews: PreviewProvider {
       SUBezierButton(size: .small, variant: .outlined, semantic: .secondary, title: "Label") {}
       SUBezierButton(size: .medium, variant: .ghost, semantic: .destructive, title: "Label") {}
       SUBezierButton(size: .large, variant: .filled, semantic: .destructive, title: "Confirm", leadingIcon: Image(systemName: "trash")) {}
-      SUBezierButton(size: .xlarge, variant: .filled, semantic: .primary, resizing: .fill, title: "Continue", trailingIcon: Image(systemName: "arrow.right")) {}
+      SUBezierButton(size: .xlarge, variant: .filled, semantic: .primary, title: "Continue", trailingIcon: Image(systemName: "arrow.right")) {}
       SUBezierButton(size: .medium, variant: .filled, semantic: .primary, title: "Loading", isLoading: true) {}
     }
     .padding()


### PR DESCRIPTION
## Summary

`figma-component-spec` 사이클로 V3 BezierButton(#119)을 Figma SSOT(`1734:146`)와 1:1 정합 검증한 결과 발견된 3건의 불일치를 정리합니다.

- **`BezierButtonResizing` 제거** — Figma component property에 부재. V1 LegacyBezierButton의 init parameter를 무비판적으로 승계한 코드 전용 옵션.
- **Loading Spinner 5-size 정확화** — 기존 2-bucket scale(0.6/0.8) → `BezierButtonSize.spinnerLength`(12/14/16/18/18).
- **Typography raw 값 직접 적용** — Figma Button 텍스트 노드가 Foundation typography token(`Typography/heading/*`, `heading/size/*`)에 미연결인 SSOT 실태와 코드를 일치. large/xlarge lineHeight 24→20.

신규 산출물: `Sources/BezierSwift/MasterComponent/BezierButton/SPEC.md` (Figma SSOT 문서화 — figma-component-spec Phase 1 산출물).

## 검증 (`figma-component-spec` v6 — 6+2 subagents 병렬)

| Phase | Validator | 결과 |
|---|---|---|
| 2 | Component Properties | ✅ 4축 × 225 매트릭스 |
| 2 | Layout | ✅ 35/35 cells |
| 2 | Color | ✅ 27 mapping + 4 negative |
| 2 | Typography | ✅ Custom 분류 + 사유 적정 |
| 2 | Spec Noise Detector | ✅ 노이즈 0건 |
| 2 | Implementation Reference | ✅ 정/역 매핑 + 잔존 0건 |
| 3 | UIKit Impl Validator | ✅ 87/87 |
| 3 | SwiftUI Impl Validator | ✅ 87/87 |

## Test plan

- [ ] BezierSwift / UIKitExample / SwiftUIExample 3 scheme BUILD SUCCEEDED (iPhone 16 / iOS 18.6)
- [ ] UIKitExample.BezierButtonTestViewController 카탈로그 — 5 size × 3 variant × 3 semantic 시각 확인, Resizing 컨트롤 제거 후 단일 hug 동작만 확인
- [ ] SwiftUIExample.BezierButtonTestView 카탈로그 — 동일 매트릭스 확인 + isLoading 토글 시 5 size별 spinner 크기 12/14/16/18/18 시각 확인
- [ ] large/xlarge 텍스트 라인 박스가 height 안에 정상 centered (lineHeight 20 적용 후)

## 참고

- Linear: [MOB-4914](https://linear.app/channel/issue/MOB-4914)
- Figma SSOT: [Mobile-Components / Button (1734:146)](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=1734-146)
- 선행 PR: #119 ([MOB-4876] V3 BezierButton 추가)
- SPEC.md: `Sources/BezierSwift/MasterComponent/BezierButton/SPEC.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 버튼의 Resizing 기능이 제거되었으며, 크기 조정 로직이 단순화되었습니다.
  * 로딩 표시기 스케일 계산 방식이 개선되었습니다.
  * 버튼 타이틀 렌더링 방식이 개선되었습니다.

* **Documentation**
  * 버튼 컴포넌트 사양 문서가 추가되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/channel-io/BezierSwift/pull/122?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->