### PR TITLE
[MOB-4879] V3 BezierTag 추가 (SwiftUI/UIKit) + Figma SSOT 정합

### DIFF
--- a/Examples/SwiftUIExample/SwiftUIExample.xcodeproj/project.pbxproj
+++ b/Examples/SwiftUIExample/SwiftUIExample.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		BB48760B2B11FE0100000001 /* BezierButtonTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB48760A2B11FE0100000001 /* BezierButtonTestView.swift */; };
 		BB48760D2B11FE0100000002 /* BezierIconButtonTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB48760C2B11FE0100000002 /* BezierIconButtonTestView.swift */; };
 		BB48760D2B11FE0100000003 /* BezierBadgeTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB48760C2B11FE0100000003 /* BezierBadgeTestView.swift */; };
+		BB48760D2B11FE0100000004 /* BezierTagTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB48760C2B11FE0100000004 /* BezierTagTestView.swift */; };
 		E2789E4D2A737BC700B98B8D /* BezierElevationTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2789E4C2A737BC700B98B8D /* BezierElevationTestView.swift */; };
 		E28212322A4B32F700018327 /* SwiftUIExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28212312A4B32F700018327 /* SwiftUIExampleApp.swift */; };
 		E28212342A4B32F700018327 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28212332A4B32F700018327 /* ContentView.swift */; };
@@ -26,6 +27,7 @@
 		BB48760A2B11FE0100000001 /* BezierButtonTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierButtonTestView.swift; sourceTree = "<group>"; };
 		BB48760C2B11FE0100000002 /* BezierIconButtonTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierIconButtonTestView.swift; sourceTree = "<group>"; };
 		BB48760C2B11FE0100000003 /* BezierBadgeTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierBadgeTestView.swift; sourceTree = "<group>"; };
+		BB48760C2B11FE0100000004 /* BezierTagTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierTagTestView.swift; sourceTree = "<group>"; };
 		E2789E4C2A737BC700B98B8D /* BezierElevationTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierElevationTestView.swift; sourceTree = "<group>"; };
 		E282122E2A4B32F700018327 /* SwiftUIExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftUIExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E28212312A4B32F700018327 /* SwiftUIExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIExampleApp.swift; sourceTree = "<group>"; };
@@ -55,6 +57,7 @@
 				BB48760A2B11FE0100000001 /* BezierButtonTestView.swift */,
 				BB48760C2B11FE0100000002 /* BezierIconButtonTestView.swift */,
 				BB48760C2B11FE0100000003 /* BezierBadgeTestView.swift */,
+				BB48760C2B11FE0100000004 /* BezierTagTestView.swift */,
 			);
 			path = TestViews;
 			sourceTree = "<group>";
@@ -183,6 +186,7 @@
 				BB48760B2B11FE0100000001 /* BezierButtonTestView.swift in Sources */,
 				BB48760D2B11FE0100000002 /* BezierIconButtonTestView.swift in Sources */,
 				BB48760D2B11FE0100000003 /* BezierBadgeTestView.swift in Sources */,
+				BB48760D2B11FE0100000004 /* BezierTagTestView.swift in Sources */,
 				E28212322A4B32F700018327 /* SwiftUIExampleApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Examples/SwiftUIExample/SwiftUIExample/ContentView.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/ContentView.swift
@@ -29,6 +29,9 @@ struct ContentView: View, Themeable {
         NavigationLink("Badge") {
           BezierBadgeTestView()
         }
+        NavigationLink("Tag") {
+          BezierTagTestView()
+        }
         NavigationLink("Elevation Test") {
           BezierElevationTestView()
         }

--- a/Examples/SwiftUIExample/SwiftUIExample/TestViews/BezierTagTestView.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/TestViews/BezierTagTestView.swift
@@ -1,0 +1,102 @@
+//
+//  BezierTagTestView.swift
+//  SwiftUIExample
+//
+
+import SwiftUI
+import BezierSwift
+
+struct BezierTagTestView: View {
+  @State private var size: BezierTagSize = .small
+  @State private var variant: BezierTagVariant = .default
+  @State private var labelText: String = "Tag"
+  @State private var hasOnDelete: Bool = false
+  @State private var deleteCount: Int = 0
+
+  var body: some View {
+    Form {
+      Section("Preview") {
+        SUBezierTag(
+          size: self.size,
+          variant: self.variant,
+          label: self.labelText.isEmpty ? nil : self.labelText,
+          onDelete: self.hasOnDelete ? { self.deleteCount += 1 } : nil
+        )
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 8)
+      }
+
+      Section("Size") {
+        Picker("Size", selection: self.$size) {
+          ForEach(BezierTagSize.allCases, id: \.self) { size in
+            Text(size.rawValue).tag(size)
+          }
+        }
+        .pickerStyle(.segmented)
+      }
+
+      Section("Variant") {
+        Picker("Variant", selection: self.$variant) {
+          ForEach(BezierTagVariant.allCases, id: \.self) { variant in
+            Text(variant.rawValue).tag(variant)
+          }
+        }
+      }
+
+      Section("Label") {
+        TextField("Label", text: self.$labelText)
+      }
+
+      Section("Content") {
+        Toggle("onDelete enabled", isOn: self.$hasOnDelete)
+        if self.hasOnDelete {
+          Text("Delete tapped: \(self.deleteCount) times")
+            .font(.caption)
+            .foregroundColor(.secondary)
+        }
+      }
+
+      Section("Catalog") {
+        ScrollView(.vertical) {
+          VStack(alignment: .leading, spacing: 16) {
+            ForEach(BezierTagSize.allCases, id: \.self) { size in
+              VStack(alignment: .leading, spacing: 8) {
+                Text(size.rawValue)
+                  .font(.caption.weight(.semibold))
+                  .foregroundColor(.secondary)
+                self.row(size: size, hasOnDelete: false)
+                self.row(size: size, hasOnDelete: true)
+              }
+            }
+          }
+          .padding(.vertical, 8)
+        }
+        .frame(height: 400)
+      }
+    }
+    .navigationTitle("Tag (SwiftUI)")
+  }
+
+  private func row(size: BezierTagSize, hasOnDelete: Bool) -> some View {
+    ScrollView(.horizontal, showsIndicators: false) {
+      HStack(spacing: 8) {
+        ForEach(BezierTagVariant.allCases, id: \.self) { variant in
+          SUBezierTag(
+            size: size,
+            variant: variant,
+            label: "Tag",
+            onDelete: hasOnDelete ? {} : nil
+          )
+        }
+      }
+    }
+  }
+}
+
+struct BezierTagTestView_Previews: PreviewProvider {
+  static var previews: some View {
+    NavigationView {
+      BezierTagTestView()
+    }
+  }
+}

--- a/Examples/UIKitExample/UIKitExample.xcodeproj/project.pbxproj
+++ b/Examples/UIKitExample/UIKitExample.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		BB48761A2B11FE0200000002 /* BezierButtonTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB48761B2B11FE0200000002 /* BezierButtonTestViewController.swift */; };
 		BB48761C2B11FE0200000003 /* BezierIconButtonTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB48761D2B11FE0200000003 /* BezierIconButtonTestViewController.swift */; };
 		BB48761C2B11FE0200000004 /* BezierBadgeTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB48761D2B11FE0200000004 /* BezierBadgeTestViewController.swift */; };
+		BB4876202B11FE0200000005 /* BezierTagTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB4876212B11FE0200000005 /* BezierTagTestViewController.swift */; };
 		E28212432A4B3C0900018327 /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28212422A4B3C0900018327 /* BaseViewController.swift */; };
 		A1B2C3E12A737BD700C99C9E /* BezierIconCatalogViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3E02A737BD700C99C9E /* BezierIconCatalogViewController.swift */; };
 		E2C2C3D32A4B2DE700A7E5E6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2C2C3D22A4B2DE700A7E5E6 /* AppDelegate.swift */; };
@@ -24,6 +25,7 @@
 		BB48761B2B11FE0200000002 /* BezierButtonTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierButtonTestViewController.swift; sourceTree = "<group>"; };
 		BB48761D2B11FE0200000003 /* BezierIconButtonTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierIconButtonTestViewController.swift; sourceTree = "<group>"; };
 		BB48761D2B11FE0200000004 /* BezierBadgeTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierBadgeTestViewController.swift; sourceTree = "<group>"; };
+		BB4876212B11FE0200000005 /* BezierTagTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierTagTestViewController.swift; sourceTree = "<group>"; };
 		E28212422A4B3C0900018327 /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
 		A1B2C3E02A737BD700C99C9E /* BezierIconCatalogViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierIconCatalogViewController.swift; sourceTree = "<group>"; };
 		E2C2C3CF2A4B2DE700A7E5E6 /* UIKitExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = UIKitExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -82,6 +84,7 @@
 				BB48761B2B11FE0200000002 /* BezierButtonTestViewController.swift */,
 				BB48761D2B11FE0200000003 /* BezierIconButtonTestViewController.swift */,
 				BB48761D2B11FE0200000004 /* BezierBadgeTestViewController.swift */,
+				BB4876212B11FE0200000005 /* BezierTagTestViewController.swift */,
 				E2C2C3DB2A4B2DE800A7E5E6 /* Assets.xcassets */,
 				E2C2C3DD2A4B2DE800A7E5E6 /* LaunchScreen.storyboard */,
 				E2C2C3E02A4B2DE800A7E5E6 /* Info.plist */,
@@ -168,6 +171,7 @@
 				BB48761A2B11FE0200000002 /* BezierButtonTestViewController.swift in Sources */,
 				BB48761C2B11FE0200000003 /* BezierIconButtonTestViewController.swift in Sources */,
 				BB48761C2B11FE0200000004 /* BezierBadgeTestViewController.swift in Sources */,
+				BB4876202B11FE0200000005 /* BezierTagTestViewController.swift in Sources */,
 				E2C2C3D32A4B2DE700A7E5E6 /* AppDelegate.swift in Sources */,
 				E2C2C3D52A4B2DE700A7E5E6 /* SceneDelegate.swift in Sources */,
 			);

--- a/Examples/UIKitExample/UIKitExample/BezierTagTestViewController.swift
+++ b/Examples/UIKitExample/UIKitExample/BezierTagTestViewController.swift
@@ -1,0 +1,292 @@
+//
+//  BezierTagTestViewController.swift
+//  UIKitExample
+//
+
+import UIKit
+import BezierSwift
+
+final class BezierTagTestViewController: BaseViewController {
+  // MARK: - State
+
+  private var size: BezierTagSize = .small
+  private var variant: BezierTagVariant = .default
+  private var labelText: String = "Tag"
+  private var hasOnDelete: Bool = false
+  private var deleteCount: Int = 0
+
+  // MARK: - Subviews
+
+  private let scrollView: UIScrollView = {
+    let scrollView = UIScrollView()
+    scrollView.translatesAutoresizingMaskIntoConstraints = false
+    return scrollView
+  }()
+
+  private let containerStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    stackView.spacing = 16
+    stackView.alignment = .fill
+    stackView.layoutMargins = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+    stackView.isLayoutMarginsRelativeArrangement = true
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    return stackView
+  }()
+
+  private let previewContainer: UIView = {
+    let view = UIView()
+    view.backgroundColor = .secondarySystemBackground
+    view.layer.cornerRadius = 12
+    view.translatesAutoresizingMaskIntoConstraints = false
+    return view
+  }()
+
+  private lazy var previewTag: BezierTag = {
+    let tag = BezierTag(size: self.size, variant: self.variant)
+    tag.label = self.labelText
+    return tag
+  }()
+
+  private lazy var sizeControl: UISegmentedControl = {
+    let control = UISegmentedControl(items: BezierTagSize.allCases.map { $0.rawValue })
+    control.selectedSegmentIndex = BezierTagSize.allCases.firstIndex(of: self.size) ?? 0
+    control.addTarget(self, action: #selector(self.onSizeChanged(_:)), for: .valueChanged)
+    return control
+  }()
+
+  private lazy var variantPicker: UIPickerView = {
+    let picker = UIPickerView()
+    picker.dataSource = self
+    picker.delegate = self
+    picker.selectRow(BezierTagVariant.allCases.firstIndex(of: self.variant) ?? 0, inComponent: 0, animated: false)
+    return picker
+  }()
+
+  private lazy var labelTextField: UITextField = {
+    let field = UITextField()
+    field.borderStyle = .roundedRect
+    field.text = self.labelText
+    field.placeholder = "Label"
+    field.autocorrectionType = .no
+    field.autocapitalizationType = .none
+    field.addTarget(self, action: #selector(self.onLabelChanged(_:)), for: .editingChanged)
+    return field
+  }()
+
+  private lazy var onDeleteSwitch: UISwitch = {
+    let toggle = UISwitch()
+    toggle.isOn = self.hasOnDelete
+    toggle.addTarget(self, action: #selector(self.onDeleteToggled(_:)), for: .valueChanged)
+    return toggle
+  }()
+
+  private lazy var deleteCountLabel: UILabel = {
+    let label = UILabel()
+    label.font = .preferredFont(forTextStyle: .footnote)
+    label.textColor = .secondaryLabel
+    label.text = "Delete tapped: 0 times"
+    return label
+  }()
+
+  // MARK: - Lifecycle
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    self.title = "Tag (UIKit)"
+    self.view.backgroundColor = .systemBackground
+    self.setUpLayout()
+    self.refreshPreview()
+  }
+
+  private func setUpLayout() {
+    self.view.addSubview(self.scrollView)
+    self.scrollView.addSubview(self.containerStackView)
+
+    NSLayoutConstraint.activate([
+      self.scrollView.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor),
+      self.scrollView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+      self.scrollView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+      self.scrollView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor),
+
+      self.containerStackView.topAnchor.constraint(equalTo: self.scrollView.contentLayoutGuide.topAnchor),
+      self.containerStackView.leadingAnchor.constraint(equalTo: self.scrollView.contentLayoutGuide.leadingAnchor),
+      self.containerStackView.trailingAnchor.constraint(equalTo: self.scrollView.contentLayoutGuide.trailingAnchor),
+      self.containerStackView.bottomAnchor.constraint(equalTo: self.scrollView.contentLayoutGuide.bottomAnchor),
+      self.containerStackView.widthAnchor.constraint(equalTo: self.scrollView.frameLayoutGuide.widthAnchor),
+    ])
+
+    self.containerStackView.addArrangedSubview(self.makeSectionTitle("Preview"))
+    self.containerStackView.addArrangedSubview(self.makePreviewSection())
+    self.containerStackView.addArrangedSubview(self.makeSectionTitle("Size"))
+    self.containerStackView.addArrangedSubview(self.sizeControl)
+    self.containerStackView.addArrangedSubview(self.makeSectionTitle("Variant"))
+    self.containerStackView.addArrangedSubview(self.variantPicker)
+    self.containerStackView.addArrangedSubview(self.makeSectionTitle("Label"))
+    self.containerStackView.addArrangedSubview(self.labelTextField)
+    self.containerStackView.addArrangedSubview(self.makeSectionTitle("Content"))
+    self.containerStackView.addArrangedSubview(self.makeRow(label: "onDelete enabled", control: self.onDeleteSwitch))
+    self.containerStackView.addArrangedSubview(self.deleteCountLabel)
+    self.containerStackView.addArrangedSubview(self.makeSectionTitle("Catalog"))
+    self.containerStackView.addArrangedSubview(self.makeCatalogSection())
+  }
+
+  private func makeCatalogSection() -> UIView {
+    let container = UIStackView()
+    container.axis = .vertical
+    container.spacing = 16
+    container.alignment = .fill
+
+    for size in BezierTagSize.allCases {
+      let title = UILabel()
+      title.text = size.rawValue
+      title.font = .preferredFont(forTextStyle: .footnote)
+      title.textColor = .secondaryLabel
+      container.addArrangedSubview(title)
+
+      container.addArrangedSubview(self.makeCatalogRow(size: size, hasOnDelete: false))
+      container.addArrangedSubview(self.makeCatalogRow(size: size, hasOnDelete: true))
+    }
+    return container
+  }
+
+  private func makeCatalogRow(size: BezierTagSize, hasOnDelete: Bool) -> UIView {
+    let scroll = UIScrollView()
+    scroll.showsHorizontalScrollIndicator = false
+    scroll.translatesAutoresizingMaskIntoConstraints = false
+
+    let row = UIStackView()
+    row.axis = .horizontal
+    row.spacing = 8
+    row.alignment = .center
+    row.translatesAutoresizingMaskIntoConstraints = false
+
+    for variant in BezierTagVariant.allCases {
+      let tag = BezierTag(size: size, variant: variant)
+      tag.label = "Tag"
+      if hasOnDelete {
+        tag.onDelete = {}
+      }
+      row.addArrangedSubview(tag)
+    }
+
+    scroll.addSubview(row)
+    NSLayoutConstraint.activate([
+      row.topAnchor.constraint(equalTo: scroll.contentLayoutGuide.topAnchor),
+      row.leadingAnchor.constraint(equalTo: scroll.contentLayoutGuide.leadingAnchor),
+      row.trailingAnchor.constraint(equalTo: scroll.contentLayoutGuide.trailingAnchor),
+      row.bottomAnchor.constraint(equalTo: scroll.contentLayoutGuide.bottomAnchor),
+      row.heightAnchor.constraint(equalTo: scroll.frameLayoutGuide.heightAnchor),
+      scroll.heightAnchor.constraint(equalToConstant: size.height + 4),
+    ])
+    return scroll
+  }
+
+  private func makePreviewSection() -> UIView {
+    let stack = UIStackView()
+    stack.axis = .vertical
+    stack.alignment = .center
+    stack.spacing = 12
+    stack.isLayoutMarginsRelativeArrangement = true
+    stack.layoutMargins = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+    stack.translatesAutoresizingMaskIntoConstraints = false
+
+    self.previewContainer.addSubview(stack)
+    NSLayoutConstraint.activate([
+      stack.topAnchor.constraint(equalTo: self.previewContainer.topAnchor),
+      stack.leadingAnchor.constraint(equalTo: self.previewContainer.leadingAnchor),
+      stack.trailingAnchor.constraint(equalTo: self.previewContainer.trailingAnchor),
+      stack.bottomAnchor.constraint(equalTo: self.previewContainer.bottomAnchor),
+    ])
+
+    let tagRow = UIView()
+    tagRow.translatesAutoresizingMaskIntoConstraints = false
+    tagRow.addSubview(self.previewTag)
+    NSLayoutConstraint.activate([
+      tagRow.leadingAnchor.constraint(equalTo: self.previewTag.leadingAnchor),
+      tagRow.trailingAnchor.constraint(equalTo: self.previewTag.trailingAnchor),
+      tagRow.topAnchor.constraint(equalTo: self.previewTag.topAnchor),
+      tagRow.bottomAnchor.constraint(equalTo: self.previewTag.bottomAnchor),
+    ])
+
+    stack.addArrangedSubview(tagRow)
+    return self.previewContainer
+  }
+
+  private func makeSectionTitle(_ text: String) -> UILabel {
+    let label = UILabel()
+    label.text = text
+    label.font = .preferredFont(forTextStyle: .footnote)
+    label.textColor = .secondaryLabel
+    return label
+  }
+
+  private func makeRow(label text: String, control: UIView) -> UIView {
+    let container = UIStackView()
+    container.axis = .horizontal
+    container.distribution = .fill
+    container.alignment = .center
+    container.spacing = 12
+
+    let titleLabel = UILabel()
+    titleLabel.text = text
+    titleLabel.font = .preferredFont(forTextStyle: .body)
+
+    container.addArrangedSubview(titleLabel)
+    let spacer = UIView()
+    spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+    container.addArrangedSubview(spacer)
+    container.addArrangedSubview(control)
+    return container
+  }
+
+  // MARK: - Refresh
+
+  private func refreshPreview() {
+    self.previewTag.size = self.size
+    self.previewTag.variant = self.variant
+    self.previewTag.label = self.labelText.isEmpty ? nil : self.labelText
+    self.previewTag.onDelete = self.hasOnDelete ? { [weak self] in
+      guard let self else { return }
+      self.deleteCount += 1
+      self.deleteCountLabel.text = "Delete tapped: \(self.deleteCount) times"
+    } : nil
+    self.deleteCountLabel.isHidden = !self.hasOnDelete
+  }
+
+  // MARK: - Actions
+
+  @objc private func onSizeChanged(_ sender: UISegmentedControl) {
+    self.size = BezierTagSize.allCases[sender.selectedSegmentIndex]
+    self.refreshPreview()
+  }
+
+  @objc private func onLabelChanged(_ sender: UITextField) {
+    self.labelText = sender.text ?? ""
+    self.refreshPreview()
+  }
+
+  @objc private func onDeleteToggled(_ sender: UISwitch) {
+    self.hasOnDelete = sender.isOn
+    self.refreshPreview()
+  }
+}
+
+// MARK: - UIPickerView
+
+extension BezierTagTestViewController: UIPickerViewDataSource, UIPickerViewDelegate {
+  func numberOfComponents(in pickerView: UIPickerView) -> Int { 1 }
+
+  func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+    BezierTagVariant.allCases.count
+  }
+
+  func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
+    BezierTagVariant.allCases[row].rawValue
+  }
+
+  func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+    self.variant = BezierTagVariant.allCases[row]
+    self.refreshPreview()
+  }
+}

--- a/Examples/UIKitExample/UIKitExample/ViewController.swift
+++ b/Examples/UIKitExample/UIKitExample/ViewController.swift
@@ -14,13 +14,15 @@ final class ViewController: BaseViewController {
     case bezierButton
     case bezierIconButton
     case bezierBadge
+    case bezierTag
 
     var title: String {
       switch self {
       case .bezierIconCatalog: return "Bezier Icon Catalog"
-      case .bezierButton:      return "Button"
-      case .bezierIconButton:  return "IconButton"
-      case .bezierBadge:       return "Badge"
+      case .bezierButton:     return "Button"
+      case .bezierIconButton: return "IconButton"
+      case .bezierBadge:      return "Badge"
+      case .bezierTag:        return "Tag"
       }
     }
   }
@@ -74,6 +76,8 @@ extension ViewController: UITableViewDataSource, UITableViewDelegate {
       self.navigationController?.pushViewController(BezierIconButtonTestViewController(), animated: true)
     case .bezierBadge:
       self.navigationController?.pushViewController(BezierBadgeTestViewController(), animated: true)
+    case .bezierTag:
+      self.navigationController?.pushViewController(BezierTagTestViewController(), animated: true)
     }
   }
 }

--- a/Sources/BezierSwift/MasterComponent/BezierTag/BezierTag.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierTag/BezierTag.swift
@@ -1,0 +1,239 @@
+//
+//  BezierTag.swift
+//  BezierSwift
+//
+
+import UIKit
+
+public final class BezierTag: UIView, BezierComponentable {
+  // MARK: - BezierComponentable
+
+  public var colorTheme: BezierColorTheme { .systemBezierColorTheme() }
+  public var componentTheme: BezierComponentTheme = .normal {
+    didSet { self.refreshAppearance() }
+  }
+
+  // MARK: - Public Properties
+
+  public var size: BezierTagSize = .small {
+    didSet { if oldValue != self.size { self.refreshLayout() } }
+  }
+
+  public var variant: BezierTagVariant = .default {
+    didSet { if oldValue != self.variant { self.refreshAppearance() } }
+  }
+
+  public var label: String? {
+    didSet { if oldValue != self.label { self.refreshContent() } }
+  }
+
+  /// Trailing 위치에 표시되는 close 아이콘 (SPEC §6). 기본값은 `BezierIcon.cancelSmall`.
+  /// `onDelete` 핸들러가 설정되어 있을 때만 표시된다.
+  public var closeIcon: UIImage? = BezierIcon.cancelSmall.uiImage {
+    didSet { self.refreshContent() }
+  }
+
+  /// `onDelete` 콜백이 설정되어 있으면 trailing close 아이콘이 노출되고, 탭 시 호출된다.
+  /// `nil`이면 읽기 전용.
+  public var onDelete: (() -> Void)? {
+    didSet { self.refreshContent() }
+  }
+
+  // MARK: - Subviews
+
+  private let contentStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .horizontal
+    stackView.alignment = .center
+    stackView.distribution = .fill
+    stackView.spacing = 0
+    stackView.isUserInteractionEnabled = true
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    return stackView
+  }()
+
+  private let titleLabel: BezierTagPaddedLabel = {
+    let label = BezierTagPaddedLabel()
+    label.numberOfLines = 1
+    label.textAlignment = .center
+    return label
+  }()
+
+  private lazy var closeButton: UIButton = {
+    let button = UIButton(type: .system)
+    button.translatesAutoresizingMaskIntoConstraints = false
+    button.contentMode = .scaleAspectFit
+    button.imageView?.contentMode = .scaleAspectFit
+    button.addTarget(self, action: #selector(self.handleCloseTap), for: .touchUpInside)
+    return button
+  }()
+
+  // MARK: - Layout Constraints
+
+  private var heightConstraint: NSLayoutConstraint?
+  private var contentLeadingConstraint: NSLayoutConstraint?
+  private var contentTrailingConstraint: NSLayoutConstraint?
+  private var closeButtonWidthConstraint: NSLayoutConstraint?
+  private var closeButtonHeightConstraint: NSLayoutConstraint?
+
+  // MARK: - Init
+
+  public init(
+    size: BezierTagSize = .small,
+    variant: BezierTagVariant = .default
+  ) {
+    self.size = size
+    self.variant = variant
+    super.init(frame: .zero)
+    self.setUp()
+  }
+
+  public required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    self.setUp()
+  }
+
+  // MARK: - Setup
+
+  private func setUp() {
+    self.translatesAutoresizingMaskIntoConstraints = false
+    self.layer.masksToBounds = true
+    self.layer.borderWidth = 0
+
+    self.contentStackView.addArrangedSubview(self.titleLabel)
+    self.contentStackView.addArrangedSubview(self.closeButton)
+
+    self.addSubview(self.contentStackView)
+
+    let heightConstraint = self.heightAnchor.constraint(equalToConstant: self.size.height)
+    let contentLeadingConstraint = self.contentStackView.leadingAnchor.constraint(
+      equalTo: self.leadingAnchor,
+      constant: self.size.horizontalPadding
+    )
+    let contentTrailingConstraint = self.contentStackView.trailingAnchor.constraint(
+      equalTo: self.trailingAnchor,
+      constant: -self.size.horizontalPadding
+    )
+    let closeButtonWidthConstraint = self.closeButton.widthAnchor.constraint(
+      equalToConstant: self.size.closeIconLength
+    )
+    let closeButtonHeightConstraint = self.closeButton.heightAnchor.constraint(
+      equalToConstant: self.size.closeIconLength
+    )
+
+    NSLayoutConstraint.activate([
+      heightConstraint,
+      contentLeadingConstraint,
+      contentTrailingConstraint,
+      closeButtonWidthConstraint,
+      closeButtonHeightConstraint,
+      self.contentStackView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+    ])
+
+    self.heightConstraint = heightConstraint
+    self.contentLeadingConstraint = contentLeadingConstraint
+    self.contentTrailingConstraint = contentTrailingConstraint
+    self.closeButtonWidthConstraint = closeButtonWidthConstraint
+    self.closeButtonHeightConstraint = closeButtonHeightConstraint
+
+    self.refreshLayout()
+    self.refreshAppearance()
+  }
+
+  // MARK: - Layout Update
+
+  public override func layoutSubviews() {
+    super.layoutSubviews()
+    self.layer.cornerRadius = self.bounds.height / 2
+  }
+
+  public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    self.refreshAppearance()
+  }
+
+  // MARK: - Refresh
+
+  private func refreshLayout() {
+    self.heightConstraint?.constant = self.size.height
+    self.contentLeadingConstraint?.constant = self.size.horizontalPadding
+    self.contentTrailingConstraint?.constant = -self.size.horizontalPadding
+    self.closeButtonWidthConstraint?.constant = self.size.closeIconLength
+    self.closeButtonHeightConstraint?.constant = self.size.closeIconLength
+
+    self.titleLabel.contentInsets = UIEdgeInsets(
+      top: 0,
+      left: self.size.textHorizontalPadding,
+      bottom: 0,
+      right: self.size.textHorizontalPadding
+    )
+
+    self.refreshContent()
+    self.invalidateIntrinsicContentSize()
+    self.setNeedsLayout()
+  }
+
+  private func refreshContent() {
+    let foregroundColor = self.variant.foregroundToken.palette(self)
+
+    if let label = self.label, !label.isEmpty {
+      // TYPO-MIGRATION: Figma raw 값을 직접 사용. 추후 BTSemanticToken으로 통합 예정 (BezierTagSpec.swift 참고).
+      let font = UIFont.systemFont(
+        ofSize: self.size.fontSize,
+        weight: self.size.fontWeight.uiKitWeight
+      )
+      self.titleLabel.attributedText = label.applyBezierFont(
+        height: self.size.lineHeight,
+        font: font,
+        color: foregroundColor,
+        letterSpacing: self.size.letterSpacing,
+        alignment: .center
+      )
+      self.titleLabel.isHidden = false
+    } else {
+      self.titleLabel.attributedText = nil
+      self.titleLabel.isHidden = true
+    }
+
+    let showCloseButton = self.onDelete != nil
+    self.closeButton.isHidden = !showCloseButton
+    if showCloseButton {
+      self.closeButton.setImage(self.closeIcon?.withRenderingMode(.alwaysTemplate), for: .normal)
+      self.closeButton.tintColor = foregroundColor
+    }
+  }
+
+  private func refreshAppearance() {
+    self.backgroundColor = self.variant.backgroundToken.palette(self)
+    self.refreshContent()
+  }
+
+  // MARK: - Actions
+
+  @objc private func handleCloseTap() {
+    self.onDelete?()
+  }
+}
+
+// MARK: - Padded Label
+
+final class BezierTagPaddedLabel: UILabel {
+  var contentInsets: UIEdgeInsets = .zero {
+    didSet {
+      self.invalidateIntrinsicContentSize()
+      self.setNeedsDisplay()
+    }
+  }
+
+  override func drawText(in rect: CGRect) {
+    super.drawText(in: rect.inset(by: self.contentInsets))
+  }
+
+  override var intrinsicContentSize: CGSize {
+    let size = super.intrinsicContentSize
+    return CGSize(
+      width: size.width + self.contentInsets.left + self.contentInsets.right,
+      height: size.height + self.contentInsets.top + self.contentInsets.bottom
+    )
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierTag/BezierTagSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierTag/BezierTagSpec.swift
@@ -1,0 +1,114 @@
+//
+//  BezierTagSpec.swift
+//  BezierSwift
+//
+
+import CoreGraphics
+import UIKit
+
+public enum BezierTagSize: String, CaseIterable {
+  case xsmall
+  case small
+  case medium
+  case large
+
+  public var height: CGFloat {
+    switch self {
+    case .xsmall: return 18
+    case .small:  return 22
+    case .medium: return 22
+    case .large:  return 26
+    }
+  }
+
+  public var horizontalPadding: CGFloat { 4 }
+
+  public var textHorizontalPadding: CGFloat { 4 }
+
+  public var verticalPadding: CGFloat {
+    switch self {
+    case .xsmall: return 1
+    case .small:  return 2
+    case .medium: return 2
+    case .large:  return 3
+    }
+  }
+
+  public var closeIconLength: CGFloat { 16 }
+
+  // MARK: - Typography (Figma raw, see SPEC §3)
+  //
+  // TYPO-MIGRATION: Figma component description의 `📌 TYPO-MIGRATION: Text Style
+  // 미적용` 상태에 따라 raw 값을 직접 사용한다. 디자인팀의 로컬 typography 스타일
+  // 일괄 바인딩이 끝나 raw가 token과 정합되면 BTSemanticToken 기반 API로 통합 예정.
+
+  public var fontSize: CGFloat {
+    switch self {
+    case .xsmall: return 12
+    case .small:  return 14
+    case .medium: return 15
+    case .large:  return 16
+    }
+  }
+
+  public var lineHeight: CGFloat {
+    switch self {
+    case .xsmall: return 16
+    case .small, .medium: return 18
+    case .large: return 20
+    }
+  }
+
+  public var letterSpacing: CGFloat {
+    switch self {
+    case .xsmall, .small: return 0
+    case .medium, .large: return -0.1
+    }
+  }
+
+  public var fontWeight: BTFontWeight { .regular }
+
+  public var lineSpacing: CGFloat {
+    let font = UIFont.systemFont(ofSize: self.fontSize, weight: self.fontWeight.uiKitWeight)
+    return max(0, self.lineHeight - font.lineHeight)
+  }
+
+  public var verticalLineSpacing: CGFloat { self.lineSpacing / 2 }
+}
+
+public enum BezierTagVariant: String, CaseIterable {
+  case `default`
+  case red
+  case orange
+  case yellow
+  case olive
+  case green
+  case cobalt
+  case purple
+  case pink
+  case navy
+  case blue
+  case teal
+}
+
+extension BezierTagVariant {
+  public var backgroundToken: BCSemanticToken {
+    switch self {
+    case .default: return .fillNeutralLight
+    case .red:     return .fillAccentRedHeavy
+    case .orange:  return .fillAccentOrangeHeavy
+    case .yellow:  return .fillAccentYellowHeavy
+    case .olive:   return .fillAccentOliveHeavy
+    case .green:   return .fillAccentGreenHeavy
+    case .cobalt:  return .fillAccentCobaltHeavy
+    case .purple:  return .fillAccentPurpleHeavy
+    case .pink:    return .fillAccentPinkHeavy
+    case .navy:    return .fillAccentNavyHeavy
+    case .blue:    return .fillAccentBlueHeavy
+    case .teal:    return .fillAccentTealHeavy
+    }
+  }
+
+  // SPEC §4: 모든 variant에서 foreground는 동일한 `color/text/neutral`.
+  public var foregroundToken: BCSemanticToken { .textNeutral }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierTag/SPEC.md
+++ b/Sources/BezierSwift/MasterComponent/BezierTag/SPEC.md
@@ -1,0 +1,200 @@
+# BezierTag Spec
+
+> Figma: [🚧 Mobile Components — Tag](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=1064-2)
+> Design spec doc: [bezier-v3/component-spec/Tag-spec.md](https://github.com/channel-io/design-team/blob/main/docs/bezier-v3/component-spec/Tag-spec.md)
+
+객체(상담·연락처·채팅 등)에 직접 부여하거나 제거할 수 있는 분류 레이블.
+
+- **모양**: Capsule (radius/32 = 32pt, 실제 높이가 32 미만이므로 capsule 형태로 렌더링)
+- **인터랙션**: 본체는 읽기 전용. `onDelete = true`일 때 trailing 위치의 × 아이콘이 제거 트리거 역할
+- **Badge와의 구분**: 읽기 전용 상태·속성 표시에는 Badge 사용. Tag는 제거 가능한 분류 레이블 의미를 내포
+
+---
+
+## 1. Component Properties
+
+Figma 컴포넌트가 정의하는 property와 옵션은 다음이 전부다.
+
+| Property | 값 | 비고 |
+|---|---|---|
+| **Size** | `xsmall` / `small` / `medium` / `large` | 4단계 |
+| **Color** | `default` / `red` / `orange` / `yellow` / `olive` / `green` / `cobalt` / `purple` / `pink` / `navy` / `blue` / `teal` | 12가지 |
+| **onDelete** | `true` / `false` | `true` 시 trailing 16×16 × 아이콘 노출 (제거 트리거). 기본 `false` (읽기 전용) |
+| **label** | string | 분류 레이블 텍스트. Figma의 `"Tag"`는 컴포넌트 preview용 placeholder이며 API default가 아님 |
+
+총 instance: `4 size × 12 color = 48개` (Figma 컴포넌트 인스턴스 수와 일치)
+
+---
+
+## 2. Size 별 Spec
+
+| Size | Height | Horizontal Padding | Vertical Padding | Text Horizontal Padding (TagText 내부) | Close Icon Length |
+|---|---|---|---|---|---|
+| `xsmall` | 18pt | 4pt | 1pt | 4pt | 16pt |
+| `small`  | 22pt | 4pt | 2pt | 4pt | 16pt |
+| `medium` | 22pt | 4pt | 2pt | 4pt | 16pt |
+| `large`  | 26pt | 4pt | 3pt | 4pt | 16pt |
+
+- **Corner radius**: `radius/32 = 32pt`. height < 32 이므로 capsule 형태로 보임.
+- **Min height**: `xsmall`은 `min-h-[16px]` (Figma container에 직접 지정).
+- **Layout**: `flex items-center justify-center` — TagText → (optional) close icon 순. content gap 0 (TagText 자체 horizontal padding 4pt가 close icon과의 간격을 만든다).
+- **onDelete 시 layout**: trailing close icon 16×16이 추가됨. 컨테이너 horizontal padding 영역 안에는 들어가지 않고, TagText 우측에 인접 배치.
+
+---
+
+## 3. Size 별 Typography
+
+> 📌 **TYPO-MIGRATION** (Figma description 인용): Text Style 미적용 — 로컬 타이포 스타일 등록 시 일괄 바인딩 예정. Figma는 raw value 직접 지정 상태.
+
+| Size | Font Size | Line Height | Letter Spacing | Font Family Variable |
+|---|---|---|---|---|
+| `xsmall` | 12pt | 16pt | 0 (`text/letter-spacing`) | `text/font-family` (Inter) |
+| `small`  | 14pt | 18pt | 0 (`label/letter-spacing`) | `label/font-family` (Inter) |
+| `medium` | 15pt | 18pt | -0.1pt (`text/letter-spacing/tight`) | `font-family/sans-kr` (Inter) |
+| `large`  | 16pt | 20pt | -0.1pt (`text/letter-spacing/tight`) | `text/font-family` (Inter) |
+
+- Weight: 전부 regular (400).
+- Italic: 전부 not-italic.
+
+---
+
+## 4. Color 별 컬러 토큰
+
+### Background (variant 12개)
+
+| Variant | Figma Variable | Raw |
+|---|---|---|
+| `default` | `color/fill/neutral/light` | `#0000000D` (rgba(0,0,0,0.05)) |
+| `red` | `color/fill/accent/red/heavy` | `#E1535D33` |
+| `orange` | `color/fill/accent/orange/heavy` | `#E67F2B33` |
+| `yellow` | `color/fill/accent/yellow/heavy` | `#EDAE0D33` |
+| `olive` | `color/fill/accent/olive/heavy` | `#A9B11033` |
+| `green` | `color/fill/accent/green/heavy` | `#20AB5533` |
+| `cobalt` | `color/fill/accent/cobalt/heavy` | `#3292E333` |
+| `purple` | `color/fill/accent/purple/heavy` | `#8E57E733` |
+| `pink` | `color/fill/accent/pink/heavy` | `#D64BB533` |
+| `navy` | `color/fill/accent/navy/heavy` | `#424FAB33` |
+| `blue` | `color/fill/accent/blue/heavy` | `#6157EA33` |
+| `teal` | `color/fill/accent/teal/heavy` | `#09B2AC33` |
+
+### Foreground (text & close icon)
+
+| Variant | Figma Variable | Raw |
+|---|---|---|
+| (모든 variant 공통) | `color/text/neutral` | `#000000D9` (rgba(0,0,0,0.85)) |
+
+> Tag는 Badge와 달리 모든 variant에서 동일한 `color/text/neutral` foreground를 사용한다. 배경색은 variant별로 다르지만 텍스트와 close 아이콘 색은 단일.
+
+---
+
+## 5. State
+
+해당 없음. Tag 컴포넌트는 state property를 갖지 않는다 (default/pressed/active/disabled/loading 분기 없음). 단, `onDelete = true` 시 trailing close 아이콘이 노출되며 이 아이콘이 제거(remove) 동작의 트리거가 된다.
+
+---
+
+## 6. Close Icon (onDelete = true 시)
+
+| Spec | 값 |
+|---|---|
+| Size | 16pt × 16pt |
+| 자산 | Figma `data-name="icon/cancel-small"` → 코드 매핑 `BezierIcon.cancelSmall` (rawValue `"icon-cancel-small"`) |
+| 색 | `color/text/neutral` (변동 없음, foreground와 동일) |
+| 배치 | TagText 우측. TagText horizontal padding(4pt)이 시각적 간격 역할 |
+
+- `onDelete = false`일 때는 close icon 영역이 layout에 포함되지 않는다 (컨테이너 width 변동).
+- 자산은 Figma SSOT(cancel-small)와 동일해야 한다. SF Symbol(`xmark`) 등 임의 fallback 금지.
+
+---
+
+## 7. 디자이너 가이드라인 (Figma component description 인용)
+
+- **variant 의미**: 의미 구분이 필요하면 variant 색상 지정. 동일 레벨의 태그는 `default`로 통일.
+- **onDelete**: `false` = 읽기 전용. `true` = 우측 × 아이콘으로 직접 제거 가능.
+- **Badge와의 구분**: 읽기 전용 상태·속성 표시에는 Badge 사용. Tag는 제거 가능한 분류 레이블 의미를 내포함.
+
+---
+
+## 8. 매핑되는 코드 심볼
+
+| 정의 | 파일 |
+|---|---|
+| UIKit 구현 | `BezierTag.swift` |
+| SwiftUI 구현 | `SUBezierTag.swift` |
+| Size / Variant enum | `BezierTagSpec.swift` |
+| 색상 토큰 (semantic) | `Sources/BezierSwift/Foundation/Color/V3/BCSemanticToken.swift` |
+| 타이포 토큰 (semantic) | `Sources/BezierSwift/Foundation/Typography/V3/BTSemanticToken.swift` |
+| Close icon 자산 | `Sources/BezierSwift/Icons/BezierIcon.swift` (`BezierIcon.cancelSmall`) |
+
+> ⚠️ **Typography 매핑 정책 (TYPO-MIGRATION 진행 중 잠정 매핑)**: Figma component description의 `📌 TYPO-MIGRATION: Text Style 미적용 — 로컬 타이포 스타일 등록 시 일괄 바인딩 예정`에 따라, Figma는 현재 raw value를 직접 박아놓은 상태다.
+>
+> **현재 정책**: Figma SSOT를 우선시한다. `BTSemanticToken`의 case 중 Figma raw와 정확히 일치하는 것이 있더라도 일관성을 위해 **모든 size에서 raw 값을 직접 사용**한다.
+>
+> | Size | Figma raw (FS/LH/LS) |
+> |---|---|
+> | xsmall | 12 / 16 / 0 |
+> | small | 14 / 18 / 0 |
+> | medium | 15 / 18 / -0.1 |
+> | large | 16 / 20 / -0.1 |
+>
+> **TODO**: 디자인팀의 TYPO-MIGRATION (로컬 typography style 일괄 바인딩) 완료 후 raw 값과 token이 정합되면 `BTSemanticToken` 기반 API로 통합 예정.
+
+---
+
+## 9. Variant 매트릭스
+
+총 instance: `4 size × 12 color = 48개`
+
+```text
+Size=xsmall, Color=default = 1730:2
+Size=xsmall, Color=red     = 1730:5
+Size=xsmall, Color=orange  = 1730:8
+Size=xsmall, Color=yellow  = 1730:11
+Size=xsmall, Color=olive   = 1730:14
+Size=xsmall, Color=green   = 1730:17
+Size=xsmall, Color=cobalt  = 1730:20
+Size=xsmall, Color=purple  = 1730:23
+Size=xsmall, Color=pink    = 1730:26
+Size=xsmall, Color=navy    = 1730:29
+Size=xsmall, Color=blue    = 1731:42
+Size=xsmall, Color=teal    = 1731:58
+
+Size=small, Color=default  = 1730:32
+Size=small, Color=red      = 1730:35
+Size=small, Color=orange   = 1730:38
+Size=small, Color=yellow   = 1730:41
+Size=small, Color=olive    = 1730:44
+Size=small, Color=green    = 1730:47
+Size=small, Color=cobalt   = 1730:50
+Size=small, Color=purple   = 1730:53
+Size=small, Color=pink     = 1730:56
+Size=small, Color=navy     = 1730:59
+Size=small, Color=blue     = 1731:46
+Size=small, Color=teal     = 1731:62
+
+Size=medium, Color=default = 1730:62
+Size=medium, Color=red     = 1730:65
+Size=medium, Color=orange  = 1730:68
+Size=medium, Color=yellow  = 1730:71
+Size=medium, Color=olive   = 1730:74
+Size=medium, Color=green   = 1730:77
+Size=medium, Color=cobalt  = 1730:80
+Size=medium, Color=purple  = 1730:83
+Size=medium, Color=pink    = 1730:86
+Size=medium, Color=navy    = 1730:89
+Size=medium, Color=blue    = 1731:50
+Size=medium, Color=teal    = 1731:66
+
+Size=large, Color=default  = 1730:92
+Size=large, Color=red      = 1730:95
+Size=large, Color=orange   = 1730:98
+Size=large, Color=yellow   = 1730:101
+Size=large, Color=olive    = 1730:104
+Size=large, Color=green    = 1730:107
+Size=large, Color=cobalt   = 1730:110
+Size=large, Color=purple   = 1730:113
+Size=large, Color=pink     = 1730:116
+Size=large, Color=navy     = 1730:119
+Size=large, Color=blue     = 1731:54
+Size=large, Color=teal     = 1731:70
+```

--- a/Sources/BezierSwift/MasterComponent/BezierTag/SUBezierTag.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierTag/SUBezierTag.swift
@@ -1,0 +1,100 @@
+//
+//  SUBezierTag.swift
+//  BezierSwift
+//
+
+import SwiftUI
+
+public struct SUBezierTag: View, Themeable {
+  private let size: BezierTagSize
+  private let variant: BezierTagVariant
+  private let label: String?
+  private let closeIcon: Image
+  private let onDelete: (() -> Void)?
+
+  @Environment(\.colorScheme) public var colorScheme
+
+  public init(
+    size: BezierTagSize = .small,
+    variant: BezierTagVariant = .default,
+    label: String? = nil,
+    closeIcon: Image = BezierIcon.cancelSmall.image,
+    onDelete: (() -> Void)? = nil
+  ) {
+    self.size = size
+    self.variant = variant
+    self.label = label
+    self.closeIcon = closeIcon
+    self.onDelete = onDelete
+  }
+
+  public var body: some View {
+    HStack(spacing: 0) {
+      if let label = self.label, !label.isEmpty {
+        // TYPO-MIGRATION: Figma raw 값을 직접 사용. 추후 BTSemanticToken으로 통합 예정 (BezierTagSpec.swift 참고).
+        Text(label)
+          .font(.system(size: self.size.fontSize, weight: self.size.fontWeight.swiftUIWeight))
+          .tracking(self.size.letterSpacing)
+          .lineSpacing(self.size.lineSpacing)
+          .padding(.vertical, self.size.verticalLineSpacing)
+          .foregroundColor(self.palette(self.variant.foregroundToken))
+          .padding(.horizontal, self.size.textHorizontalPadding)
+          .fixedSize(horizontal: true, vertical: false)
+      }
+      if let onDelete = self.onDelete {
+        Button(action: onDelete) {
+          self.closeIcon
+            .renderingMode(.template)
+            .resizable()
+            .scaledToFit()
+            .frame(width: self.size.closeIconLength, height: self.size.closeIconLength)
+            .foregroundColor(self.palette(self.variant.foregroundToken))
+        }
+        .buttonStyle(.plain)
+      }
+    }
+    .padding(.horizontal, self.size.horizontalPadding)
+    .frame(minHeight: self.size.height, maxHeight: self.size.height)
+    .background(Capsule().fill(self.palette(self.variant.backgroundToken)))
+    .clipShape(Capsule())
+  }
+}
+
+struct SUBezierTag_Previews: PreviewProvider {
+  static var previews: some View {
+    ScrollView {
+      VStack(alignment: .leading, spacing: 20) {
+        ForEach(BezierTagSize.allCases, id: \.self) { size in
+          VStack(alignment: .leading, spacing: 8) {
+            Text(size.rawValue)
+              .font(.caption.weight(.semibold))
+              .foregroundColor(.secondary)
+            VariantRow(size: size)
+            VariantRow(size: size, hasOnDelete: true)
+          }
+        }
+      }
+      .padding()
+    }
+  }
+
+  private struct VariantRow: View {
+    let size: BezierTagSize
+    var hasOnDelete: Bool = false
+
+    var body: some View {
+      ScrollView(.horizontal, showsIndicators: false) {
+        HStack(spacing: 8) {
+          ForEach(BezierTagVariant.allCases, id: \.self) { variant in
+            SUBezierTag(
+              size: size,
+              variant: variant,
+              label: "Tag",
+              onDelete: hasOnDelete ? {} : nil
+            )
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- V3 BezierTag 컴포넌트(UIKit + SwiftUI) 추가
- Figma SSOT: [🚧 Mobile Components — Tag](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=1064-2)
- `BezierBadge` 패턴 기반(capsule, 12 color × 4 size), `onDelete` 콜백 설정 시 trailing `BezierIcon.cancelSmall` 노출
- UIKit/SwiftUI Examples Catalog에 `Tag` 진입점 추가 (Size·Variant·Label·onDelete 토글 + 4×12 카탈로그)

## Spec

`Sources/BezierSwift/MasterComponent/BezierTag/SPEC.md` 참고. 핵심 SSOT 매핑:

| 차원 | 값 |
|---|---|
| Properties | Size(`xsmall`/`small`/`medium`/`large`) × Color(12) × `onDelete` × `label` |
| Layout | height 18/22/22/26, horizontalPadding 4, verticalPadding 1/2/2/3, textHorizontalPadding 4, closeIcon 16, cornerRadius = height/2 |
| Color | 12 variant별 `fillAccent…Heavy` / `fillNeutralLight`, foreground는 모든 variant에서 `textNeutral` 단일 |
| Typography | xsmall=12/16/0, small=14/18/0, medium=15/18/-0.1, large=16/20/-0.1 (regular, Custom raw — TYPO-MIGRATION) |
| Close icon | `BezierIcon.cancelSmall` (`icon-cancel-small`) — SF Symbol fallback 금지 |

## Verification 절차

`figma-component-spec` skill의 3단계 사이클로 작성:
1. **Phase 1** — Figma MCP로 SSOT 수집 → SPEC.md 작성
2. **Phase 2** — 7개 검증 subagent 병렬(Properties / Layout / Color / Typography / Asset / Spec Noise / Implementation Reference)
3. **Phase 3** — UIKit + SwiftUI Implementation Validator 병렬

검증 과정에서 발견한 SSOT 어긋남(SF Symbol fallback, medium/large `letter-spacing/tight` 누락)을 모두 정정.

## Catalog 캡처

|SwiftUI|UIKit|
|:---:|:---:|
|<img width="370" alt="Simulator Screenshot - iPhone 16 Pro - 2026-05-20 at 01 28 11" src="https://github.com/user-attachments/assets/df30faa3-f7c6-405c-9901-111137820e44" />|<img width="370" alt="Simulator Screenshot - iPhone 16 - 2026-05-20 at 01 28 04" src="https://github.com/user-attachments/assets/ee916942-22da-46fd-96ed-50a5018deb0d" />|

## Test plan

- [ ] UIKitExample → Tag: Size/Variant/Label/onDelete 토글이 preview·catalog에 정확히 반영
- [ ] SwiftUIExample → Tag: 동일 시나리오에서 Themeable/dark mode 색 표시
- [ ] onDelete=true 시 trailing close 아이콘이 `icon-cancel-small`(× 모양)로 렌더되는지 (iPhone 16 / 16 Pro 시뮬레이터에서 시각 비교)
- [ ] 4 size × 12 variant × {onDelete on/off} = 96 인스턴스 카탈로그 회귀 확인
- [ ] medium/large의 letterSpacing `-0.1pt`가 Figma와 시각적으로 일치

🤖 Generated with [Claude Code](https://claude.com/claude-code)