### PR TITLE
V3 Components: BezierButton, BezierBadge, BezierIconButton 추가

### DIFF
--- a/Examples/SwiftUIExample/SwiftUIExample.xcodeproj/project.pbxproj
+++ b/Examples/SwiftUIExample/SwiftUIExample.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		A1B2C3D42A737BD700C99C9E /* TypographyTokenCatalogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D32A737BD700C99C9E /* TypographyTokenCatalogView.swift */; };
 		A1B2C3D62A737BD700C99C9E /* BezierIconCatalogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D52A737BD700C99C9E /* BezierIconCatalogView.swift */; };
+		BB48760B2B11FE0100000001 /* BezierButtonTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB48760A2B11FE0100000001 /* BezierButtonTestView.swift */; };
 		E2789E4D2A737BC700B98B8D /* BezierElevationTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2789E4C2A737BC700B98B8D /* BezierElevationTestView.swift */; };
 		E28212322A4B32F700018327 /* SwiftUIExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28212312A4B32F700018327 /* SwiftUIExampleApp.swift */; };
 		E28212342A4B32F700018327 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28212332A4B32F700018327 /* ContentView.swift */; };
@@ -20,6 +21,7 @@
 /* Begin PBXFileReference section */
 		A1B2C3D32A737BD700C99C9E /* TypographyTokenCatalogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypographyTokenCatalogView.swift; sourceTree = "<group>"; };
 		A1B2C3D52A737BD700C99C9E /* BezierIconCatalogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierIconCatalogView.swift; sourceTree = "<group>"; };
+		BB48760A2B11FE0100000001 /* BezierButtonTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierButtonTestView.swift; sourceTree = "<group>"; };
 		E2789E4C2A737BC700B98B8D /* BezierElevationTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierElevationTestView.swift; sourceTree = "<group>"; };
 		E282122E2A4B32F700018327 /* SwiftUIExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftUIExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E28212312A4B32F700018327 /* SwiftUIExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIExampleApp.swift; sourceTree = "<group>"; };
@@ -46,6 +48,7 @@
 				E2789E4C2A737BC700B98B8D /* BezierElevationTestView.swift */,
 				A1B2C3D32A737BD700C99C9E /* TypographyTokenCatalogView.swift */,
 				A1B2C3D52A737BD700C99C9E /* BezierIconCatalogView.swift */,
+				BB48760A2B11FE0100000001 /* BezierButtonTestView.swift */,
 			);
 			path = TestViews;
 			sourceTree = "<group>";
@@ -171,6 +174,7 @@
 				E2789E4D2A737BC700B98B8D /* BezierElevationTestView.swift in Sources */,
 				A1B2C3D42A737BD700C99C9E /* TypographyTokenCatalogView.swift in Sources */,
 				A1B2C3D62A737BD700C99C9E /* BezierIconCatalogView.swift in Sources */,
+				BB48760B2B11FE0100000001 /* BezierButtonTestView.swift in Sources */,
 				E28212322A4B32F700018327 /* SwiftUIExampleApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Examples/SwiftUIExample/SwiftUIExample.xcodeproj/project.pbxproj
+++ b/Examples/SwiftUIExample/SwiftUIExample.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		A1B2C3D42A737BD700C99C9E /* TypographyTokenCatalogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D32A737BD700C99C9E /* TypographyTokenCatalogView.swift */; };
 		A1B2C3D62A737BD700C99C9E /* BezierIconCatalogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D52A737BD700C99C9E /* BezierIconCatalogView.swift */; };
 		BB48760B2B11FE0100000001 /* BezierButtonTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB48760A2B11FE0100000001 /* BezierButtonTestView.swift */; };
+		BB48760D2B11FE0100000003 /* BezierBadgeTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB48760C2B11FE0100000003 /* BezierBadgeTestView.swift */; };
 		E2789E4D2A737BC700B98B8D /* BezierElevationTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2789E4C2A737BC700B98B8D /* BezierElevationTestView.swift */; };
 		E28212322A4B32F700018327 /* SwiftUIExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28212312A4B32F700018327 /* SwiftUIExampleApp.swift */; };
 		E28212342A4B32F700018327 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28212332A4B32F700018327 /* ContentView.swift */; };
@@ -22,6 +23,7 @@
 		A1B2C3D32A737BD700C99C9E /* TypographyTokenCatalogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypographyTokenCatalogView.swift; sourceTree = "<group>"; };
 		A1B2C3D52A737BD700C99C9E /* BezierIconCatalogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierIconCatalogView.swift; sourceTree = "<group>"; };
 		BB48760A2B11FE0100000001 /* BezierButtonTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierButtonTestView.swift; sourceTree = "<group>"; };
+		BB48760C2B11FE0100000003 /* BezierBadgeTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierBadgeTestView.swift; sourceTree = "<group>"; };
 		E2789E4C2A737BC700B98B8D /* BezierElevationTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierElevationTestView.swift; sourceTree = "<group>"; };
 		E282122E2A4B32F700018327 /* SwiftUIExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftUIExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E28212312A4B32F700018327 /* SwiftUIExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIExampleApp.swift; sourceTree = "<group>"; };
@@ -49,6 +51,7 @@
 				A1B2C3D32A737BD700C99C9E /* TypographyTokenCatalogView.swift */,
 				A1B2C3D52A737BD700C99C9E /* BezierIconCatalogView.swift */,
 				BB48760A2B11FE0100000001 /* BezierButtonTestView.swift */,
+				BB48760C2B11FE0100000003 /* BezierBadgeTestView.swift */,
 			);
 			path = TestViews;
 			sourceTree = "<group>";
@@ -175,6 +178,7 @@
 				A1B2C3D42A737BD700C99C9E /* TypographyTokenCatalogView.swift in Sources */,
 				A1B2C3D62A737BD700C99C9E /* BezierIconCatalogView.swift in Sources */,
 				BB48760B2B11FE0100000001 /* BezierButtonTestView.swift in Sources */,
+				BB48760D2B11FE0100000003 /* BezierBadgeTestView.swift in Sources */,
 				E28212322A4B32F700018327 /* SwiftUIExampleApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Examples/SwiftUIExample/SwiftUIExample.xcodeproj/project.pbxproj
+++ b/Examples/SwiftUIExample/SwiftUIExample.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		A1B2C3D42A737BD700C99C9E /* TypographyTokenCatalogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D32A737BD700C99C9E /* TypographyTokenCatalogView.swift */; };
 		A1B2C3D62A737BD700C99C9E /* BezierIconCatalogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D52A737BD700C99C9E /* BezierIconCatalogView.swift */; };
 		BB48760B2B11FE0100000001 /* BezierButtonTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB48760A2B11FE0100000001 /* BezierButtonTestView.swift */; };
+		BB48760D2B11FE0100000002 /* BezierIconButtonTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB48760C2B11FE0100000002 /* BezierIconButtonTestView.swift */; };
 		BB48760D2B11FE0100000003 /* BezierBadgeTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB48760C2B11FE0100000003 /* BezierBadgeTestView.swift */; };
 		E2789E4D2A737BC700B98B8D /* BezierElevationTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2789E4C2A737BC700B98B8D /* BezierElevationTestView.swift */; };
 		E28212322A4B32F700018327 /* SwiftUIExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28212312A4B32F700018327 /* SwiftUIExampleApp.swift */; };
@@ -23,6 +24,7 @@
 		A1B2C3D32A737BD700C99C9E /* TypographyTokenCatalogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypographyTokenCatalogView.swift; sourceTree = "<group>"; };
 		A1B2C3D52A737BD700C99C9E /* BezierIconCatalogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierIconCatalogView.swift; sourceTree = "<group>"; };
 		BB48760A2B11FE0100000001 /* BezierButtonTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierButtonTestView.swift; sourceTree = "<group>"; };
+		BB48760C2B11FE0100000002 /* BezierIconButtonTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierIconButtonTestView.swift; sourceTree = "<group>"; };
 		BB48760C2B11FE0100000003 /* BezierBadgeTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierBadgeTestView.swift; sourceTree = "<group>"; };
 		E2789E4C2A737BC700B98B8D /* BezierElevationTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierElevationTestView.swift; sourceTree = "<group>"; };
 		E282122E2A4B32F700018327 /* SwiftUIExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftUIExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -51,6 +53,7 @@
 				A1B2C3D32A737BD700C99C9E /* TypographyTokenCatalogView.swift */,
 				A1B2C3D52A737BD700C99C9E /* BezierIconCatalogView.swift */,
 				BB48760A2B11FE0100000001 /* BezierButtonTestView.swift */,
+				BB48760C2B11FE0100000002 /* BezierIconButtonTestView.swift */,
 				BB48760C2B11FE0100000003 /* BezierBadgeTestView.swift */,
 			);
 			path = TestViews;
@@ -178,6 +181,7 @@
 				A1B2C3D42A737BD700C99C9E /* TypographyTokenCatalogView.swift in Sources */,
 				A1B2C3D62A737BD700C99C9E /* BezierIconCatalogView.swift in Sources */,
 				BB48760B2B11FE0100000001 /* BezierButtonTestView.swift in Sources */,
+				BB48760D2B11FE0100000002 /* BezierIconButtonTestView.swift in Sources */,
 				BB48760D2B11FE0100000003 /* BezierBadgeTestView.swift in Sources */,
 				E28212322A4B32F700018327 /* SwiftUIExampleApp.swift in Sources */,
 			);

--- a/Examples/SwiftUIExample/SwiftUIExample/ContentView.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/ContentView.swift
@@ -20,6 +20,9 @@ struct ContentView: View, Themeable {
         NavigationLink("Bezier Icon Catalog") {
           BezierIconCatalogView()
         }
+        NavigationLink("Button") {
+          BezierButtonTestView()
+        }
         NavigationLink("Elevation Test") {
           BezierElevationTestView()
         }

--- a/Examples/SwiftUIExample/SwiftUIExample/ContentView.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/ContentView.swift
@@ -23,6 +23,9 @@ struct ContentView: View, Themeable {
         NavigationLink("Button") {
           BezierButtonTestView()
         }
+        NavigationLink("Badge") {
+          BezierBadgeTestView()
+        }
         NavigationLink("Elevation Test") {
           BezierElevationTestView()
         }

--- a/Examples/SwiftUIExample/SwiftUIExample/ContentView.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/ContentView.swift
@@ -23,6 +23,9 @@ struct ContentView: View, Themeable {
         NavigationLink("Button") {
           BezierButtonTestView()
         }
+        NavigationLink("IconButton") {
+          BezierIconButtonTestView()
+        }
         NavigationLink("Badge") {
           BezierBadgeTestView()
         }

--- a/Examples/SwiftUIExample/SwiftUIExample/TestViews/BezierBadgeTestView.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/TestViews/BezierBadgeTestView.swift
@@ -1,0 +1,91 @@
+//
+//  BezierBadgeTestView.swift
+//  SwiftUIExample
+//
+
+import SwiftUI
+import BezierSwift
+
+struct BezierBadgeTestView: View {
+  @State private var size: BezierBadgeSize = .small
+  @State private var variant: BezierBadgeVariant = .default
+  @State private var labelText: String = ""
+  @State private var hasLeadingIcon: Bool = false
+
+  var body: some View {
+    Form {
+      Section("Preview") {
+        SUBezierBadge(
+          size: self.size,
+          variant: self.variant,
+          label: self.labelText.isEmpty ? nil : self.labelText,
+          leadingIcon: self.hasLeadingIcon ? Image(systemName: "plus") : nil
+        )
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 8)
+      }
+
+      Section("Size") {
+        Picker("Size", selection: self.$size) {
+          ForEach(BezierBadgeSize.allCases, id: \.self) { size in
+            Text(size.rawValue).tag(size)
+          }
+        }
+        .pickerStyle(.segmented)
+      }
+
+      Section("Variant") {
+        Picker("Variant", selection: self.$variant) {
+          ForEach(BezierBadgeVariant.allCases, id: \.self) { variant in
+            Text(variant.rawValue).tag(variant)
+          }
+        }
+      }
+
+      Section("Label") {
+        TextField("Label", text: self.$labelText)
+      }
+
+      Section("Content") {
+        Toggle("Leading Icon", isOn: self.$hasLeadingIcon)
+      }
+
+      Section("Catalog") {
+        ScrollView(.vertical) {
+          VStack(alignment: .leading, spacing: 16) {
+            ForEach(BezierBadgeSize.allCases, id: \.self) { size in
+              VStack(alignment: .leading, spacing: 8) {
+                Text(size.rawValue)
+                  .font(.caption.weight(.semibold))
+                  .foregroundColor(.secondary)
+                self.row(size: size, leadingIcon: nil)
+                self.row(size: size, leadingIcon: Image(systemName: "plus"))
+              }
+            }
+          }
+          .padding(.vertical, 8)
+        }
+        .frame(height: 400)
+      }
+    }
+    .navigationTitle("Badge (SwiftUI)")
+  }
+
+  private func row(size: BezierBadgeSize, leadingIcon: Image?) -> some View {
+    ScrollView(.horizontal, showsIndicators: false) {
+      HStack(spacing: 8) {
+        ForEach(BezierBadgeVariant.allCases, id: \.self) { variant in
+          SUBezierBadge(size: size, variant: variant, label: "Badge", leadingIcon: leadingIcon)
+        }
+      }
+    }
+  }
+}
+
+struct BezierBadgeTestView_Previews: PreviewProvider {
+  static var previews: some View {
+    NavigationView {
+      BezierBadgeTestView()
+    }
+  }
+}

--- a/Examples/SwiftUIExample/SwiftUIExample/TestViews/BezierButtonTestView.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/TestViews/BezierButtonTestView.swift
@@ -1,0 +1,132 @@
+//
+//  BezierButtonTestView.swift
+//  SwiftUIExample
+//
+
+import SwiftUI
+import BezierSwift
+
+struct BezierButtonTestView: View {
+  @State private var size: BezierButtonSize = .medium
+  @State private var variant: BezierButtonVariant = .filled
+  @State private var semantic: BezierButtonSemantic = .primary
+  @State private var resizing: BezierButtonResizing = .hug
+  @State private var title: String = "Label"
+  @State private var hasLeadingIcon: Bool = false
+  @State private var hasTrailingIcon: Bool = false
+  @State private var isLoading: Bool = false
+  @State private var isEnabled: Bool = true
+  @State private var tapCount: Int = 0
+
+  var body: some View {
+    Form {
+      Section("Preview") {
+        VStack(spacing: 12) {
+          SUBezierButton(
+            size: self.size,
+            variant: self.variant,
+            semantic: self.semantic,
+            resizing: self.resizing,
+            title: self.title.isEmpty ? nil : self.title,
+            leadingIcon: self.hasLeadingIcon ? Image(systemName: "star.fill") : nil,
+            trailingIcon: self.hasTrailingIcon ? Image(systemName: "arrow.right") : nil,
+            isLoading: self.isLoading,
+            action: { self.tapCount += 1 }
+          )
+          .disabled(!self.isEnabled)
+
+          Text("Tapped: \(self.tapCount)")
+            .font(.caption)
+            .foregroundColor(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 8)
+      }
+
+      Section("Size") {
+        Picker("Size", selection: self.$size) {
+          ForEach(BezierButtonSize.allCases, id: \.self) { size in
+            Text(size.rawValue).tag(size)
+          }
+        }
+        .pickerStyle(.segmented)
+      }
+
+      Section("Variant") {
+        Picker("Variant", selection: self.$variant) {
+          ForEach(BezierButtonVariant.allCases, id: \.self) { variant in
+            Text(variant.rawValue).tag(variant)
+          }
+        }
+        .pickerStyle(.segmented)
+      }
+
+      Section("Semantic") {
+        Picker("Semantic", selection: self.$semantic) {
+          ForEach(BezierButtonSemantic.allCases, id: \.self) { semantic in
+            Text(semantic.rawValue).tag(semantic)
+          }
+        }
+        .pickerStyle(.segmented)
+      }
+
+      Section("Resizing") {
+        Picker("Resizing", selection: self.$resizing) {
+          ForEach(BezierButtonResizing.allCases, id: \.self) { resizing in
+            Text(resizing.rawValue).tag(resizing)
+          }
+        }
+        .pickerStyle(.segmented)
+      }
+
+      Section("Content") {
+        TextField("Title", text: self.$title)
+        Toggle("Leading Icon", isOn: self.$hasLeadingIcon)
+        Toggle("Trailing Icon", isOn: self.$hasTrailingIcon)
+      }
+
+      Section("State") {
+        Toggle("Enabled", isOn: self.$isEnabled)
+        Toggle("Loading", isOn: self.$isLoading)
+      }
+
+      Section("Catalog") {
+        ScrollView(.vertical) {
+          VStack(alignment: .leading, spacing: 16) {
+            ForEach(BezierButtonSize.allCases, id: \.self) { size in
+              VStack(alignment: .leading, spacing: 8) {
+                Text(size.rawValue)
+                  .font(.caption.weight(.semibold))
+                  .foregroundColor(.secondary)
+                ForEach(BezierButtonVariant.allCases, id: \.self) { variant in
+                  HStack(spacing: 8) {
+                    ForEach(BezierButtonSemantic.allCases, id: \.self) { semantic in
+                      SUBezierButton(
+                        size: size,
+                        variant: variant,
+                        semantic: semantic,
+                        title: "Label",
+                        action: {}
+                      )
+                    }
+                  }
+                }
+              }
+            }
+          }
+          .padding(.vertical, 8)
+        }
+        .frame(height: 400)
+      }
+    }
+    .navigationTitle("Button (SwiftUI)")
+  }
+}
+
+struct BezierButtonTestView_Previews: PreviewProvider {
+  static var previews: some View {
+    NavigationView {
+      BezierButtonTestView()
+    }
+  }
+}

--- a/Examples/SwiftUIExample/SwiftUIExample/TestViews/BezierButtonTestView.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/TestViews/BezierButtonTestView.swift
@@ -10,7 +10,6 @@ struct BezierButtonTestView: View {
   @State private var size: BezierButtonSize = .medium
   @State private var variant: BezierButtonVariant = .filled
   @State private var semantic: BezierButtonSemantic = .primary
-  @State private var resizing: BezierButtonResizing = .hug
   @State private var title: String = "Label"
   @State private var hasLeadingIcon: Bool = false
   @State private var hasTrailingIcon: Bool = false
@@ -26,7 +25,6 @@ struct BezierButtonTestView: View {
             size: self.size,
             variant: self.variant,
             semantic: self.semantic,
-            resizing: self.resizing,
             title: self.title.isEmpty ? nil : self.title,
             leadingIcon: self.hasLeadingIcon ? Image(systemName: "star.fill") : nil,
             trailingIcon: self.hasTrailingIcon ? Image(systemName: "arrow.right") : nil,
@@ -65,15 +63,6 @@ struct BezierButtonTestView: View {
         Picker("Semantic", selection: self.$semantic) {
           ForEach(BezierButtonSemantic.allCases, id: \.self) { semantic in
             Text(semantic.rawValue).tag(semantic)
-          }
-        }
-        .pickerStyle(.segmented)
-      }
-
-      Section("Resizing") {
-        Picker("Resizing", selection: self.$resizing) {
-          ForEach(BezierButtonResizing.allCases, id: \.self) { resizing in
-            Text(resizing.rawValue).tag(resizing)
           }
         }
         .pickerStyle(.segmented)

--- a/Examples/SwiftUIExample/SwiftUIExample/TestViews/BezierIconButtonTestView.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/TestViews/BezierIconButtonTestView.swift
@@ -1,0 +1,121 @@
+//
+//  BezierIconButtonTestView.swift
+//  SwiftUIExample
+//
+
+import SwiftUI
+import BezierSwift
+
+struct BezierIconButtonTestView: View {
+  private enum IconOption: String, CaseIterable, Identifiable {
+    case xmark
+    case plus
+    case trash
+    case ellipsis
+    case arrowRight = "arrow.right"
+
+    var id: String { self.rawValue }
+    var systemName: String { self.rawValue }
+    var label: String { self.rawValue }
+  }
+
+  @State private var size: BezierIconButtonSize = .medium
+  @State private var variant: BezierIconButtonVariant = .ghost
+  @State private var iconOption: IconOption = .xmark
+  @State private var isLoading: Bool = false
+  @State private var isEnabled: Bool = true
+  @State private var isActive: Bool = false
+  @State private var tapCount: Int = 0
+
+  var body: some View {
+    Form {
+      Section("Preview") {
+        VStack(spacing: 12) {
+          SUBezierIconButton(
+            size: self.size,
+            variant: self.variant,
+            icon: Image(systemName: self.iconOption.systemName),
+            isActive: self.isActive,
+            isLoading: self.isLoading,
+            action: { self.tapCount += 1 }
+          )
+          .disabled(!self.isEnabled)
+
+          Text("Tapped: \(self.tapCount)")
+            .font(.caption)
+            .foregroundColor(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 8)
+      }
+
+      Section("Size") {
+        Picker("Size", selection: self.$size) {
+          ForEach(BezierIconButtonSize.allCases, id: \.self) { size in
+            Text(size.rawValue).tag(size)
+          }
+        }
+        .pickerStyle(.segmented)
+      }
+
+      Section("Variant") {
+        Picker("Variant", selection: self.$variant) {
+          ForEach(BezierIconButtonVariant.allCases, id: \.self) { variant in
+            Text(variant.rawValue).tag(variant)
+          }
+        }
+        .pickerStyle(.segmented)
+      }
+
+      Section("Icon") {
+        Picker("Icon", selection: self.$iconOption) {
+          ForEach(IconOption.allCases) { option in
+            Text(option.label).tag(option)
+          }
+        }
+        .pickerStyle(.segmented)
+      }
+
+      Section("State") {
+        Toggle("Active", isOn: self.$isActive)
+        Toggle("Enabled", isOn: self.$isEnabled)
+        Toggle("Loading", isOn: self.$isLoading)
+      }
+
+      Section("Catalog") {
+        ScrollView(.vertical) {
+          VStack(alignment: .leading, spacing: 16) {
+            ForEach(BezierIconButtonSize.allCases, id: \.self) { size in
+              VStack(alignment: .leading, spacing: 8) {
+                Text(size.rawValue)
+                  .font(.caption.weight(.semibold))
+                  .foregroundColor(.secondary)
+                HStack(spacing: 8) {
+                  ForEach(BezierIconButtonVariant.allCases, id: \.self) { variant in
+                    SUBezierIconButton(
+                      size: size,
+                      variant: variant,
+                      icon: Image(systemName: "xmark"),
+                      action: {}
+                    )
+                  }
+                }
+              }
+            }
+          }
+          .padding(.vertical, 8)
+        }
+        .frame(height: 400)
+      }
+    }
+    .navigationTitle("IconButton (SwiftUI)")
+  }
+}
+
+struct BezierIconButtonTestView_Previews: PreviewProvider {
+  static var previews: some View {
+    NavigationView {
+      BezierIconButtonTestView()
+    }
+  }
+}

--- a/Examples/UIKitExample/UIKitExample.xcodeproj/project.pbxproj
+++ b/Examples/UIKitExample/UIKitExample.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		E28212242A4B31BD00018327 /* BezierSwift in Frameworks */ = {isa = PBXBuildFile; productRef = E28212232A4B31BD00018327 /* BezierSwift */; };
+		BB48761A2B11FE0200000002 /* BezierButtonTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB48761B2B11FE0200000002 /* BezierButtonTestViewController.swift */; };
 		E28212432A4B3C0900018327 /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28212422A4B3C0900018327 /* BaseViewController.swift */; };
 		A1B2C3E12A737BD700C99C9E /* BezierIconCatalogViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3E02A737BD700C99C9E /* BezierIconCatalogViewController.swift */; };
 		E2C2C3D32A4B2DE700A7E5E6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2C2C3D22A4B2DE700A7E5E6 /* AppDelegate.swift */; };
@@ -18,6 +19,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		BB48761B2B11FE0200000002 /* BezierButtonTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierButtonTestViewController.swift; sourceTree = "<group>"; };
 		E28212422A4B3C0900018327 /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
 		A1B2C3E02A737BD700C99C9E /* BezierIconCatalogViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierIconCatalogViewController.swift; sourceTree = "<group>"; };
 		E2C2C3CF2A4B2DE700A7E5E6 /* UIKitExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = UIKitExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -73,6 +75,7 @@
 				E2C2C3D62A4B2DE700A7E5E6 /* ViewController.swift */,
 				E28212422A4B3C0900018327 /* BaseViewController.swift */,
 				A1B2C3E02A737BD700C99C9E /* BezierIconCatalogViewController.swift */,
+				BB48761B2B11FE0200000002 /* BezierButtonTestViewController.swift */,
 				E2C2C3DB2A4B2DE800A7E5E6 /* Assets.xcassets */,
 				E2C2C3DD2A4B2DE800A7E5E6 /* LaunchScreen.storyboard */,
 				E2C2C3E02A4B2DE800A7E5E6 /* Info.plist */,
@@ -156,6 +159,7 @@
 				E2C2C3D72A4B2DE700A7E5E6 /* ViewController.swift in Sources */,
 				E28212432A4B3C0900018327 /* BaseViewController.swift in Sources */,
 				A1B2C3E12A737BD700C99C9E /* BezierIconCatalogViewController.swift in Sources */,
+				BB48761A2B11FE0200000002 /* BezierButtonTestViewController.swift in Sources */,
 				E2C2C3D32A4B2DE700A7E5E6 /* AppDelegate.swift in Sources */,
 				E2C2C3D52A4B2DE700A7E5E6 /* SceneDelegate.swift in Sources */,
 			);

--- a/Examples/UIKitExample/UIKitExample.xcodeproj/project.pbxproj
+++ b/Examples/UIKitExample/UIKitExample.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		E28212242A4B31BD00018327 /* BezierSwift in Frameworks */ = {isa = PBXBuildFile; productRef = E28212232A4B31BD00018327 /* BezierSwift */; };
 		BB48761A2B11FE0200000002 /* BezierButtonTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB48761B2B11FE0200000002 /* BezierButtonTestViewController.swift */; };
+		BB48761C2B11FE0200000004 /* BezierBadgeTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB48761D2B11FE0200000004 /* BezierBadgeTestViewController.swift */; };
 		E28212432A4B3C0900018327 /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28212422A4B3C0900018327 /* BaseViewController.swift */; };
 		A1B2C3E12A737BD700C99C9E /* BezierIconCatalogViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3E02A737BD700C99C9E /* BezierIconCatalogViewController.swift */; };
 		E2C2C3D32A4B2DE700A7E5E6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2C2C3D22A4B2DE700A7E5E6 /* AppDelegate.swift */; };
@@ -20,6 +21,7 @@
 
 /* Begin PBXFileReference section */
 		BB48761B2B11FE0200000002 /* BezierButtonTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierButtonTestViewController.swift; sourceTree = "<group>"; };
+		BB48761D2B11FE0200000004 /* BezierBadgeTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierBadgeTestViewController.swift; sourceTree = "<group>"; };
 		E28212422A4B3C0900018327 /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
 		A1B2C3E02A737BD700C99C9E /* BezierIconCatalogViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierIconCatalogViewController.swift; sourceTree = "<group>"; };
 		E2C2C3CF2A4B2DE700A7E5E6 /* UIKitExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = UIKitExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -76,6 +78,7 @@
 				E28212422A4B3C0900018327 /* BaseViewController.swift */,
 				A1B2C3E02A737BD700C99C9E /* BezierIconCatalogViewController.swift */,
 				BB48761B2B11FE0200000002 /* BezierButtonTestViewController.swift */,
+				BB48761D2B11FE0200000004 /* BezierBadgeTestViewController.swift */,
 				E2C2C3DB2A4B2DE800A7E5E6 /* Assets.xcassets */,
 				E2C2C3DD2A4B2DE800A7E5E6 /* LaunchScreen.storyboard */,
 				E2C2C3E02A4B2DE800A7E5E6 /* Info.plist */,
@@ -160,6 +163,7 @@
 				E28212432A4B3C0900018327 /* BaseViewController.swift in Sources */,
 				A1B2C3E12A737BD700C99C9E /* BezierIconCatalogViewController.swift in Sources */,
 				BB48761A2B11FE0200000002 /* BezierButtonTestViewController.swift in Sources */,
+				BB48761C2B11FE0200000004 /* BezierBadgeTestViewController.swift in Sources */,
 				E2C2C3D32A4B2DE700A7E5E6 /* AppDelegate.swift in Sources */,
 				E2C2C3D52A4B2DE700A7E5E6 /* SceneDelegate.swift in Sources */,
 			);

--- a/Examples/UIKitExample/UIKitExample.xcodeproj/project.pbxproj
+++ b/Examples/UIKitExample/UIKitExample.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		E28212242A4B31BD00018327 /* BezierSwift in Frameworks */ = {isa = PBXBuildFile; productRef = E28212232A4B31BD00018327 /* BezierSwift */; };
 		BB48761A2B11FE0200000002 /* BezierButtonTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB48761B2B11FE0200000002 /* BezierButtonTestViewController.swift */; };
+		BB48761C2B11FE0200000003 /* BezierIconButtonTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB48761D2B11FE0200000003 /* BezierIconButtonTestViewController.swift */; };
 		BB48761C2B11FE0200000004 /* BezierBadgeTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB48761D2B11FE0200000004 /* BezierBadgeTestViewController.swift */; };
 		E28212432A4B3C0900018327 /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28212422A4B3C0900018327 /* BaseViewController.swift */; };
 		A1B2C3E12A737BD700C99C9E /* BezierIconCatalogViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3E02A737BD700C99C9E /* BezierIconCatalogViewController.swift */; };
@@ -21,6 +22,7 @@
 
 /* Begin PBXFileReference section */
 		BB48761B2B11FE0200000002 /* BezierButtonTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierButtonTestViewController.swift; sourceTree = "<group>"; };
+		BB48761D2B11FE0200000003 /* BezierIconButtonTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierIconButtonTestViewController.swift; sourceTree = "<group>"; };
 		BB48761D2B11FE0200000004 /* BezierBadgeTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierBadgeTestViewController.swift; sourceTree = "<group>"; };
 		E28212422A4B3C0900018327 /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
 		A1B2C3E02A737BD700C99C9E /* BezierIconCatalogViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierIconCatalogViewController.swift; sourceTree = "<group>"; };
@@ -78,6 +80,7 @@
 				E28212422A4B3C0900018327 /* BaseViewController.swift */,
 				A1B2C3E02A737BD700C99C9E /* BezierIconCatalogViewController.swift */,
 				BB48761B2B11FE0200000002 /* BezierButtonTestViewController.swift */,
+				BB48761D2B11FE0200000003 /* BezierIconButtonTestViewController.swift */,
 				BB48761D2B11FE0200000004 /* BezierBadgeTestViewController.swift */,
 				E2C2C3DB2A4B2DE800A7E5E6 /* Assets.xcassets */,
 				E2C2C3DD2A4B2DE800A7E5E6 /* LaunchScreen.storyboard */,
@@ -163,6 +166,7 @@
 				E28212432A4B3C0900018327 /* BaseViewController.swift in Sources */,
 				A1B2C3E12A737BD700C99C9E /* BezierIconCatalogViewController.swift in Sources */,
 				BB48761A2B11FE0200000002 /* BezierButtonTestViewController.swift in Sources */,
+				BB48761C2B11FE0200000003 /* BezierIconButtonTestViewController.swift in Sources */,
 				BB48761C2B11FE0200000004 /* BezierBadgeTestViewController.swift in Sources */,
 				E2C2C3D32A4B2DE700A7E5E6 /* AppDelegate.swift in Sources */,
 				E2C2C3D52A4B2DE700A7E5E6 /* SceneDelegate.swift in Sources */,

--- a/Examples/UIKitExample/UIKitExample/BezierBadgeTestViewController.swift
+++ b/Examples/UIKitExample/UIKitExample/BezierBadgeTestViewController.swift
@@ -1,0 +1,275 @@
+//
+//  BezierBadgeTestViewController.swift
+//  UIKitExample
+//
+
+import UIKit
+import BezierSwift
+
+final class BezierBadgeTestViewController: BaseViewController {
+  // MARK: - State
+
+  private var size: BezierBadgeSize = .small
+  private var variant: BezierBadgeVariant = .default
+  private var labelText: String = "Badge"
+  private var hasLeadingIcon: Bool = false
+
+  // MARK: - Subviews
+
+  private let scrollView: UIScrollView = {
+    let scrollView = UIScrollView()
+    scrollView.translatesAutoresizingMaskIntoConstraints = false
+    return scrollView
+  }()
+
+  private let containerStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    stackView.spacing = 16
+    stackView.alignment = .fill
+    stackView.layoutMargins = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+    stackView.isLayoutMarginsRelativeArrangement = true
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    return stackView
+  }()
+
+  private let previewContainer: UIView = {
+    let view = UIView()
+    view.backgroundColor = .secondarySystemBackground
+    view.layer.cornerRadius = 12
+    view.translatesAutoresizingMaskIntoConstraints = false
+    return view
+  }()
+
+  private lazy var previewBadge: BezierBadge = {
+    let badge = BezierBadge(size: self.size, variant: self.variant)
+    badge.label = self.labelText
+    return badge
+  }()
+
+  private lazy var sizeControl: UISegmentedControl = {
+    let control = UISegmentedControl(items: BezierBadgeSize.allCases.map { $0.rawValue })
+    control.selectedSegmentIndex = BezierBadgeSize.allCases.firstIndex(of: self.size) ?? 0
+    control.addTarget(self, action: #selector(self.onSizeChanged(_:)), for: .valueChanged)
+    return control
+  }()
+
+  private lazy var variantPicker: UIPickerView = {
+    let picker = UIPickerView()
+    picker.dataSource = self
+    picker.delegate = self
+    picker.selectRow(BezierBadgeVariant.allCases.firstIndex(of: self.variant) ?? 0, inComponent: 0, animated: false)
+    return picker
+  }()
+
+  private lazy var labelTextField: UITextField = {
+    let field = UITextField()
+    field.borderStyle = .roundedRect
+    field.text = self.labelText
+    field.placeholder = "Label"
+    field.autocorrectionType = .no
+    field.autocapitalizationType = .none
+    field.addTarget(self, action: #selector(self.onLabelChanged(_:)), for: .editingChanged)
+    return field
+  }()
+
+  private lazy var leadingIconSwitch: UISwitch = {
+    let toggle = UISwitch()
+    toggle.isOn = self.hasLeadingIcon
+    toggle.addTarget(self, action: #selector(self.onLeadingIconToggled(_:)), for: .valueChanged)
+    return toggle
+  }()
+
+  // MARK: - Lifecycle
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    self.title = "Badge (UIKit)"
+    self.view.backgroundColor = .systemBackground
+    self.setUpLayout()
+    self.refreshPreview()
+  }
+
+  private func setUpLayout() {
+    self.view.addSubview(self.scrollView)
+    self.scrollView.addSubview(self.containerStackView)
+
+    NSLayoutConstraint.activate([
+      self.scrollView.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor),
+      self.scrollView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+      self.scrollView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+      self.scrollView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor),
+
+      self.containerStackView.topAnchor.constraint(equalTo: self.scrollView.contentLayoutGuide.topAnchor),
+      self.containerStackView.leadingAnchor.constraint(equalTo: self.scrollView.contentLayoutGuide.leadingAnchor),
+      self.containerStackView.trailingAnchor.constraint(equalTo: self.scrollView.contentLayoutGuide.trailingAnchor),
+      self.containerStackView.bottomAnchor.constraint(equalTo: self.scrollView.contentLayoutGuide.bottomAnchor),
+      self.containerStackView.widthAnchor.constraint(equalTo: self.scrollView.frameLayoutGuide.widthAnchor),
+    ])
+
+    self.containerStackView.addArrangedSubview(self.makeSectionTitle("Preview"))
+    self.containerStackView.addArrangedSubview(self.makePreviewSection())
+    self.containerStackView.addArrangedSubview(self.makeSectionTitle("Size"))
+    self.containerStackView.addArrangedSubview(self.sizeControl)
+    self.containerStackView.addArrangedSubview(self.makeSectionTitle("Variant"))
+    self.containerStackView.addArrangedSubview(self.variantPicker)
+    self.containerStackView.addArrangedSubview(self.makeSectionTitle("Label"))
+    self.containerStackView.addArrangedSubview(self.labelTextField)
+    self.containerStackView.addArrangedSubview(self.makeSectionTitle("Content"))
+    self.containerStackView.addArrangedSubview(self.makeRow(label: "Leading Icon", control: self.leadingIconSwitch))
+    self.containerStackView.addArrangedSubview(self.makeSectionTitle("Catalog"))
+    self.containerStackView.addArrangedSubview(self.makeCatalogSection())
+  }
+
+  private func makeCatalogSection() -> UIView {
+    let container = UIStackView()
+    container.axis = .vertical
+    container.spacing = 16
+    container.alignment = .fill
+
+    for size in BezierBadgeSize.allCases {
+      let title = UILabel()
+      title.text = size.rawValue
+      title.font = .preferredFont(forTextStyle: .footnote)
+      title.textColor = .secondaryLabel
+      container.addArrangedSubview(title)
+
+      container.addArrangedSubview(self.makeCatalogRow(size: size, leadingIcon: nil))
+      container.addArrangedSubview(self.makeCatalogRow(size: size, leadingIcon: UIImage(systemName: "plus")))
+    }
+    return container
+  }
+
+  private func makeCatalogRow(size: BezierBadgeSize, leadingIcon: UIImage?) -> UIView {
+    let scroll = UIScrollView()
+    scroll.showsHorizontalScrollIndicator = false
+    scroll.translatesAutoresizingMaskIntoConstraints = false
+
+    let row = UIStackView()
+    row.axis = .horizontal
+    row.spacing = 8
+    row.alignment = .center
+    row.translatesAutoresizingMaskIntoConstraints = false
+
+    for variant in BezierBadgeVariant.allCases {
+      let badge = BezierBadge(size: size, variant: variant)
+      badge.label = "Badge"
+      badge.leadingIcon = leadingIcon
+      row.addArrangedSubview(badge)
+    }
+
+    scroll.addSubview(row)
+    NSLayoutConstraint.activate([
+      row.topAnchor.constraint(equalTo: scroll.contentLayoutGuide.topAnchor),
+      row.leadingAnchor.constraint(equalTo: scroll.contentLayoutGuide.leadingAnchor),
+      row.trailingAnchor.constraint(equalTo: scroll.contentLayoutGuide.trailingAnchor),
+      row.bottomAnchor.constraint(equalTo: scroll.contentLayoutGuide.bottomAnchor),
+      row.heightAnchor.constraint(equalTo: scroll.frameLayoutGuide.heightAnchor),
+      scroll.heightAnchor.constraint(equalToConstant: size.height + 4),
+    ])
+    return scroll
+  }
+
+  private func makePreviewSection() -> UIView {
+    let stack = UIStackView()
+    stack.axis = .vertical
+    stack.alignment = .center
+    stack.spacing = 12
+    stack.isLayoutMarginsRelativeArrangement = true
+    stack.layoutMargins = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+    stack.translatesAutoresizingMaskIntoConstraints = false
+
+    self.previewContainer.addSubview(stack)
+    NSLayoutConstraint.activate([
+      stack.topAnchor.constraint(equalTo: self.previewContainer.topAnchor),
+      stack.leadingAnchor.constraint(equalTo: self.previewContainer.leadingAnchor),
+      stack.trailingAnchor.constraint(equalTo: self.previewContainer.trailingAnchor),
+      stack.bottomAnchor.constraint(equalTo: self.previewContainer.bottomAnchor),
+    ])
+
+    let badgeRow = UIView()
+    badgeRow.translatesAutoresizingMaskIntoConstraints = false
+    badgeRow.addSubview(self.previewBadge)
+    NSLayoutConstraint.activate([
+      badgeRow.leadingAnchor.constraint(equalTo: self.previewBadge.leadingAnchor),
+      badgeRow.trailingAnchor.constraint(equalTo: self.previewBadge.trailingAnchor),
+      badgeRow.topAnchor.constraint(equalTo: self.previewBadge.topAnchor),
+      badgeRow.bottomAnchor.constraint(equalTo: self.previewBadge.bottomAnchor),
+    ])
+
+    stack.addArrangedSubview(badgeRow)
+    return self.previewContainer
+  }
+
+  private func makeSectionTitle(_ text: String) -> UILabel {
+    let label = UILabel()
+    label.text = text
+    label.font = .preferredFont(forTextStyle: .footnote)
+    label.textColor = .secondaryLabel
+    return label
+  }
+
+  private func makeRow(label text: String, control: UIView) -> UIView {
+    let container = UIStackView()
+    container.axis = .horizontal
+    container.distribution = .fill
+    container.alignment = .center
+    container.spacing = 12
+
+    let titleLabel = UILabel()
+    titleLabel.text = text
+    titleLabel.font = .preferredFont(forTextStyle: .body)
+
+    container.addArrangedSubview(titleLabel)
+    let spacer = UIView()
+    spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+    container.addArrangedSubview(spacer)
+    container.addArrangedSubview(control)
+    return container
+  }
+
+  // MARK: - Refresh
+
+  private func refreshPreview() {
+    self.previewBadge.size = self.size
+    self.previewBadge.variant = self.variant
+    self.previewBadge.label = self.labelText.isEmpty ? nil : self.labelText
+    self.previewBadge.leadingIcon = self.hasLeadingIcon ? UIImage(systemName: "plus") : nil
+  }
+
+  // MARK: - Actions
+
+  @objc private func onSizeChanged(_ sender: UISegmentedControl) {
+    self.size = BezierBadgeSize.allCases[sender.selectedSegmentIndex]
+    self.refreshPreview()
+  }
+
+  @objc private func onLabelChanged(_ sender: UITextField) {
+    self.labelText = sender.text ?? ""
+    self.refreshPreview()
+  }
+
+  @objc private func onLeadingIconToggled(_ sender: UISwitch) {
+    self.hasLeadingIcon = sender.isOn
+    self.refreshPreview()
+  }
+}
+
+// MARK: - UIPickerView
+
+extension BezierBadgeTestViewController: UIPickerViewDataSource, UIPickerViewDelegate {
+  func numberOfComponents(in pickerView: UIPickerView) -> Int { 1 }
+
+  func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+    BezierBadgeVariant.allCases.count
+  }
+
+  func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
+    BezierBadgeVariant.allCases[row].rawValue
+  }
+
+  func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+    self.variant = BezierBadgeVariant.allCases[row]
+    self.refreshPreview()
+  }
+}

--- a/Examples/UIKitExample/UIKitExample/BezierButtonTestViewController.swift
+++ b/Examples/UIKitExample/UIKitExample/BezierButtonTestViewController.swift
@@ -1,0 +1,325 @@
+//
+//  BezierButtonTestViewController.swift
+//  UIKitExample
+//
+
+import UIKit
+import BezierSwift
+
+final class BezierButtonTestViewController: BaseViewController {
+  // MARK: - State
+
+  private var size: BezierButtonSize = .medium
+  private var variant: BezierButtonVariant = .filled
+  private var semantic: BezierButtonSemantic = .primary
+  private var resizing: BezierButtonResizing = .hug
+  private var titleText: String = "Label"
+  private var hasLeadingIcon: Bool = false
+  private var hasTrailingIcon: Bool = false
+  private var isLoadingState: Bool = false
+  private var isEnabledState: Bool = true
+  private var tapCount: Int = 0
+
+  // MARK: - Subviews
+
+  private let scrollView: UIScrollView = {
+    let scrollView = UIScrollView()
+    scrollView.translatesAutoresizingMaskIntoConstraints = false
+    return scrollView
+  }()
+
+  private let containerStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    stackView.spacing = 20
+    stackView.alignment = .fill
+    stackView.layoutMargins = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+    stackView.isLayoutMarginsRelativeArrangement = true
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    return stackView
+  }()
+
+  private let previewContainer: UIView = {
+    let view = UIView()
+    view.backgroundColor = .secondarySystemBackground
+    view.layer.cornerRadius = 12
+    view.translatesAutoresizingMaskIntoConstraints = false
+    return view
+  }()
+
+  private lazy var previewButton: BezierButton = {
+    let button = BezierButton(
+      size: self.size,
+      variant: self.variant,
+      semantic: self.semantic,
+      resizing: self.resizing
+    )
+    button.title = self.titleText
+    button.addTarget(self, action: #selector(self.onPreviewTapped), for: .touchUpInside)
+    return button
+  }()
+
+  private let tapCountLabel: UILabel = {
+    let label = UILabel()
+    label.font = .preferredFont(forTextStyle: .caption1)
+    label.textColor = .secondaryLabel
+    label.textAlignment = .center
+    label.translatesAutoresizingMaskIntoConstraints = false
+    return label
+  }()
+
+  private lazy var sizeControl: UISegmentedControl = {
+    let control = UISegmentedControl(items: BezierButtonSize.allCases.map { $0.rawValue })
+    control.selectedSegmentIndex = BezierButtonSize.allCases.firstIndex(of: self.size) ?? 0
+    control.addTarget(self, action: #selector(self.onSizeChanged(_:)), for: .valueChanged)
+    return control
+  }()
+
+  private lazy var variantControl: UISegmentedControl = {
+    let control = UISegmentedControl(items: BezierButtonVariant.allCases.map { $0.rawValue })
+    control.selectedSegmentIndex = BezierButtonVariant.allCases.firstIndex(of: self.variant) ?? 0
+    control.addTarget(self, action: #selector(self.onVariantChanged(_:)), for: .valueChanged)
+    return control
+  }()
+
+  private lazy var semanticControl: UISegmentedControl = {
+    let control = UISegmentedControl(items: BezierButtonSemantic.allCases.map { $0.rawValue })
+    control.selectedSegmentIndex = BezierButtonSemantic.allCases.firstIndex(of: self.semantic) ?? 0
+    control.addTarget(self, action: #selector(self.onSemanticChanged(_:)), for: .valueChanged)
+    return control
+  }()
+
+  private lazy var resizingControl: UISegmentedControl = {
+    let control = UISegmentedControl(items: BezierButtonResizing.allCases.map { $0.rawValue })
+    control.selectedSegmentIndex = BezierButtonResizing.allCases.firstIndex(of: self.resizing) ?? 0
+    control.addTarget(self, action: #selector(self.onResizingChanged(_:)), for: .valueChanged)
+    return control
+  }()
+
+  private lazy var titleField: UITextField = {
+    let field = UITextField()
+    field.borderStyle = .roundedRect
+    field.text = self.titleText
+    field.placeholder = "Title"
+    field.autocorrectionType = .no
+    field.autocapitalizationType = .none
+    field.addTarget(self, action: #selector(self.onTitleChanged(_:)), for: .editingChanged)
+    return field
+  }()
+
+  private lazy var leadingIconSwitch: UISwitch = {
+    let toggle = UISwitch()
+    toggle.isOn = self.hasLeadingIcon
+    toggle.addTarget(self, action: #selector(self.onLeadingIconToggled(_:)), for: .valueChanged)
+    return toggle
+  }()
+
+  private lazy var trailingIconSwitch: UISwitch = {
+    let toggle = UISwitch()
+    toggle.isOn = self.hasTrailingIcon
+    toggle.addTarget(self, action: #selector(self.onTrailingIconToggled(_:)), for: .valueChanged)
+    return toggle
+  }()
+
+  private lazy var enabledSwitch: UISwitch = {
+    let toggle = UISwitch()
+    toggle.isOn = self.isEnabledState
+    toggle.addTarget(self, action: #selector(self.onEnabledToggled(_:)), for: .valueChanged)
+    return toggle
+  }()
+
+  private lazy var loadingSwitch: UISwitch = {
+    let toggle = UISwitch()
+    toggle.isOn = self.isLoadingState
+    toggle.addTarget(self, action: #selector(self.onLoadingToggled(_:)), for: .valueChanged)
+    return toggle
+  }()
+
+  // MARK: - Lifecycle
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    self.title = "Button (UIKit)"
+    self.view.backgroundColor = .systemBackground
+    self.setUpLayout()
+    self.refreshPreview()
+    self.refreshTapCount()
+  }
+
+  // MARK: - Layout
+
+  private func setUpLayout() {
+    self.view.addSubview(self.scrollView)
+    self.scrollView.addSubview(self.containerStackView)
+
+    NSLayoutConstraint.activate([
+      self.scrollView.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor),
+      self.scrollView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+      self.scrollView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+      self.scrollView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor),
+
+      self.containerStackView.topAnchor.constraint(equalTo: self.scrollView.contentLayoutGuide.topAnchor),
+      self.containerStackView.leadingAnchor.constraint(equalTo: self.scrollView.contentLayoutGuide.leadingAnchor),
+      self.containerStackView.trailingAnchor.constraint(equalTo: self.scrollView.contentLayoutGuide.trailingAnchor),
+      self.containerStackView.bottomAnchor.constraint(equalTo: self.scrollView.contentLayoutGuide.bottomAnchor),
+      self.containerStackView.widthAnchor.constraint(equalTo: self.scrollView.frameLayoutGuide.widthAnchor),
+    ])
+
+    self.containerStackView.addArrangedSubview(self.makeSectionTitle("Preview"))
+    self.containerStackView.addArrangedSubview(self.makePreviewSection())
+    self.containerStackView.addArrangedSubview(self.makeSectionTitle("Size"))
+    self.containerStackView.addArrangedSubview(self.sizeControl)
+    self.containerStackView.addArrangedSubview(self.makeSectionTitle("Variant"))
+    self.containerStackView.addArrangedSubview(self.variantControl)
+    self.containerStackView.addArrangedSubview(self.makeSectionTitle("Semantic"))
+    self.containerStackView.addArrangedSubview(self.semanticControl)
+    self.containerStackView.addArrangedSubview(self.makeSectionTitle("Resizing"))
+    self.containerStackView.addArrangedSubview(self.resizingControl)
+    self.containerStackView.addArrangedSubview(self.makeSectionTitle("Title"))
+    self.containerStackView.addArrangedSubview(self.titleField)
+    self.containerStackView.addArrangedSubview(self.makeRow(label: "Leading Icon", control: self.leadingIconSwitch))
+    self.containerStackView.addArrangedSubview(self.makeRow(label: "Trailing Icon", control: self.trailingIconSwitch))
+    self.containerStackView.addArrangedSubview(self.makeRow(label: "Enabled", control: self.enabledSwitch))
+    self.containerStackView.addArrangedSubview(self.makeRow(label: "Loading", control: self.loadingSwitch))
+  }
+
+  private func makePreviewSection() -> UIView {
+    let containerStackView = UIStackView()
+    containerStackView.axis = .vertical
+    containerStackView.spacing = 8
+    containerStackView.alignment = .center
+    containerStackView.isLayoutMarginsRelativeArrangement = true
+    containerStackView.layoutMargins = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+    containerStackView.translatesAutoresizingMaskIntoConstraints = false
+
+    self.previewContainer.addSubview(containerStackView)
+    NSLayoutConstraint.activate([
+      containerStackView.topAnchor.constraint(equalTo: self.previewContainer.topAnchor),
+      containerStackView.leadingAnchor.constraint(equalTo: self.previewContainer.leadingAnchor),
+      containerStackView.trailingAnchor.constraint(equalTo: self.previewContainer.trailingAnchor),
+      containerStackView.bottomAnchor.constraint(equalTo: self.previewContainer.bottomAnchor),
+    ])
+
+    let buttonRow = UIView()
+    buttonRow.translatesAutoresizingMaskIntoConstraints = false
+    buttonRow.addSubview(self.previewButton)
+    NSLayoutConstraint.activate([
+      buttonRow.leadingAnchor.constraint(equalTo: self.previewButton.leadingAnchor),
+      buttonRow.trailingAnchor.constraint(equalTo: self.previewButton.trailingAnchor),
+      buttonRow.topAnchor.constraint(equalTo: self.previewButton.topAnchor),
+      buttonRow.bottomAnchor.constraint(equalTo: self.previewButton.bottomAnchor),
+    ])
+
+    let fillRow = UIView()
+    fillRow.translatesAutoresizingMaskIntoConstraints = false
+    fillRow.heightAnchor.constraint(greaterThanOrEqualToConstant: 0).isActive = true
+
+    containerStackView.addArrangedSubview(buttonRow)
+    containerStackView.addArrangedSubview(self.tapCountLabel)
+
+    return self.previewContainer
+  }
+
+  private func makeSectionTitle(_ text: String) -> UILabel {
+    let label = UILabel()
+    label.text = text
+    label.font = .preferredFont(forTextStyle: .footnote)
+    label.textColor = .secondaryLabel
+    return label
+  }
+
+  private func makeRow(label text: String, control: UIView) -> UIView {
+    let container = UIStackView()
+    container.axis = .horizontal
+    container.distribution = .fill
+    container.alignment = .center
+    container.spacing = 12
+
+    let titleLabel = UILabel()
+    titleLabel.text = text
+    titleLabel.font = .preferredFont(forTextStyle: .body)
+
+    container.addArrangedSubview(titleLabel)
+    let spacer = UIView()
+    spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+    container.addArrangedSubview(spacer)
+    container.addArrangedSubview(control)
+    return container
+  }
+
+  // MARK: - Refresh
+
+  private func refreshPreview() {
+    self.previewButton.size = self.size
+    self.previewButton.variant = self.variant
+    self.previewButton.semantic = self.semantic
+    self.previewButton.resizing = self.resizing
+    self.previewButton.title = self.titleText.isEmpty ? nil : self.titleText
+    self.previewButton.leadingIcon = self.hasLeadingIcon ? UIImage(systemName: "star.fill") : nil
+    self.previewButton.trailingIcon = self.hasTrailingIcon ? UIImage(systemName: "arrow.right") : nil
+    self.previewButton.isLoading = self.isLoadingState
+    self.previewButton.isEnabled = self.isEnabledState
+
+    if self.resizing == .fill {
+      self.previewButton.setContentHuggingPriority(.defaultLow, for: .horizontal)
+    } else {
+      self.previewButton.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+    }
+  }
+
+  private func refreshTapCount() {
+    self.tapCountLabel.text = "Tapped: \(self.tapCount)"
+  }
+
+  // MARK: - Actions
+
+  @objc private func onPreviewTapped() {
+    self.tapCount += 1
+    self.refreshTapCount()
+  }
+
+  @objc private func onSizeChanged(_ sender: UISegmentedControl) {
+    self.size = BezierButtonSize.allCases[sender.selectedSegmentIndex]
+    self.refreshPreview()
+  }
+
+  @objc private func onVariantChanged(_ sender: UISegmentedControl) {
+    self.variant = BezierButtonVariant.allCases[sender.selectedSegmentIndex]
+    self.refreshPreview()
+  }
+
+  @objc private func onSemanticChanged(_ sender: UISegmentedControl) {
+    self.semantic = BezierButtonSemantic.allCases[sender.selectedSegmentIndex]
+    self.refreshPreview()
+  }
+
+  @objc private func onResizingChanged(_ sender: UISegmentedControl) {
+    self.resizing = BezierButtonResizing.allCases[sender.selectedSegmentIndex]
+    self.refreshPreview()
+  }
+
+  @objc private func onTitleChanged(_ sender: UITextField) {
+    self.titleText = sender.text ?? ""
+    self.refreshPreview()
+  }
+
+  @objc private func onLeadingIconToggled(_ sender: UISwitch) {
+    self.hasLeadingIcon = sender.isOn
+    self.refreshPreview()
+  }
+
+  @objc private func onTrailingIconToggled(_ sender: UISwitch) {
+    self.hasTrailingIcon = sender.isOn
+    self.refreshPreview()
+  }
+
+  @objc private func onEnabledToggled(_ sender: UISwitch) {
+    self.isEnabledState = sender.isOn
+    self.refreshPreview()
+  }
+
+  @objc private func onLoadingToggled(_ sender: UISwitch) {
+    self.isLoadingState = sender.isOn
+    self.refreshPreview()
+  }
+}

--- a/Examples/UIKitExample/UIKitExample/BezierButtonTestViewController.swift
+++ b/Examples/UIKitExample/UIKitExample/BezierButtonTestViewController.swift
@@ -12,7 +12,6 @@ final class BezierButtonTestViewController: BaseViewController {
   private var size: BezierButtonSize = .medium
   private var variant: BezierButtonVariant = .filled
   private var semantic: BezierButtonSemantic = .primary
-  private var resizing: BezierButtonResizing = .hug
   private var titleText: String = "Label"
   private var hasLeadingIcon: Bool = false
   private var hasTrailingIcon: Bool = false
@@ -51,8 +50,7 @@ final class BezierButtonTestViewController: BaseViewController {
     let button = BezierButton(
       size: self.size,
       variant: self.variant,
-      semantic: self.semantic,
-      resizing: self.resizing
+      semantic: self.semantic
     )
     button.title = self.titleText
     button.addTarget(self, action: #selector(self.onPreviewTapped), for: .touchUpInside)
@@ -86,13 +84,6 @@ final class BezierButtonTestViewController: BaseViewController {
     let control = UISegmentedControl(items: BezierButtonSemantic.allCases.map { $0.rawValue })
     control.selectedSegmentIndex = BezierButtonSemantic.allCases.firstIndex(of: self.semantic) ?? 0
     control.addTarget(self, action: #selector(self.onSemanticChanged(_:)), for: .valueChanged)
-    return control
-  }()
-
-  private lazy var resizingControl: UISegmentedControl = {
-    let control = UISegmentedControl(items: BezierButtonResizing.allCases.map { $0.rawValue })
-    control.selectedSegmentIndex = BezierButtonResizing.allCases.firstIndex(of: self.resizing) ?? 0
-    control.addTarget(self, action: #selector(self.onResizingChanged(_:)), for: .valueChanged)
     return control
   }()
 
@@ -173,8 +164,6 @@ final class BezierButtonTestViewController: BaseViewController {
     self.containerStackView.addArrangedSubview(self.variantControl)
     self.containerStackView.addArrangedSubview(self.makeSectionTitle("Semantic"))
     self.containerStackView.addArrangedSubview(self.semanticControl)
-    self.containerStackView.addArrangedSubview(self.makeSectionTitle("Resizing"))
-    self.containerStackView.addArrangedSubview(self.resizingControl)
     self.containerStackView.addArrangedSubview(self.makeSectionTitle("Title"))
     self.containerStackView.addArrangedSubview(self.titleField)
     self.containerStackView.addArrangedSubview(self.makeRow(label: "Leading Icon", control: self.leadingIconSwitch))
@@ -253,18 +242,11 @@ final class BezierButtonTestViewController: BaseViewController {
     self.previewButton.size = self.size
     self.previewButton.variant = self.variant
     self.previewButton.semantic = self.semantic
-    self.previewButton.resizing = self.resizing
     self.previewButton.title = self.titleText.isEmpty ? nil : self.titleText
     self.previewButton.leadingIcon = self.hasLeadingIcon ? UIImage(systemName: "star.fill") : nil
     self.previewButton.trailingIcon = self.hasTrailingIcon ? UIImage(systemName: "arrow.right") : nil
     self.previewButton.isLoading = self.isLoadingState
     self.previewButton.isEnabled = self.isEnabledState
-
-    if self.resizing == .fill {
-      self.previewButton.setContentHuggingPriority(.defaultLow, for: .horizontal)
-    } else {
-      self.previewButton.setContentHuggingPriority(.defaultHigh, for: .horizontal)
-    }
   }
 
   private func refreshTapCount() {
@@ -290,11 +272,6 @@ final class BezierButtonTestViewController: BaseViewController {
 
   @objc private func onSemanticChanged(_ sender: UISegmentedControl) {
     self.semantic = BezierButtonSemantic.allCases[sender.selectedSegmentIndex]
-    self.refreshPreview()
-  }
-
-  @objc private func onResizingChanged(_ sender: UISegmentedControl) {
-    self.resizing = BezierButtonResizing.allCases[sender.selectedSegmentIndex]
     self.refreshPreview()
   }
 

--- a/Examples/UIKitExample/UIKitExample/BezierIconButtonTestViewController.swift
+++ b/Examples/UIKitExample/UIKitExample/BezierIconButtonTestViewController.swift
@@ -1,0 +1,284 @@
+//
+//  BezierIconButtonTestViewController.swift
+//  UIKitExample
+//
+
+import UIKit
+import BezierSwift
+
+final class BezierIconButtonTestViewController: BaseViewController {
+  // MARK: - Icon Options
+
+  private enum IconOption: Int, CaseIterable {
+    case xmark
+    case plus
+    case trash
+    case ellipsis
+    case arrowRight
+
+    var systemName: String {
+      switch self {
+      case .xmark:      return "xmark"
+      case .plus:       return "plus"
+      case .trash:      return "trash"
+      case .ellipsis:   return "ellipsis"
+      case .arrowRight: return "arrow.right"
+      }
+    }
+
+    var label: String { self.systemName }
+  }
+
+  // MARK: - State
+
+  private var size: BezierIconButtonSize = .medium
+  private var variant: BezierIconButtonVariant = .ghost
+  private var iconOption: IconOption = .xmark
+  private var isLoadingState: Bool = false
+  private var isEnabledState: Bool = true
+  private var isActiveState: Bool = false
+  private var tapCount: Int = 0
+
+  // MARK: - Subviews
+
+  private let scrollView: UIScrollView = {
+    let scrollView = UIScrollView()
+    scrollView.translatesAutoresizingMaskIntoConstraints = false
+    return scrollView
+  }()
+
+  private let containerStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    stackView.spacing = 20
+    stackView.alignment = .fill
+    stackView.layoutMargins = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+    stackView.isLayoutMarginsRelativeArrangement = true
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    return stackView
+  }()
+
+  private let previewContainer: UIView = {
+    let view = UIView()
+    view.backgroundColor = .secondarySystemBackground
+    view.layer.cornerRadius = 12
+    view.translatesAutoresizingMaskIntoConstraints = false
+    return view
+  }()
+
+  private lazy var previewButton: BezierIconButton = {
+    let button = BezierIconButton(
+      size: self.size,
+      variant: self.variant
+    )
+    button.icon = UIImage(systemName: self.iconOption.systemName)
+    button.addTarget(self, action: #selector(self.onPreviewTapped), for: .touchUpInside)
+    return button
+  }()
+
+  private let tapCountLabel: UILabel = {
+    let label = UILabel()
+    label.font = .preferredFont(forTextStyle: .caption1)
+    label.textColor = .secondaryLabel
+    label.textAlignment = .center
+    label.translatesAutoresizingMaskIntoConstraints = false
+    return label
+  }()
+
+  private lazy var sizeControl: UISegmentedControl = {
+    let control = UISegmentedControl(items: BezierIconButtonSize.allCases.map { $0.rawValue })
+    control.selectedSegmentIndex = BezierIconButtonSize.allCases.firstIndex(of: self.size) ?? 0
+    control.addTarget(self, action: #selector(self.onSizeChanged(_:)), for: .valueChanged)
+    return control
+  }()
+
+  private lazy var variantControl: UISegmentedControl = {
+    let control = UISegmentedControl(items: BezierIconButtonVariant.allCases.map { $0.rawValue })
+    control.selectedSegmentIndex = BezierIconButtonVariant.allCases.firstIndex(of: self.variant) ?? 0
+    control.addTarget(self, action: #selector(self.onVariantChanged(_:)), for: .valueChanged)
+    return control
+  }()
+
+  private lazy var iconControl: UISegmentedControl = {
+    let control = UISegmentedControl(items: IconOption.allCases.map { $0.label })
+    control.selectedSegmentIndex = self.iconOption.rawValue
+    control.addTarget(self, action: #selector(self.onIconChanged(_:)), for: .valueChanged)
+    return control
+  }()
+
+  private lazy var enabledSwitch: UISwitch = {
+    let toggle = UISwitch()
+    toggle.isOn = self.isEnabledState
+    toggle.addTarget(self, action: #selector(self.onEnabledToggled(_:)), for: .valueChanged)
+    return toggle
+  }()
+
+  private lazy var loadingSwitch: UISwitch = {
+    let toggle = UISwitch()
+    toggle.isOn = self.isLoadingState
+    toggle.addTarget(self, action: #selector(self.onLoadingToggled(_:)), for: .valueChanged)
+    return toggle
+  }()
+
+  private lazy var activeSwitch: UISwitch = {
+    let toggle = UISwitch()
+    toggle.isOn = self.isActiveState
+    toggle.addTarget(self, action: #selector(self.onActiveToggled(_:)), for: .valueChanged)
+    return toggle
+  }()
+
+  // MARK: - Lifecycle
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    self.title = "IconButton (UIKit)"
+    self.view.backgroundColor = .systemBackground
+    self.setUpLayout()
+    self.refreshPreview()
+    self.refreshTapCount()
+  }
+
+  // MARK: - Layout
+
+  private func setUpLayout() {
+    self.view.addSubview(self.scrollView)
+    self.scrollView.addSubview(self.containerStackView)
+
+    NSLayoutConstraint.activate([
+      self.scrollView.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor),
+      self.scrollView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+      self.scrollView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+      self.scrollView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor),
+
+      self.containerStackView.topAnchor.constraint(equalTo: self.scrollView.contentLayoutGuide.topAnchor),
+      self.containerStackView.leadingAnchor.constraint(equalTo: self.scrollView.contentLayoutGuide.leadingAnchor),
+      self.containerStackView.trailingAnchor.constraint(equalTo: self.scrollView.contentLayoutGuide.trailingAnchor),
+      self.containerStackView.bottomAnchor.constraint(equalTo: self.scrollView.contentLayoutGuide.bottomAnchor),
+      self.containerStackView.widthAnchor.constraint(equalTo: self.scrollView.frameLayoutGuide.widthAnchor),
+    ])
+
+    self.containerStackView.addArrangedSubview(self.makeSectionTitle("Preview"))
+    self.containerStackView.addArrangedSubview(self.makePreviewSection())
+    self.containerStackView.addArrangedSubview(self.makeSectionTitle("Size"))
+    self.containerStackView.addArrangedSubview(self.sizeControl)
+    self.containerStackView.addArrangedSubview(self.makeSectionTitle("Variant"))
+    self.containerStackView.addArrangedSubview(self.variantControl)
+    self.containerStackView.addArrangedSubview(self.makeSectionTitle("Icon"))
+    self.containerStackView.addArrangedSubview(self.iconControl)
+    self.containerStackView.addArrangedSubview(self.makeRow(label: "Active", control: self.activeSwitch))
+    self.containerStackView.addArrangedSubview(self.makeRow(label: "Enabled", control: self.enabledSwitch))
+    self.containerStackView.addArrangedSubview(self.makeRow(label: "Loading", control: self.loadingSwitch))
+  }
+
+  private func makePreviewSection() -> UIView {
+    let containerStackView = UIStackView()
+    containerStackView.axis = .vertical
+    containerStackView.spacing = 8
+    containerStackView.alignment = .center
+    containerStackView.isLayoutMarginsRelativeArrangement = true
+    containerStackView.layoutMargins = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+    containerStackView.translatesAutoresizingMaskIntoConstraints = false
+
+    self.previewContainer.addSubview(containerStackView)
+    NSLayoutConstraint.activate([
+      containerStackView.topAnchor.constraint(equalTo: self.previewContainer.topAnchor),
+      containerStackView.leadingAnchor.constraint(equalTo: self.previewContainer.leadingAnchor),
+      containerStackView.trailingAnchor.constraint(equalTo: self.previewContainer.trailingAnchor),
+      containerStackView.bottomAnchor.constraint(equalTo: self.previewContainer.bottomAnchor),
+    ])
+
+    let buttonRow = UIView()
+    buttonRow.translatesAutoresizingMaskIntoConstraints = false
+    buttonRow.addSubview(self.previewButton)
+    NSLayoutConstraint.activate([
+      buttonRow.leadingAnchor.constraint(equalTo: self.previewButton.leadingAnchor),
+      buttonRow.trailingAnchor.constraint(equalTo: self.previewButton.trailingAnchor),
+      buttonRow.topAnchor.constraint(equalTo: self.previewButton.topAnchor),
+      buttonRow.bottomAnchor.constraint(equalTo: self.previewButton.bottomAnchor),
+    ])
+
+    containerStackView.addArrangedSubview(buttonRow)
+    containerStackView.addArrangedSubview(self.tapCountLabel)
+
+    return self.previewContainer
+  }
+
+  private func makeSectionTitle(_ text: String) -> UILabel {
+    let label = UILabel()
+    label.text = text
+    label.font = .preferredFont(forTextStyle: .footnote)
+    label.textColor = .secondaryLabel
+    return label
+  }
+
+  private func makeRow(label text: String, control: UIView) -> UIView {
+    let container = UIStackView()
+    container.axis = .horizontal
+    container.distribution = .fill
+    container.alignment = .center
+    container.spacing = 12
+
+    let titleLabel = UILabel()
+    titleLabel.text = text
+    titleLabel.font = .preferredFont(forTextStyle: .body)
+
+    container.addArrangedSubview(titleLabel)
+    let spacer = UIView()
+    spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+    container.addArrangedSubview(spacer)
+    container.addArrangedSubview(control)
+    return container
+  }
+
+  // MARK: - Refresh
+
+  private func refreshPreview() {
+    self.previewButton.size = self.size
+    self.previewButton.variant = self.variant
+    self.previewButton.icon = UIImage(systemName: self.iconOption.systemName)
+    self.previewButton.isLoading = self.isLoadingState
+    self.previewButton.isEnabled = self.isEnabledState
+    self.previewButton.isSelected = self.isActiveState
+  }
+
+  private func refreshTapCount() {
+    self.tapCountLabel.text = "Tapped: \(self.tapCount)"
+  }
+
+  // MARK: - Actions
+
+  @objc private func onPreviewTapped() {
+    self.tapCount += 1
+    self.refreshTapCount()
+  }
+
+  @objc private func onSizeChanged(_ sender: UISegmentedControl) {
+    self.size = BezierIconButtonSize.allCases[sender.selectedSegmentIndex]
+    self.refreshPreview()
+  }
+
+  @objc private func onVariantChanged(_ sender: UISegmentedControl) {
+    self.variant = BezierIconButtonVariant.allCases[sender.selectedSegmentIndex]
+    self.refreshPreview()
+  }
+
+  @objc private func onIconChanged(_ sender: UISegmentedControl) {
+    self.iconOption = IconOption.allCases[sender.selectedSegmentIndex]
+    self.refreshPreview()
+  }
+
+  @objc private func onEnabledToggled(_ sender: UISwitch) {
+    self.isEnabledState = sender.isOn
+    self.refreshPreview()
+  }
+
+  @objc private func onLoadingToggled(_ sender: UISwitch) {
+    self.isLoadingState = sender.isOn
+    self.refreshPreview()
+  }
+
+  @objc private func onActiveToggled(_ sender: UISwitch) {
+    self.isActiveState = sender.isOn
+    self.refreshPreview()
+  }
+}

--- a/Examples/UIKitExample/UIKitExample/ViewController.swift
+++ b/Examples/UIKitExample/UIKitExample/ViewController.swift
@@ -12,11 +12,13 @@ final class ViewController: BaseViewController {
   private enum Row: Int, CaseIterable {
     case bezierIconCatalog
     case bezierButton
+    case bezierBadge
 
     var title: String {
       switch self {
       case .bezierIconCatalog: return "Bezier Icon Catalog"
       case .bezierButton: return "Button"
+      case .bezierBadge:  return "Badge"
       }
     }
   }
@@ -66,6 +68,8 @@ extension ViewController: UITableViewDataSource, UITableViewDelegate {
       self.navigationController?.pushViewController(BezierIconCatalogViewController(), animated: true)
     case .bezierButton:
       self.navigationController?.pushViewController(BezierButtonTestViewController(), animated: true)
+    case .bezierBadge:
+      self.navigationController?.pushViewController(BezierBadgeTestViewController(), animated: true)
     }
   }
 }

--- a/Examples/UIKitExample/UIKitExample/ViewController.swift
+++ b/Examples/UIKitExample/UIKitExample/ViewController.swift
@@ -11,10 +11,12 @@ import BezierSwift
 final class ViewController: BaseViewController {
   private enum Row: Int, CaseIterable {
     case bezierIconCatalog
+    case bezierButton
 
     var title: String {
       switch self {
       case .bezierIconCatalog: return "Bezier Icon Catalog"
+      case .bezierButton: return "Button"
       }
     }
   }
@@ -62,6 +64,8 @@ extension ViewController: UITableViewDataSource, UITableViewDelegate {
     switch row {
     case .bezierIconCatalog:
       self.navigationController?.pushViewController(BezierIconCatalogViewController(), animated: true)
+    case .bezierButton:
+      self.navigationController?.pushViewController(BezierButtonTestViewController(), animated: true)
     }
   }
 }

--- a/Examples/UIKitExample/UIKitExample/ViewController.swift
+++ b/Examples/UIKitExample/UIKitExample/ViewController.swift
@@ -12,13 +12,15 @@ final class ViewController: BaseViewController {
   private enum Row: Int, CaseIterable {
     case bezierIconCatalog
     case bezierButton
+    case bezierIconButton
     case bezierBadge
 
     var title: String {
       switch self {
       case .bezierIconCatalog: return "Bezier Icon Catalog"
-      case .bezierButton: return "Button"
-      case .bezierBadge:  return "Badge"
+      case .bezierButton:      return "Button"
+      case .bezierIconButton:  return "IconButton"
+      case .bezierBadge:       return "Badge"
       }
     }
   }
@@ -68,6 +70,8 @@ extension ViewController: UITableViewDataSource, UITableViewDelegate {
       self.navigationController?.pushViewController(BezierIconCatalogViewController(), animated: true)
     case .bezierButton:
       self.navigationController?.pushViewController(BezierButtonTestViewController(), animated: true)
+    case .bezierIconButton:
+      self.navigationController?.pushViewController(BezierIconButtonTestViewController(), animated: true)
     case .bezierBadge:
       self.navigationController?.pushViewController(BezierBadgeTestViewController(), animated: true)
     }

--- a/Sources/BezierSwift/MasterComponent/BezierBadge/BezierBadge.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBadge/BezierBadge.swift
@@ -1,0 +1,220 @@
+//
+//  BezierBadge.swift
+//  BezierSwift
+//
+
+import UIKit
+
+public final class BezierBadge: UIView, BezierComponentable {
+  // MARK: - BezierComponentable
+
+  public var colorTheme: BezierColorTheme { .systemBezierColorTheme() }
+  public var componentTheme: BezierComponentTheme = .normal {
+    didSet { self.refreshAppearance() }
+  }
+
+  // MARK: - Public Properties
+
+  public var size: BezierBadgeSize = .small {
+    didSet { if oldValue != self.size { self.refreshLayout() } }
+  }
+
+  public var variant: BezierBadgeVariant = .default {
+    didSet { if oldValue != self.variant { self.refreshAppearance() } }
+  }
+
+  public var label: String? {
+    didSet { if oldValue != self.label { self.refreshContent() } }
+  }
+
+  public var leadingIcon: UIImage? {
+    didSet { self.refreshContent() }
+  }
+
+  // MARK: - Subviews
+
+  private let contentStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .horizontal
+    stackView.alignment = .center
+    stackView.distribution = .fill
+    stackView.spacing = 0
+    stackView.isUserInteractionEnabled = false
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    return stackView
+  }()
+
+  private let leadingImageView: UIImageView = {
+    let imageView = UIImageView()
+    imageView.contentMode = .scaleAspectFit
+    imageView.isHidden = true
+    imageView.translatesAutoresizingMaskIntoConstraints = false
+    return imageView
+  }()
+
+  private let titleLabel: BezierBadgePaddedLabel = {
+    let label = BezierBadgePaddedLabel()
+    label.numberOfLines = 1
+    label.textAlignment = .center
+    return label
+  }()
+
+  // MARK: - Layout Constraints
+
+  private var heightConstraint: NSLayoutConstraint?
+  private var leadingImageWidthConstraint: NSLayoutConstraint?
+  private var leadingImageHeightConstraint: NSLayoutConstraint?
+  private var contentLeadingConstraint: NSLayoutConstraint?
+  private var contentTrailingConstraint: NSLayoutConstraint?
+
+  // MARK: - Init
+
+  public init(
+    size: BezierBadgeSize = .small,
+    variant: BezierBadgeVariant = .default
+  ) {
+    self.size = size
+    self.variant = variant
+    super.init(frame: .zero)
+    self.setUp()
+  }
+
+  public required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    self.setUp()
+  }
+
+  // MARK: - Setup
+
+  private func setUp() {
+    self.translatesAutoresizingMaskIntoConstraints = false
+    self.isUserInteractionEnabled = false
+
+    self.layer.masksToBounds = true
+    self.layer.borderWidth = 0
+
+    self.contentStackView.addArrangedSubview(self.leadingImageView)
+    self.contentStackView.addArrangedSubview(self.titleLabel)
+
+    self.addSubview(self.contentStackView)
+
+    let heightConstraint = self.heightAnchor.constraint(equalToConstant: self.size.height)
+    let leadingImageWidthConstraint = self.leadingImageView.widthAnchor.constraint(equalToConstant: self.size.iconLength)
+    let leadingImageHeightConstraint = self.leadingImageView.heightAnchor.constraint(equalToConstant: self.size.iconLength)
+    let contentLeadingConstraint = self.contentStackView.leadingAnchor.constraint(
+      equalTo: self.leadingAnchor,
+      constant: self.size.horizontalPadding
+    )
+    let contentTrailingConstraint = self.contentStackView.trailingAnchor.constraint(
+      equalTo: self.trailingAnchor,
+      constant: -self.size.horizontalPadding
+    )
+
+    NSLayoutConstraint.activate([
+      heightConstraint,
+      leadingImageWidthConstraint,
+      leadingImageHeightConstraint,
+      contentLeadingConstraint,
+      contentTrailingConstraint,
+      self.contentStackView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+    ])
+
+    self.heightConstraint = heightConstraint
+    self.leadingImageWidthConstraint = leadingImageWidthConstraint
+    self.leadingImageHeightConstraint = leadingImageHeightConstraint
+    self.contentLeadingConstraint = contentLeadingConstraint
+    self.contentTrailingConstraint = contentTrailingConstraint
+
+    self.refreshLayout()
+    self.refreshAppearance()
+  }
+
+  // MARK: - Layout Update
+
+  public override func layoutSubviews() {
+    super.layoutSubviews()
+    self.layer.cornerRadius = self.bounds.height / 2
+  }
+
+  public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    self.refreshAppearance()
+  }
+
+  // MARK: - Refresh
+
+  private func refreshLayout() {
+    self.heightConstraint?.constant = self.size.height
+    self.leadingImageWidthConstraint?.constant = self.size.iconLength
+    self.leadingImageHeightConstraint?.constant = self.size.iconLength
+    self.contentLeadingConstraint?.constant = self.size.horizontalPadding
+    self.contentTrailingConstraint?.constant = -self.size.horizontalPadding
+
+    self.titleLabel.contentInsets = UIEdgeInsets(
+      top: 0,
+      left: self.size.textHorizontalPadding,
+      bottom: 0,
+      right: self.size.textHorizontalPadding
+    )
+
+    self.refreshContent()
+    self.invalidateIntrinsicContentSize()
+    self.setNeedsLayout()
+  }
+
+  private func refreshContent() {
+    self.leadingImageView.image = self.leadingIcon?.withRenderingMode(.alwaysTemplate)
+    self.leadingImageView.isHidden = self.leadingIcon == nil
+
+    let foregroundToken = self.variant.foregroundToken
+    self.leadingImageView.tintColor = foregroundToken.palette(self)
+
+    if let label = self.label, !label.isEmpty {
+      // TYPO-MIGRATION: Figma raw 값을 직접 사용. 추후 BTSemanticToken으로 통합 예정 (BezierBadgeSpec.swift 참고).
+      let font = UIFont.systemFont(
+        ofSize: self.size.fontSize,
+        weight: self.size.fontWeight.uiKitWeight
+      )
+      self.titleLabel.attributedText = label.applyBezierFont(
+        height: self.size.lineHeight,
+        font: font,
+        color: foregroundToken.palette(self),
+        letterSpacing: self.size.letterSpacing,
+        alignment: .center
+      )
+      self.titleLabel.isHidden = false
+    } else {
+      self.titleLabel.attributedText = nil
+      self.titleLabel.isHidden = true
+    }
+  }
+
+  private func refreshAppearance() {
+    self.backgroundColor = self.variant.backgroundToken.palette(self)
+    self.leadingImageView.tintColor = self.variant.foregroundToken.palette(self)
+    self.refreshContent()
+  }
+}
+
+// MARK: - Padded Label
+
+final class BezierBadgePaddedLabel: UILabel {
+  var contentInsets: UIEdgeInsets = .zero {
+    didSet {
+      self.invalidateIntrinsicContentSize()
+      self.setNeedsDisplay()
+    }
+  }
+
+  override func drawText(in rect: CGRect) {
+    super.drawText(in: rect.inset(by: self.contentInsets))
+  }
+
+  override var intrinsicContentSize: CGSize {
+    let size = super.intrinsicContentSize
+    return CGSize(
+      width: size.width + self.contentInsets.left + self.contentInsets.right,
+      height: size.height + self.contentInsets.top + self.contentInsets.bottom
+    )
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierBadge/BezierBadgeSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBadge/BezierBadgeSpec.swift
@@ -1,0 +1,141 @@
+//
+//  BezierBadgeSpec.swift
+//  BezierSwift
+//
+
+import CoreGraphics
+import UIKit
+
+public enum BezierBadgeSize: String, CaseIterable {
+  case xsmall
+  case small
+  case medium
+  case large
+
+  public var height: CGFloat {
+    switch self {
+    case .xsmall: return 18
+    case .small:  return 22
+    case .medium: return 22
+    case .large:  return 26
+    }
+  }
+
+  public var horizontalPadding: CGFloat { 4 }
+
+  public var textHorizontalPadding: CGFloat { 4 }
+
+  public var verticalPadding: CGFloat {
+    switch self {
+    case .xsmall: return 1
+    case .small:  return 2
+    case .medium: return 2
+    case .large:  return 3
+    }
+  }
+
+  public var iconLength: CGFloat { 16 }
+
+  // MARK: - Typography (Figma raw, see SPEC §3)
+  //
+  // TYPO-MIGRATION: Figma component description의 `📌 TYPO-MIGRATION: Text Style
+  // 미적용` 상태에 따라 raw 값을 직접 사용한다. xsmall/small은 BTSemanticToken
+  // (.textXSmall / .textMedium)과 정합하지만, medium/large는 lineHeight·letterSpacing
+  // 이 token(.textLarge / .textXLarge)과 일치하지 않으므로 token을 우회하고 raw 값을
+  // 적용한다. 디자인팀의 로컬 typography 스타일 일괄 바인딩이 끝나 raw가 token과
+  // 정합되면 BTSemanticToken 기반 API로 통합 예정.
+
+  public var fontSize: CGFloat {
+    switch self {
+    case .xsmall: return 12
+    case .small:  return 14
+    case .medium: return 15
+    case .large:  return 16
+    }
+  }
+
+  public var lineHeight: CGFloat {
+    switch self {
+    case .xsmall: return 16
+    case .small:  return 18
+    case .medium: return 18
+    case .large:  return 20
+    }
+  }
+
+  public var letterSpacing: CGFloat {
+    switch self {
+    case .xsmall, .small, .medium: return 0
+    case .large: return -0.1
+    }
+  }
+
+  public var fontWeight: BTFontWeight { .regular }
+
+  /// SwiftUI `.lineSpacing` modifier에 전달할 값. UIFont의 line height와 spec의
+  /// lineHeight 차이를 보정한다.
+  public var lineSpacing: CGFloat {
+    let font = UIFont.systemFont(ofSize: self.fontSize, weight: self.fontWeight.uiKitWeight)
+    return max(0, self.lineHeight - font.lineHeight)
+  }
+
+  /// 상·하 line-box 보정을 균등하게 적용하기 위한 vertical padding.
+  public var verticalLineSpacing: CGFloat { self.lineSpacing / 2 }
+}
+
+public enum BezierBadgeVariant: String, CaseIterable {
+  case `default`
+  case monochromeLight
+  case monochromeDark
+  case blue
+  case cobalt
+  case teal
+  case green
+  case olive
+  case pink
+  case navy
+  case yellow
+  case orange
+  case red
+  case purple
+}
+
+extension BezierBadgeVariant {
+  public var backgroundToken: BCSemanticToken {
+    switch self {
+    case .default:         return .fillNeutralLight
+    case .monochromeLight: return .fillNeutralLight
+    case .monochromeDark:  return .fillNeutralHeavier
+    case .blue:            return .fillAccentBlueHeavy
+    case .cobalt:          return .fillAccentCobaltHeavy
+    case .teal:            return .fillAccentTealHeavy
+    case .green:           return .fillAccentGreenHeavy
+    case .olive:           return .fillAccentOliveHeavy
+    case .pink:            return .fillAccentPinkHeavy
+    case .navy:            return .fillAccentNavyHeavy
+    case .yellow:          return .fillAccentYellowHeavy
+    case .orange:          return .fillAccentOrangeHeavy
+    case .red:             return .fillAccentRedHeavy
+    case .purple:          return .fillAccentPurpleHeavy
+    }
+  }
+
+  public var foregroundToken: BCSemanticToken {
+    switch self {
+    case .default:         return .textNeutral
+    case .monochromeLight: return .textNeutralLighter
+    case .monochromeDark:  return .textAbsoluteWhite
+    case .blue:            return .textAccentBlue
+    case .cobalt:          return .textAccentCobalt
+    case .teal:            return .textAccentTeal
+    case .green:           return .textAccentGreen
+    case .olive:           return .textAccentOlive
+    case .pink:            return .textAccentPink
+    case .navy:            return .textAccentNavy
+    case .yellow:          return .textAccentYellow
+    case .orange:          return .textAccentOrange
+    case .red:             return .textAccentRed
+    case .purple:          return .textAccentPurple
+    }
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierBadge/SPEC.md
+++ b/Sources/BezierSwift/MasterComponent/BezierBadge/SPEC.md
@@ -1,0 +1,175 @@
+# BezierBadge Spec
+
+> Figma: [🚧 Mobile Components — Badge](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=1729-170)
+> Design spec doc: [bezier-v3/component-spec/Badge-spec.md](https://github.com/channel-io/design-team/blob/main/docs/bezier-v3/component-spec/Badge-spec.md)
+
+목록·카드 UI에서 항목의 상태나 속성을 색상과 텍스트로 즉각 전달하는 인라인 레이블.
+
+- **모양**: Capsule (radius/32 = 32pt, 실제 높이가 32 미만이므로 capsule 형태로 렌더링)
+- **읽기 전용**: Badge는 항상 읽기 전용. 사용자가 제거할 수 있다면 Tag를 사용한다.
+- **인터랙션 없음**: state property 없음 (default/pressed/active/disabled 분기 없음)
+
+---
+
+## 1. Component Properties
+
+Figma 컴포넌트가 정의하는 property와 옵션은 다음이 전부다.
+
+| Property | 값 | 비고 |
+|---|---|---|
+| **Size** | `xsmall` / `small` / `medium` / `large` | 4단계 |
+| **Color** | `default` / `monochrome-light` / `monochrome-dark` / `blue` / `cobalt` / `teal` / `green` / `olive` / `pink` / `navy` / `yellow` / `orange` / `red` / `purple` | 14가지 |
+| **hasIcon** | `true` / `false` | 옵션. true 시 leading icon 표시 |
+| **iconSource** | slot (ReactNode) | leading icon 본체. `hasIcon = true`일 때 렌더. 사이즈 16×16 |
+| **label** | string | 디자인 시스템 콘텐츠 (placeholder default 없음). Figma의 `"Badge"`는 컴포넌트 preview용 placeholder이며 API default가 아님 |
+
+총 instance: `4 size × 14 color = 56개` (Figma 컴포넌트 인스턴스 수와 일치)
+
+---
+
+## 2. Size 별 Spec
+
+| Size | Height | Horizontal Padding | Vertical Padding | Text Horizontal Padding (BadgeText 내부) | Icon Length |
+|---|---|---|---|---|---|
+| `xsmall` | 18pt | 4pt | 1pt | 4pt | 16pt |
+| `small`  | 22pt | 4pt | 2pt | 4pt | 16pt |
+| `medium` | 22pt | 4pt | 2pt | 4pt | 16pt |
+| `large`  | 26pt | 4pt | 3pt | 4pt | 16pt |
+
+- **Corner radius**: `radius/32 = 32pt`. height < 32 이므로 capsule 형태로 보임.
+- **Min width**: container `justify-center`이며 padding 외 최소 폭 제약 없음. xsmall은 `min-h-[16px]` (Figma container에 직접 지정).
+- **Layout**: `flex items-center justify-center` — leading icon → BadgeText 순. content gap 0 (BadgeText가 자체 horizontal padding으로 간격을 만든다).
+
+---
+
+## 3. Size 별 Typography
+
+> 📌 **TYPO-MIGRATION** (Figma description 인용): Text Style 미적용 — 로컬 타이포 스타일 등록 시 일괄 바인딩 예정. Figma는 raw value 직접 지정 상태.
+
+| Size | Font Size | Line Height | Letter Spacing | Font Family |
+|---|---|---|---|---|
+| `xsmall` | 12pt | 16pt | 0 | `text/font-family` (Inter) |
+| `small`  | 14pt | 18pt | 0 | `label/font-family` (Inter) |
+| `medium` | 15pt | 18pt | 0 | `label/font-family` (Inter) |
+| `large`  | 16pt | 20pt | -0.1pt (`text/letter-spacing/tight`) | `font-family/sans-kr` (Inter) |
+
+- Weight: 전부 regular (400).
+- Italic: 전부 not-italic.
+
+---
+
+## 4. Color 별 컬러 토큰
+
+### Background
+
+| Variant | Figma Variable | Raw |
+|---|---|---|
+| `default` | `color/fill/neutral/light` | `#0000000D` (rgba(0,0,0,0.05)) |
+| `monochrome-light` | `color/fill/neutral/light` | `#0000000D` |
+| `monochrome-dark` | `color/fill/neutral/heavier` | `#00000066` (rgba(0,0,0,0.4)) |
+| `blue` | `color/fill/accent/blue/heavy` | `#6157EA33` |
+| `cobalt` | `color/fill/accent/cobalt/heavy` | `#3292E333` |
+| `teal` | `color/fill/accent/teal/heavy` | `#09B2AC33` |
+| `green` | `color/fill/accent/green/heavy` | `#20AB5533` |
+| `olive` | `color/fill/accent/olive/heavy` | `#A9B11033` |
+| `pink` | `color/fill/accent/pink/heavy` | `#D64BB533` |
+| `navy` | `color/fill/accent/navy/heavy` | `#424FAB33` |
+| `yellow` | `color/fill/accent/yellow/heavy` | `#EDAE0D33` |
+| `orange` | `color/fill/accent/orange/heavy` | `#E67F2B33` |
+| `red` | `color/fill/accent/red/heavy` | `#E1535D33` |
+| `purple` | `color/fill/accent/purple/heavy` | `#8E57E733` |
+
+### Foreground (text & icon)
+
+| Variant | Figma Variable | Raw |
+|---|---|---|
+| `default` | `color/text/neutral` | `#000000D9` (rgba(0,0,0,0.85)) |
+| `monochrome-light` | `color/text/neutral/lighter` | `#00000066` |
+| `monochrome-dark` | `color/text/absolute/white` | `#FFFFFF` |
+| `blue` | `color/text/accent/blue` | `#6157EA` |
+| `cobalt` | `color/text/accent/cobalt` | `#3292E3` |
+| `teal` | `color/text/accent/teal` | `#09B2AC` |
+| `green` | `color/text/accent/green` | `#20AB55` |
+| `olive` | `color/text/accent/olive` | `#A9B110` |
+| `pink` | `color/text/accent/pink` | `#D64BB5` |
+| `navy` | `color/text/accent/navy` | `#424FAB` |
+| `yellow` | `color/text/accent/yellow` | `#EDAE0D` |
+| `orange` | `color/text/accent/orange` | `#E67F2B` |
+| `red` | `color/text/accent/red` | `#E1535D` |
+| `purple` | `color/text/accent/purple` | `#8E57E7` |
+
+---
+
+## 5. State
+
+해당 없음. Badge는 항상 읽기 전용이며 default/pressed/active/disabled/loading state property가 존재하지 않는다.
+
+---
+
+## 6. 디자이너 가이드라인 (Figma component description 인용)
+
+- **상태 의미**: `green`=성공·활성 / `red`=오류·긴급 / `orange`=경고 / `blue`=정보·진행 / `monochrome-light`=비활성·초안
+- **읽기 전용**: 사용자가 제거할 수 있으면 Tag 사용. Badge는 항상 읽기 전용.
+
+---
+
+## 7. 매핑되는 코드 심볼
+
+| 정의 | 파일 |
+|---|---|
+| UIKit 구현 | `BezierBadge.swift` |
+| SwiftUI 구현 | `SUBezierBadge.swift` |
+| Size / Variant enum | `BezierBadgeSpec.swift` |
+| 색상 토큰 (semantic) | `Sources/BezierSwift/Foundation/Color/V3/BCSemanticToken.swift` |
+| 타이포 토큰 (semantic) | `Sources/BezierSwift/Foundation/Typography/V3/BTSemanticToken.swift` |
+
+> ⚠️ **Typography 매핑 정책 (TYPO-MIGRATION 진행 중 잠정 매핑)**: Figma component description의 `📌 TYPO-MIGRATION: Text Style 미적용 — 로컬 타이포 스타일 등록 시 일괄 바인딩 예정`에 따라, Figma는 현재 raw value를 직접 박아놓은 상태다.
+>
+> **현재 정책**: Figma SSOT를 우선시한다. `BTSemanticToken`의 case 중 Figma raw와 정확히 일치하는 것이 있더라도 일관성을 위해 **모든 size에서 raw 값을 직접 사용**한다. 일치하지 않는 medium/large는 token이 아닌 raw로 처리.
+>
+> | Size | Figma raw (FS/LH/LS) | 가장 가까운 token (참고용) | Token 정합성 |
+> |---|---|---|---|
+> | xsmall | 12 / 16 / 0 | `.textXSmall(.regular)` (12 / 16 / 0) | ✅ 일치 (참고) |
+> | small | 14 / 18 / 0 | `.textMedium(.regular)` (14 / 18 / 0) | ✅ 일치 (참고) |
+> | medium | 15 / 18 / 0 | `.textLarge(.regular)` (15 / 20 / -0.1) | ⚠️ lineHeight·spacing 불일치 |
+> | large | 16 / 20 / -0.1 | `.textXLarge(.regular)` (16 / 24 / -0.1) | ⚠️ lineHeight 불일치 |
+>
+> **TODO**: 디자인팀의 TYPO-MIGRATION (로컬 typography style 일괄 바인딩) 완료 후 raw 값과 token이 정합되면 `BTSemanticToken` 기반 API로 통합 예정.
+
+---
+
+## 8. Variant 매트릭스
+
+총 instance: `4 size × 14 color = 56개`
+
+```text
+Size=xsmall, Color=default          = 1729:2
+Size=xsmall, Color=monochrome-light = 1729:41
+Size=xsmall, Color=monochrome-dark  = 1729:38
+Size=xsmall, Color=blue             = 1729:5
+Size=xsmall, Color=cobalt           = 1729:8
+Size=xsmall, Color=teal             = 1729:11
+Size=xsmall, Color=green            = 1729:14
+Size=xsmall, Color=olive            = 1729:17
+Size=xsmall, Color=pink             = 1729:20
+Size=xsmall, Color=navy             = 1729:23
+Size=xsmall, Color=yellow           = 1729:26
+Size=xsmall, Color=orange           = 1729:29
+Size=xsmall, Color=red              = 1729:32
+Size=xsmall, Color=purple           = 1729:35
+
+Size=small, Color=default           = 1729:44
+... (각 색상별 14 instance, 동일 패턴)
+Size=small, Color=monochrome-light  = 1729:83
+Size=small, Color=monochrome-dark   = 1729:80
+
+Size=medium, Color=default          = 1729:86
+... (각 색상별 14 instance, 동일 패턴)
+Size=medium, Color=monochrome-light = 1729:125
+Size=medium, Color=monochrome-dark  = 1729:122
+
+Size=large, Color=default           = 1729:128
+... (각 색상별 14 instance, 동일 패턴)
+Size=large, Color=monochrome-light  = 1729:167
+Size=large, Color=monochrome-dark   = 1729:164
+```

--- a/Sources/BezierSwift/MasterComponent/BezierBadge/SUBezierBadge.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBadge/SUBezierBadge.swift
@@ -1,0 +1,93 @@
+//
+//  SUBezierBadge.swift
+//  BezierSwift
+//
+
+import SwiftUI
+
+public struct SUBezierBadge: View, Themeable {
+  private let size: BezierBadgeSize
+  private let variant: BezierBadgeVariant
+  private let label: String?
+  private let leadingIcon: Image?
+
+  @Environment(\.colorScheme) public var colorScheme
+
+  public init(
+    size: BezierBadgeSize = .small,
+    variant: BezierBadgeVariant = .default,
+    label: String? = nil,
+    leadingIcon: Image? = nil
+  ) {
+    self.size = size
+    self.variant = variant
+    self.label = label
+    self.leadingIcon = leadingIcon
+  }
+
+  public var body: some View {
+    HStack(spacing: 0) {
+      if let leadingIcon = self.leadingIcon {
+        self.iconView(leadingIcon)
+      }
+      if let label = self.label, !label.isEmpty {
+        // TYPO-MIGRATION: Figma raw 값을 직접 사용. 추후 BTSemanticToken으로 통합 예정 (BezierBadgeSpec.swift 참고).
+        Text(label)
+          .font(.system(size: self.size.fontSize, weight: self.size.fontWeight.swiftUIWeight))
+          .tracking(self.size.letterSpacing)
+          .lineSpacing(self.size.lineSpacing)
+          .padding(.vertical, self.size.verticalLineSpacing)
+          .foregroundColor(self.palette(self.variant.foregroundToken))
+          .padding(.horizontal, self.size.textHorizontalPadding)
+          .fixedSize(horizontal: true, vertical: false)
+      }
+    }
+    .padding(.horizontal, self.size.horizontalPadding)
+    .frame(minHeight: self.size.height, maxHeight: self.size.height)
+    .background(Capsule().fill(self.palette(self.variant.backgroundToken)))
+    .clipShape(Capsule())
+  }
+
+  private func iconView(_ image: Image) -> some View {
+    image
+      .renderingMode(.template)
+      .resizable()
+      .scaledToFit()
+      .frame(width: self.size.iconLength, height: self.size.iconLength)
+      .foregroundColor(self.palette(self.variant.foregroundToken))
+  }
+}
+
+struct SUBezierBadge_Previews: PreviewProvider {
+  static var previews: some View {
+    ScrollView {
+      VStack(alignment: .leading, spacing: 20) {
+        ForEach(BezierBadgeSize.allCases, id: \.self) { size in
+          VStack(alignment: .leading, spacing: 8) {
+            Text(size.rawValue)
+              .font(.caption.weight(.semibold))
+              .foregroundColor(.secondary)
+            VariantRow(size: size)
+            VariantRow(size: size, leadingIcon: Image(systemName: "plus"))
+          }
+        }
+      }
+      .padding()
+    }
+  }
+
+  private struct VariantRow: View {
+    let size: BezierBadgeSize
+    var leadingIcon: Image? = nil
+
+    var body: some View {
+      ScrollView(.horizontal, showsIndicators: false) {
+        HStack(spacing: 8) {
+          ForEach(BezierBadgeVariant.allCases, id: \.self) { variant in
+            SUBezierBadge(size: size, variant: variant, label: "Badge", leadingIcon: leadingIcon)
+          }
+        }
+      }
+    }
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierButton/BezierButton.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierButton/BezierButton.swift
@@ -1,732 +1,366 @@
 //
 //  BezierButton.swift
-//  
-//
-//  Created by Jam on 2023/02/09.
+//  BezierSwift
 //
 
-import SwiftUI
+import UIKit
 
-private enum Metric {
-  static let textLeadingTrailing = CGFloat(2)
-}
+public final class BezierButton: UIControl, BezierComponentable {
+  // MARK: - BezierComponentable
 
-private enum Constant {
-  static let disalbedOpacity = CGFloat(0.4)
-}
+  public var colorTheme: BezierColorTheme { .systemBezierColorTheme() }
+  public var componentTheme: BezierComponentTheme = .normal {
+    didSet { self.refreshAppearance() }
+  }
 
-public enum ButtonSize {
-  case xsmall
-  case small
-  case medium
-  case large
-  case xlarge
-  
-  var height: CGFloat {
-    switch self {
-    case .xsmall:
-      return 24
-    case .small:
-      return 30
-    case .medium:
-      return 40
-    case .large:
-      return 44
-    case .xlarge:
-      return 54
-    }
-  }
-  
-  var stackSpacing: CGFloat {
-    switch self {
-    case .xsmall, .small, .medium:
-      return 4
-    case .large:
-      return 5
-    case .xlarge:
-      return 6
-    }
-  }
-  
-  var imageLength: CGFloat {
-    switch self {
-    case .xsmall:
-      return 16
-    case .small:
-      return 20
-    case .medium, .large, .xlarge:
-      return 24
-    }
-  }
-  
-  var font: Font {
-    self.bezierFont.font
-  }
-  
-  var bezierFont: BezierFont {
-    switch self {
-    case .xsmall:
-      return BezierFont.bold13
-    case .small:
-      return BezierFont.bold14
-    case .medium:
-      return BezierFont.bold15
-    case .large, .xlarge:
-      return BezierFont.bold16
-    }
-  }
-  
-  var minLeadingTrailingPadding: CGFloat {
-    switch self {
-    case .xsmall, .small:
-      return 6
-    case .medium:
-      return 8
-    case .large:
-      return 10
-    case .xlarge:
-      return 12
-    }
-  }
-  
-  var topBottomPadding: CGFloat {
-    return (self.height - self.imageLength) / CGFloat(2)
-  }
-  
-  func cornerRadius(type: ButtonType) -> BezierCornerRadius {
-    switch type {
-    case .primary, .secondary, .tertiary:
-      switch self {
-      case .xsmall:
-        return .round6
-      case .small:
-        return .round8
-      case .medium:
-        return .round12
-      case .large:
-        return .round12
-      case .xlarge:
-        return .round16
-      }
-    case .floating:
-      return .roundHalf(length: self.height)
-    }
-  }
-}
+  // MARK: - Public Properties
 
-public enum ButtonColor: String {
-  case blue
-  case red
-  case green
-  case yellow
-  case cobalt
-  case monochrome // TODO: 레거시. monochromeLight / Dark 논의 이후에 색상 치환할 것.
-  case monochromeLight
-  case monochromeDark
-  case absoulteWhite
-  case orange
-}
-
-public enum ButtonType: Equatable {
-  case primary(ButtonColor)
-  case secondary(ButtonColor)
-  case tertiary(ButtonColor)
-  case floating(ButtonColor)
-  
-  public static func == (lhs: Self, rhs: Self) -> Bool {
-    switch (lhs, rhs) {
-    case (let .primary(lhsColor), let .primary(rhsColor)):
-      return lhsColor == rhsColor
-    case (let .secondary(lhsColor), let .secondary(rhsColor)):
-      return lhsColor == rhsColor
-    case (let .tertiary(lhsColor), let .tertiary(rhsColor)):
-      return lhsColor == rhsColor
-    case (let .floating(lhsColor), let .floating(rhsColor)):
-      return lhsColor == rhsColor
-    default:
-      return false
-    }
+  public var size: BezierButtonSize = .medium {
+    didSet { if oldValue != self.size { self.refreshLayout() } }
   }
-  
-  func textColor(_ size: ButtonSize) -> BCSemanticToken {
-    switch self {
-    case .primary(let buttonColor):
-      switch buttonColor {
-      case .monochromeLight, .monochromeDark: return .textAbsoluteWhite
-      default: return .textAbsoluteWhite
-      }
-    case .secondary(let color), .tertiary(let color):
-      switch color {
-      case .blue:
-        return .textAccentBlue
-      case .red:
-        return .textAccentRed
-      case .green:
-        return .textAccentGreen
-      case .yellow:
-        return .textAccentYellow
-      case .cobalt:
-        return .textAccentCobalt
-      case .orange:
-        return .textAccentOrange
-      case .monochrome:
-        switch size {
-        case .xsmall, .small:
-          return .textNeutralLight
-        case .medium, .large, .xlarge:
-          return .textNeutral
-        }
-      case .monochromeLight:
-        return .textNeutralLight
-      case .monochromeDark:
-        return .textNeutral
-      case .absoulteWhite:
-        return .textAbsoluteWhite
-      }
-    case .floating(let color):
-      switch color {
-      case .blue, .red, .green, .yellow, .cobalt, .absoulteWhite, .orange:
-        return .textAbsoluteWhite
-      case .monochrome, .monochromeLight, .monochromeDark:
-        return .textNeutral
-      }
-    }
-  }
-  
-  func imageTintColor(_ size: ButtonSize) -> BCSemanticToken {
-    switch self {
-    case .primary(let buttonColor):
-      switch buttonColor {
-      case .monochromeLight, .monochromeDark: return .iconAbsoluteWhite
-      default: return .iconAbsoluteWhite
-      }
-    case .secondary(let color), .tertiary(let color):
-      switch color {
-      case .blue:
-        return .iconAccentBlue
-      case .red:
-        return .iconAccentRed
-      case .green:
-        return .iconAccentGreen
-      case .yellow:
-        return .iconAccentYellow
-      case .cobalt:
-        return .iconAccentCobalt
-      case .orange:
-        return .iconAccentOrange
-      case .monochrome:
-        switch size {
-        case .xsmall, .small:
-          return .iconNeutral
-        case .medium, .large, .xlarge:
-          return .iconNeutralHeavy
-        }
-      case .monochromeLight:
-        return .iconNeutral
-      case .monochromeDark:
-        return .iconNeutralHeavy
-      case .absoulteWhite:
-        return .iconAbsoluteWhite
-      }
-    case .floating(let color):
-      switch color {
-      case .blue, .red, .green, .yellow, .cobalt, .absoulteWhite, .orange:
-        return .iconAbsoluteWhite
-      case .monochrome, .monochromeLight, .monochromeDark:
-        return .iconNeutralHeavy
-      }
-    }
-  }
-  
-  func backgroundColor(state: ButtonState) -> BCSemanticToken {
-    switch self {
-    case .primary(let color):
-      switch color {
-      case .blue:
-        switch state {
-        case .default, .disabled:
-          return .fillAccentBlueHeavier
-        case .pressed:
-          return .fillAccentBlueHeavier
-        }
-      case .red:
-        switch state {
-        case .default, .disabled:
-          return .fillAccentRedHeavier
-        case .pressed:
-          return .fillAccentRedHeavier
-        }
-      case .green:
-        switch state {
-        case .default, .disabled:
-          return .fillAccentGreenHeavier
-        case .pressed:
-          return .fillAccentGreenHeavier
-        }
-      case .yellow:
-        switch state {
-        case .default, .disabled:
-          return .fillAccentYellowHeavier
-        case .pressed:
-          return .fillAccentYellowHeavier
-        }
-      case .cobalt:
-        switch state {
-        case .default, .disabled:
-          return .fillAccentCobaltHeavier
-        case .pressed:
-          return .fillAccentCobaltHeavier
-        }
-      case .orange:
-        switch state {
-        case .default, .disabled:
-          return .fillAccentOrangeHeavier
-        case .pressed:
-          return .fillAccentOrangeHeavier
-        }
-      case .monochrome:
-        switch state {
-        case .default, .disabled:
-          return .fillAbsoluteBlackLight
-        case .pressed:
-          return .dimAbsoluteBlack
-        }
-      case .monochromeLight:
-        return .fillNeutralHeavier
-      case .monochromeDark:
-        return .fillNeutralHeaviest
-      case .absoulteWhite:
-        return .fillNeutralTransparent
-      }
-    case .secondary(let color):
-      switch color {
-      case .blue:
-        switch state {
-        case .default, .disabled:
-          return .fillAccentBlue
-        case .pressed:
-          return .fillAccentBlueHeavy
-        }
-      case .red:
-        switch state {
-        case .default, .disabled:
-          return .fillAccentRed
-        case .pressed:
-          return .fillAccentRedHeavy
-        }
-      case .green:
-        switch state {
-        case .default, .disabled:
-          return .fillAccentGreen
-        case .pressed:
-          return .fillAccentGreenHeavy
-        }
-      case .yellow:
-        switch state {
-        case .default, .disabled:
-          return .fillAccentYellow
-        case .pressed:
-          return .fillAccentYellowHeavy
-        }
-      case .cobalt:
-        switch state {
-        case .default, .disabled:
-          return .fillAccentCobalt
-        case .pressed:
-          return .fillAccentCobaltHeavy
-        }
-      case .orange:
-        switch state {
-        case .default, .disabled:
-          return .fillAccentOrange
-        case .pressed:
-          return .fillAccentOrangeHeavy
-        }
-      case .monochrome, .monochromeLight, .monochromeDark:
-        switch state {
-        case .default, .disabled:
-          return .fillNeutralLighter
-        case .pressed:
-          return .fillNeutralLight
-        }
-      case .absoulteWhite:
-        return .fillNeutralTransparent
-      }
-    case .tertiary(let color):
-      switch color {
-      case .blue:
-        switch state {
-        case .default, .disabled:
-          return .fillNeutralTransparent
-        case .pressed:
-          return .fillAccentBlue
-        }
-      case .red:
-        switch state {
-        case .default, .disabled:
-          return .fillNeutralTransparent
-        case .pressed:
-          return .fillAccentRed
-        }
-      case .green:
-        switch state {
-        case .default, .disabled:
-          return .fillNeutralTransparent
-        case .pressed:
-          return .fillAccentGreen
-        }
-      case .yellow:
-        switch state {
-        case .default, .disabled:
-          return .fillNeutralTransparent
-        case .pressed:
-          return .fillAccentYellow
-        }
-      case .cobalt:
-        switch state {
-        case .default, .disabled:
-          return .fillNeutralTransparent
-        case .pressed:
-          return .fillAccentCobalt
-        }
-      case .orange:
-        switch state {
-        case .default, .disabled:
-          return .fillNeutralTransparent
-        case .pressed:
-          return .fillAccentOrange
-        }
-      case .monochrome, .monochromeLight, .monochromeDark:
-        switch state {
-        case .default, .disabled:
-          return .fillNeutralTransparent
-        case .pressed:
-          return .fillNeutralLighter
-        }
-      case .absoulteWhite:
-        return .fillNeutralTransparent
-      }
-    case .floating(let color):
-      switch color {
-      case .blue:
-        switch state {
-        case .default, .disabled:
-          return .fillAccentBlueHeavier
-        case .pressed:
-          return .fillAccentBlueHeavier
-        }
-      case .red:
-        switch state {
-        case .default, .disabled:
-          return .fillAccentRedHeavier
-        case .pressed:
-          return .fillAccentRedHeavier
-        }
-      case .green:
-        switch state {
-        case .default, .disabled:
-          return .fillAccentGreenHeavier
-        case .pressed:
-          return .fillAccentGreenHeavier
-        }
-      case .yellow:
-        switch state {
-        case .default, .disabled:
-          return .fillAccentYellowHeavier
-        case .pressed:
-          return .fillAccentYellowHeavier
-        }
-      case .cobalt:
-        switch state {
-        case .default, .disabled:
-          return .fillAccentCobaltHeavier
-        case .pressed:
-          return .fillAccentCobaltHeavier
-        }
-      case .orange:
-        switch state {
-        case .default, .disabled:
-          return .fillAccentOrangeHeavier
-        case .pressed:
-          return .fillAccentOrangeHeavier
-        }
-      case .monochrome, .monochromeLight, .monochromeDark:
-        switch state {
-        case .default, .disabled:
-          return .surfaceHighest
-        case .pressed:
-          return .surfaceHigh
-        }
-      case .absoulteWhite:
-        return .fillNeutralTransparent
-      }
-    }
-  }
-}
 
-enum ButtonState {
-  case `default`
-  case pressed
-  case disabled
-}
+  public var variant: BezierButtonVariant = .filled {
+    didSet { if oldValue != self.variant { self.refreshAppearance() } }
+  }
 
-public enum ButtonResizing {
-  case hug
-  case fill
-}
+  public var semantic: BezierButtonSemantic = .primary {
+    didSet { if oldValue != self.semantic { self.refreshAppearance() } }
+  }
 
-public struct BezierButton: View, Themeable {
-  private var size: ButtonSize
-  private var type: ButtonType
-  private var resizing: ButtonResizing
-  
-  private let action: () -> Void
-  private let title: String?
-  private let leftImage: Image?
-  private let rightImage: Image?
-  
-  @Environment(\.colorScheme) public var colorScheme
-  
-  private init(
-    size: ButtonSize,
-    type: ButtonType,
-    resizing: ButtonResizing,
-    titleContent: String? = nil,
-    leftContent: Image? = nil,
-    rightContent: Image? = nil,
-    action: @escaping () -> Void
+  public var resizing: BezierButtonResizing = .hug {
+    didSet { if oldValue != self.resizing { self.refreshResizing() } }
+  }
+
+  public var title: String? {
+    didSet { if oldValue != self.title { self.refreshContent() } }
+  }
+
+  public var leadingIcon: UIImage? {
+    didSet { self.refreshContent() }
+  }
+
+  public var trailingIcon: UIImage? {
+    didSet { self.refreshContent() }
+  }
+
+  public var isLoading: Bool = false {
+    didSet { if oldValue != self.isLoading { self.refreshLoading() } }
+  }
+
+  public override var isEnabled: Bool {
+    didSet { if oldValue != self.isEnabled { self.refreshEnabled() } }
+  }
+
+  public override var isHighlighted: Bool {
+    didSet { self.refreshHighlight() }
+  }
+
+  // MARK: - Subviews
+
+  private let contentStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .horizontal
+    stackView.alignment = .center
+    stackView.distribution = .fill
+    stackView.isUserInteractionEnabled = false
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    return stackView
+  }()
+
+  private let leadingImageView: UIImageView = {
+    let imageView = UIImageView()
+    imageView.contentMode = .scaleAspectFit
+    imageView.isHidden = true
+    imageView.translatesAutoresizingMaskIntoConstraints = false
+    return imageView
+  }()
+
+  private let trailingImageView: UIImageView = {
+    let imageView = UIImageView()
+    imageView.contentMode = .scaleAspectFit
+    imageView.isHidden = true
+    imageView.translatesAutoresizingMaskIntoConstraints = false
+    return imageView
+  }()
+
+  private let titleLabel: BezierButtonPaddedLabel = {
+    let label = BezierButtonPaddedLabel()
+    label.numberOfLines = 1
+    label.textAlignment = .center
+    return label
+  }()
+
+  private let activityIndicator: UIActivityIndicatorView = {
+    let indicator = UIActivityIndicatorView(style: .medium)
+    indicator.hidesWhenStopped = true
+    indicator.translatesAutoresizingMaskIntoConstraints = false
+    return indicator
+  }()
+
+  // MARK: - Layout Constraints (mutable)
+
+  private var heightConstraint: NSLayoutConstraint?
+  private var minWidthConstraint: NSLayoutConstraint?
+  private var leadingImageWidthConstraint: NSLayoutConstraint?
+  private var leadingImageHeightConstraint: NSLayoutConstraint?
+  private var trailingImageWidthConstraint: NSLayoutConstraint?
+  private var trailingImageHeightConstraint: NSLayoutConstraint?
+
+  // MARK: - Init
+
+  public init(
+    size: BezierButtonSize = .medium,
+    variant: BezierButtonVariant = .filled,
+    semantic: BezierButtonSemantic = .primary,
+    resizing: BezierButtonResizing = .hug
   ) {
     self.size = size
-    self.type = type
+    self.variant = variant
+    self.semantic = semantic
     self.resizing = resizing
-    self.action = action
-    self.title = titleContent
-    self.leftImage = leftContent
-    self.rightImage = rightContent
+    super.init(frame: .zero)
+    self.setUp()
   }
-  
-  public init(
-    size: ButtonSize,
-    type: ButtonType,
-    resizing: ButtonResizing,
-    title: String,
-    leftImage: Image,
-    rightImage: Image,
-    action: @escaping () -> Void
-  ) {
-    self.init(
-      size: size,
-      type: type,
-      resizing: resizing,
-      titleContent: title,
-      leftContent: leftImage,
-      rightContent: rightImage,
-      action: action
-    )
+
+  public required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    self.setUp()
   }
-  
-  public init(
-    size: ButtonSize,
-    type: ButtonType,
-    resizing: ButtonResizing,
-    title: String,
-    leftImage: Image,
-    action: @escaping () -> Void
-  ) {
-    self.init(
-      size: size,
-      type: type,
-      resizing: resizing,
-      titleContent: title,
-      leftContent: leftImage,
-      action: action
-    )
+
+  // MARK: - Setup
+
+  private func setUp() {
+    self.translatesAutoresizingMaskIntoConstraints = false
+
+    self.layer.masksToBounds = true
+    self.layer.borderWidth = 0
+
+    self.contentStackView.addArrangedSubview(self.leadingImageView)
+    self.contentStackView.addArrangedSubview(self.titleLabel)
+    self.contentStackView.addArrangedSubview(self.trailingImageView)
+
+    self.addSubview(self.contentStackView)
+    self.addSubview(self.activityIndicator)
+
+    let heightConstraint = self.heightAnchor.constraint(equalToConstant: self.size.height)
+    let minWidthConstraint = self.widthAnchor.constraint(greaterThanOrEqualToConstant: self.size.minWidth)
+
+    let leadingImageWidthConstraint = self.leadingImageView.widthAnchor.constraint(equalToConstant: self.size.iconLength)
+    let leadingImageHeightConstraint = self.leadingImageView.heightAnchor.constraint(equalToConstant: self.size.iconLength)
+    let trailingImageWidthConstraint = self.trailingImageView.widthAnchor.constraint(equalToConstant: self.size.iconLength)
+    let trailingImageHeightConstraint = self.trailingImageView.heightAnchor.constraint(equalToConstant: self.size.iconLength)
+
+    NSLayoutConstraint.activate([
+      heightConstraint,
+      minWidthConstraint,
+      leadingImageWidthConstraint,
+      leadingImageHeightConstraint,
+      trailingImageWidthConstraint,
+      trailingImageHeightConstraint,
+      self.contentStackView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+      self.contentStackView.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+      self.contentStackView.leadingAnchor.constraint(
+        greaterThanOrEqualTo: self.leadingAnchor,
+        constant: self.size.horizontalPadding
+      ).withIdentifier("contentLeading"),
+      self.contentStackView.trailingAnchor.constraint(
+        lessThanOrEqualTo: self.trailingAnchor,
+        constant: -self.size.horizontalPadding
+      ).withIdentifier("contentTrailing"),
+      self.activityIndicator.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+      self.activityIndicator.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+    ])
+
+    self.heightConstraint = heightConstraint
+    self.minWidthConstraint = minWidthConstraint
+    self.leadingImageWidthConstraint = leadingImageWidthConstraint
+    self.leadingImageHeightConstraint = leadingImageHeightConstraint
+    self.trailingImageWidthConstraint = trailingImageWidthConstraint
+    self.trailingImageHeightConstraint = trailingImageHeightConstraint
+
+    self.refreshLayout()
+    self.refreshContent()
+    self.refreshAppearance()
+    self.refreshResizing()
+    self.refreshLoading()
+    self.refreshEnabled()
   }
-  
-  public init(
-    size: ButtonSize,
-    type: ButtonType,
-    resizing: ButtonResizing,
-    title: String,
-    rightImage: Image,
-    action: @escaping () -> Void
-  ) {
-    self.init(
-      size: size,
-      type: type,
-      resizing: resizing,
-      titleContent: title,
-      rightContent: rightImage,
-      action: action
-    )
+
+  // MARK: - Layout Update
+
+  public override func layoutSubviews() {
+    super.layoutSubviews()
+    self.layer.cornerRadius = self.bounds.height / 2
   }
-  
-  public init(
-    size: ButtonSize,
-    type: ButtonType,
-    resizing: ButtonResizing,
-    centerImage: Image,
-    action: @escaping () -> Void
-  ) {
-    self.init(
-      size: size,
-      type: type,
-      resizing: resizing,
-      leftContent: centerImage,
-      action: action
-    )
+
+  public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    self.refreshAppearance()
   }
-  
-  public init(
-    size: ButtonSize,
-    type: ButtonType,
-    resizing: ButtonResizing,
-    title: String,
-    action: @escaping () -> Void
-  ) {
-    self.init(
-      size: size,
-      type: type,
-      resizing: resizing,
-      titleContent: title,
-      action: action
-    )
-  }
-  
-  public var body: some View {
-    Button {
-      self.action()
-    } label: {
-      HStack(alignment: .center, spacing: self.size.stackSpacing) {
-        if self.resizing == .fill {
-          Spacer(minLength: 0)
-        }
-        
-        if let leftImage {
-          leftImage
-            .applyBaseImageStyle()
-            .foregroundColor(self.palette(self.type.imageTintColor(self.size)))
-            .frame(width: self.size.imageLength, height: self.size.imageLength)
-        }
-        
-        if let title {
-          Text(title)
-            .applyBezierFontStyle(
-              self.size.bezierFont,
-              semanticColorToken: self.type.textColor(self.size)
-            )
-            .padding(.horizontal, Metric.textLeadingTrailing)
-        }
-        
-        if let rightImage {
-          rightImage
-            .applyBaseImageStyle()
-            .foregroundColor(self.palette(self.type.imageTintColor(self.size)))
-            .frame(width: self.size.imageLength, height: self.size.imageLength)
-        }
-        
-        if self.resizing == .fill {
-          Spacer(minLength: 0)
-        }
+
+  // MARK: - Refresh
+
+  private func refreshLayout() {
+    self.heightConstraint?.constant = self.size.height
+    self.minWidthConstraint?.constant = self.size.minWidth
+    self.leadingImageWidthConstraint?.constant = self.size.iconLength
+    self.leadingImageHeightConstraint?.constant = self.size.iconLength
+    self.trailingImageWidthConstraint?.constant = self.size.iconLength
+    self.trailingImageHeightConstraint?.constant = self.size.iconLength
+
+    for constraint in self.constraints {
+      if constraint.identifier == "contentLeading" {
+        constraint.constant = self.size.horizontalPadding
+      } else if constraint.identifier == "contentTrailing" {
+        constraint.constant = -self.size.horizontalPadding
       }
-      .padding(.horizontal, self.minLeadingTrailing)
     }
-    .buttonStyle(
-      BezierButtonStyle(
-        size: size,
-        type: type,
-        resizing: resizing
+
+    self.contentStackView.spacing = self.size.contentSpacing
+    self.titleLabel.contentInsets = UIEdgeInsets(
+      top: 0,
+      left: self.size.textHorizontalPadding,
+      bottom: 0,
+      right: self.size.textHorizontalPadding
+    )
+    self.activityIndicator.transform = CGAffineTransform(
+      scaleX: self.activityIndicatorScale,
+      y: self.activityIndicatorScale
+    )
+    self.refreshContent()
+    self.setNeedsLayout()
+    self.invalidateIntrinsicContentSize()
+  }
+
+  private func refreshContent() {
+    self.leadingImageView.image = self.leadingIcon?.withRenderingMode(.alwaysTemplate)
+    self.leadingImageView.isHidden = self.leadingIcon == nil
+
+    self.trailingImageView.image = self.trailingIcon?.withRenderingMode(.alwaysTemplate)
+    self.trailingImageView.isHidden = self.trailingIcon == nil
+
+    let foregroundToken = self.variant.foregroundToken(self.semantic)
+    let foregroundColor = foregroundToken.palette(self)
+
+    self.leadingImageView.tintColor = foregroundColor
+    self.trailingImageView.tintColor = foregroundColor
+
+    if let title = self.title, !title.isEmpty {
+      self.titleLabel.attributedText = self.size.typography.attributedString(
+        self,
+        text: title,
+        semanticColorToken: foregroundToken,
+        alignment: .center
       )
+      self.titleLabel.isHidden = false
+    } else {
+      self.titleLabel.attributedText = nil
+      self.titleLabel.isHidden = true
+    }
+  }
+
+  private func refreshAppearance() {
+    if let backgroundToken = self.variant.backgroundToken(self.semantic) {
+      self.backgroundColor = backgroundToken.palette(self)
+    } else {
+      self.backgroundColor = .clear
+    }
+
+    if let borderToken = self.variant.borderToken(self.semantic) {
+      self.layer.borderWidth = BezierButtonConstant.borderWidth
+      self.layer.borderColor = borderToken.palette(self).cgColor
+    } else {
+      self.layer.borderWidth = 0
+      self.layer.borderColor = nil
+    }
+
+    let foregroundColor = self.variant.foregroundToken(self.semantic).palette(self)
+    self.leadingImageView.tintColor = foregroundColor
+    self.trailingImageView.tintColor = foregroundColor
+    self.activityIndicator.color = foregroundColor
+
+    self.refreshContent()
+  }
+
+  private func refreshResizing() {
+    switch self.resizing {
+    case .hug:
+      self.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+      self.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+    case .fill:
+      self.setContentHuggingPriority(.defaultLow, for: .horizontal)
+      self.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+    }
+  }
+
+  private func refreshLoading() {
+    self.isUserInteractionEnabled = !self.isLoading
+    if self.isLoading {
+      self.contentStackView.isHidden = true
+      self.activityIndicator.startAnimating()
+    } else {
+      self.contentStackView.isHidden = false
+      self.activityIndicator.stopAnimating()
+    }
+  }
+
+  private func refreshEnabled() {
+    self.alpha = self.isEnabled ? 1 : BezierButtonConstant.disabledOpacity
+  }
+
+  private func refreshHighlight() {
+    UIView.animate(withDuration: 0.1) {
+      self.alpha = self.isHighlighted
+        ? BezierButtonConstant.pressedOpacity
+        : (self.isEnabled ? 1 : BezierButtonConstant.disabledOpacity)
+    }
+  }
+
+  // MARK: - Touch
+
+  public override func sendAction(_ action: Selector, to target: Any?, for event: UIEvent?) {
+    guard !self.isLoading else { return }
+    super.sendAction(action, to: target, for: event)
+  }
+
+  // MARK: - Helpers
+
+  private var activityIndicatorScale: CGFloat {
+    switch self.size {
+    case .xsmall, .small: return 0.6
+    case .medium, .large, .xlarge: return 0.8
+    }
+  }
+}
+
+// MARK: - Padded Label
+
+final class BezierButtonPaddedLabel: UILabel {
+  var contentInsets: UIEdgeInsets = .zero {
+    didSet {
+      self.invalidateIntrinsicContentSize()
+      self.setNeedsDisplay()
+    }
+  }
+
+  override func drawText(in rect: CGRect) {
+    super.drawText(in: rect.inset(by: self.contentInsets))
+  }
+
+  override var intrinsicContentSize: CGSize {
+    let size = super.intrinsicContentSize
+    return CGSize(
+      width: size.width + self.contentInsets.left + self.contentInsets.right,
+      height: size.height + self.contentInsets.top + self.contentInsets.bottom
     )
   }
-  
-  private var minLeadingTrailing: CGFloat {
-    let isImageOnly = self.title.isNil
-    && (
-      (self.leftImage.isNotNil || self.rightImage.isNil)
-      || (self.leftImage.isNil || self.rightImage.isNotNil)
-    )
-    let minLeadingTrailing = isImageOnly
-    ? self.size.topBottomPadding : self.size.minLeadingTrailingPadding
-    
-    return minLeadingTrailing
-  }
 }
 
-private extension Image {
-  func applyBaseImageStyle() -> some View {
-    self
-      .renderingMode(.template)
-      .resizable()
-      .scaledToFit()
-  }
-}
+// MARK: - NSLayoutConstraint Identifier Helper
 
-private struct BezierButtonStyle: ButtonStyle, Themeable {
-  @Environment(\.colorScheme) var colorScheme
-  
-  private let size: ButtonSize
-  private let type: ButtonType
-  private let resizing: ButtonResizing
-  
-  @Environment(\.isEnabled) var isEnabled: Bool
-  
-  init(
-    size: ButtonSize,
-    type: ButtonType,
-    resizing: ButtonResizing
-  ) {
-    self.size = size
-    self.type = type
-    self.resizing = resizing
-  }
-  
-  func makeBody(configuration: Configuration) -> some View {
-    let buttonState: ButtonState = self.getState(configuration: configuration, isEnabled: self.isEnabled)
-    configuration.label
-      .frame(height: self.size.height)
-      .disabled(!self.isEnabled)
-      .background(self.palette(self.type.backgroundColor(state: buttonState)))
-      .applyBezierCornerRadius(type: self.size.cornerRadius(type: self.type))
-      .opacity(self.isEnabled ? 1 : Constant.disalbedOpacity)
-  }
-  
-  private func getState(configuration: Configuration, isEnabled: Bool) -> ButtonState {
-    return configuration.isPressed ? .pressed : isEnabled ? .default : .disabled
-  }
-}
-
-struct BezierButton_Previews: PreviewProvider {
-  static var previews: some View {
-    VStack {
-      BezierButton(size: .large, type: .primary(.green), resizing: .fill, title: "Get started", leftImage: Image(systemName: "trash")) {
-        print("")
-      }
-
-      BezierButton(size: .large, type: .primary(.blue), resizing: .hug, title: "Get started", leftImage: Image(systemName: "trash"), rightImage: Image(systemName: "trash")) {
-        print("")
-      }
-      
-      BezierButton(size: .large, type: .primary(.red), resizing: .hug, title: "Get started", leftImage: Image(systemName: "trash"), rightImage: Image(systemName: "trash")) {
-        print("")
-      }
-      
-      BezierButton(size: .large, type: .secondary(.red), resizing: .hug, title: "Get started", leftImage: Image(systemName: "trash"), rightImage: Image(systemName: "trash")) {
-        print("")
-      }
-      
-      BezierButton(size: .large, type: .tertiary(.red), resizing: .hug, title: "Get started", leftImage: Image(systemName: "trash"), rightImage: Image(systemName: "trash")) {
-        print("")
-      }
-      
-      BezierButton(size: .large, type: .floating(.cobalt), resizing: .hug, title: "Get started", leftImage: Image(systemName: "trash"), rightImage: Image(systemName: "trash")) {
-        print("")
-      }
-      
-      BezierButton(size: .large, type: .primary(.yellow), resizing: .hug, centerImage: Image(systemName: "trash")) {
-        print("")
-      }
-      
-    }.padding()
+private extension NSLayoutConstraint {
+  func withIdentifier(_ identifier: String) -> NSLayoutConstraint {
+    self.identifier = identifier
+    return self
   }
 }

--- a/Sources/BezierSwift/MasterComponent/BezierButton/BezierButton.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierButton/BezierButton.swift
@@ -27,10 +27,6 @@ public final class BezierButton: UIControl, BezierComponentable {
     didSet { if oldValue != self.semantic { self.refreshAppearance() } }
   }
 
-  public var resizing: BezierButtonResizing = .hug {
-    didSet { if oldValue != self.resizing { self.refreshResizing() } }
-  }
-
   public var title: String? {
     didSet { if oldValue != self.title { self.refreshContent() } }
   }
@@ -97,6 +93,9 @@ public final class BezierButton: UIControl, BezierComponentable {
     return indicator
   }()
 
+  // UIActivityIndicatorView(style: .medium) base size
+  private let activityIndicatorBaseLength: CGFloat = 20
+
   // MARK: - Layout Constraints (mutable)
 
   private var heightConstraint: NSLayoutConstraint?
@@ -111,13 +110,11 @@ public final class BezierButton: UIControl, BezierComponentable {
   public init(
     size: BezierButtonSize = .medium,
     variant: BezierButtonVariant = .filled,
-    semantic: BezierButtonSemantic = .primary,
-    resizing: BezierButtonResizing = .hug
+    semantic: BezierButtonSemantic = .primary
   ) {
     self.size = size
     self.variant = variant
     self.semantic = semantic
-    self.resizing = resizing
     super.init(frame: .zero)
     self.setUp()
   }
@@ -178,10 +175,12 @@ public final class BezierButton: UIControl, BezierComponentable {
     self.trailingImageWidthConstraint = trailingImageWidthConstraint
     self.trailingImageHeightConstraint = trailingImageHeightConstraint
 
+    self.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+    self.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+
     self.refreshLayout()
     self.refreshContent()
     self.refreshAppearance()
-    self.refreshResizing()
     self.refreshLoading()
     self.refreshEnabled()
   }
@@ -246,10 +245,14 @@ public final class BezierButton: UIControl, BezierComponentable {
     self.trailingImageView.tintColor = foregroundColor
 
     if let title = self.title, !title.isEmpty {
-      self.titleLabel.attributedText = self.size.typography.attributedString(
-        self,
-        text: title,
-        semanticColorToken: foregroundToken,
+      self.titleLabel.attributedText = title.applyBezierFont(
+        height: self.size.lineHeight,
+        font: BTGlobalToken.FontFamily.system.uiFont(
+          size: self.size.fontSize,
+          weight: self.size.fontWeight
+        ),
+        color: foregroundColor,
+        letterSpacing: 0,
         alignment: .center
       )
       self.titleLabel.isHidden = false
@@ -280,17 +283,6 @@ public final class BezierButton: UIControl, BezierComponentable {
     self.activityIndicator.color = foregroundColor
 
     self.refreshContent()
-  }
-
-  private func refreshResizing() {
-    switch self.resizing {
-    case .hug:
-      self.setContentHuggingPriority(.defaultHigh, for: .horizontal)
-      self.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
-    case .fill:
-      self.setContentHuggingPriority(.defaultLow, for: .horizontal)
-      self.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-    }
   }
 
   private func refreshLoading() {
@@ -326,10 +318,7 @@ public final class BezierButton: UIControl, BezierComponentable {
   // MARK: - Helpers
 
   private var activityIndicatorScale: CGFloat {
-    switch self.size {
-    case .xsmall, .small: return 0.6
-    case .medium, .large, .xlarge: return 0.8
-    }
+    self.size.spinnerLength / self.activityIndicatorBaseLength
   }
 }
 

--- a/Sources/BezierSwift/MasterComponent/BezierButton/BezierButtonSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierButton/BezierButtonSpec.swift
@@ -1,0 +1,129 @@
+//
+//  BezierButtonSpec.swift
+//  BezierSwift
+//
+
+import CoreGraphics
+
+public enum BezierButtonSize: String, CaseIterable {
+  case xsmall
+  case small
+  case medium
+  case large
+  case xlarge
+
+  public var height: CGFloat {
+    switch self {
+    case .xsmall: return 24
+    case .small:  return 30
+    case .medium: return 40
+    case .large:  return 44
+    case .xlarge: return 54
+    }
+  }
+
+  public var minWidth: CGFloat {
+    switch self {
+    case .xsmall: return 20
+    case .small:  return 24
+    case .medium: return 36
+    case .large:  return 44
+    case .xlarge: return 54
+    }
+  }
+
+  public var horizontalPadding: CGFloat {
+    switch self {
+    case .xsmall: return 4
+    case .small:  return 6
+    case .medium: return 10
+    case .large:  return 12
+    case .xlarge: return 20
+    }
+  }
+
+  public var contentSpacing: CGFloat {
+    switch self {
+    case .xsmall, .small: return 0
+    case .medium, .large, .xlarge: return 2
+    }
+  }
+
+  public var textHorizontalPadding: CGFloat {
+    switch self {
+    case .xsmall, .small: return 3
+    case .medium, .large, .xlarge: return 4
+    }
+  }
+
+  public var iconLength: CGFloat { 16 }
+
+  public var typography: BTSemanticToken {
+    switch self {
+    case .xsmall: return .labelMedium
+    case .small:  return .labelLarge
+    case .medium: return .headingXXSmall
+    case .large:  return .headingXSmall
+    case .xlarge: return .headingXSmall
+    }
+  }
+}
+
+public enum BezierButtonVariant: String, CaseIterable {
+  case filled
+  case outlined
+  case ghost
+}
+
+public enum BezierButtonSemantic: String, CaseIterable {
+  case primary
+  case secondary
+  case destructive
+}
+
+public enum BezierButtonResizing: String, CaseIterable {
+  case hug
+  case fill
+}
+
+enum BezierButtonConstant {
+  static let borderWidth: CGFloat = 1
+  static let disabledOpacity: CGFloat = 0.4
+  static let pressedOpacity: CGFloat = 0.7
+}
+
+extension BezierButtonVariant {
+  func backgroundToken(_ semantic: BezierButtonSemantic) -> BCSemanticToken? {
+    switch (self, semantic) {
+    case (.filled, .primary):     return .fillNeutralHeaviest
+    case (.filled, .secondary):   return .fillNeutralLight
+    case (.filled, .destructive): return .fillAccentRedHeavier
+    case (.outlined, _),
+         (.ghost, _):
+      return nil
+    }
+  }
+
+  func borderToken(_ semantic: BezierButtonSemantic) -> BCSemanticToken? {
+    switch self {
+    case .outlined: return .borderNeutral
+    case .filled, .ghost: return nil
+    }
+  }
+
+  func foregroundToken(_ semantic: BezierButtonSemantic) -> BCSemanticToken {
+    switch (self, semantic) {
+    case (.filled, .primary):     return .textInverse
+    case (.filled, .secondary):   return .textNeutral
+    case (.filled, .destructive): return .textInverse
+
+    case (.outlined, .primary):     return .textNeutralHeaviest
+    case (.outlined, .secondary):   return .textNeutralLight
+    case (.outlined, .destructive): return .textAccentRed
+
+    case (.ghost, .primary):     return .textNeutralLight
+    case (.ghost, .secondary):   return .textNeutralLighter
+    case (.ghost, .destructive): return .textAccentRed
+    }
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierButton/BezierButtonSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierButton/BezierButtonSpec.swift
@@ -58,15 +58,34 @@ public enum BezierButtonSize: String, CaseIterable {
 
   public var iconLength: CGFloat { 16 }
 
-  public var typography: BTSemanticToken {
+  public var spinnerLength: CGFloat {
     switch self {
-    case .xsmall: return .labelMedium
-    case .small:  return .labelLarge
-    case .medium: return .headingXXSmall
-    case .large:  return .headingXSmall
-    case .xlarge: return .headingXSmall
+    case .xsmall: return 12
+    case .small:  return 14
+    case .medium: return 16
+    case .large:  return 18
+    case .xlarge: return 18
     }
   }
+
+  public var fontSize: CGFloat {
+    switch self {
+    case .xsmall: return 13
+    case .small:  return 14
+    case .medium: return 15
+    case .large, .xlarge: return 16
+    }
+  }
+
+  public var lineHeight: CGFloat {
+    switch self {
+    case .xsmall, .small: return 18
+    case .medium, .large, .xlarge: return 20
+    }
+  }
+
+  // Figma SemiBold(600) → iOS BTFontWeight binary system(`bold`) 매핑 (디자인 시스템 합의)
+  public var fontWeight: BTFontWeight { .bold }
 }
 
 public enum BezierButtonVariant: String, CaseIterable {
@@ -79,11 +98,6 @@ public enum BezierButtonSemantic: String, CaseIterable {
   case primary
   case secondary
   case destructive
-}
-
-public enum BezierButtonResizing: String, CaseIterable {
-  case hug
-  case fill
 }
 
 enum BezierButtonConstant {

--- a/Sources/BezierSwift/MasterComponent/BezierButton/SPEC.md
+++ b/Sources/BezierSwift/MasterComponent/BezierButton/SPEC.md
@@ -1,0 +1,123 @@
+# BezierButton SPEC
+
+> **SSOT**: [Figma · Mobile-Components / Button (1734:146)](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=1734-146)
+>
+> 이 문서는 Figma 디자인의 단일 진실 공급원(SSOT)을 코드 관점에서 정리한 것이다. 모든 수치/토큰은 Figma에 실재해야 한다.
+
+## 1. Component Overview
+
+- **이름**: Button
+- **설명**: 클릭·제출 등 단일 액션을 트리거하는 인터랙션 컴포넌트.
+- **가이드라인**:
+  - `semantic = primary` 버튼은 한 화면에 1개만 둔다.
+  - 아이콘 전용 버튼은 IconButton(별도 컴포넌트)을 사용한다.
+
+## 2. Component Properties (Figma variant 축)
+
+| 축 | 값 | 비고 |
+|---|---|---|
+| `size` | `xsmall`, `small`, `medium`, `large`, `xlarge` | 5 옵션 |
+| `variant` | `filled`, `outlined`, `ghost` | 3 옵션 |
+| `semantic` | `primary`, `secondary`, `destructive` | 3 옵션 |
+| `state` | `default`, `pressed`, `active`, `disabled`, `loading` | **Figma 설계용 축** — 시각 검토 목적, 런타임 API로 노출하지 않는다. |
+
+Figma 매트릭스 총량: 5 × 3 × 3 × 5 = **225 symbols** (전부 실재).
+
+### 2-1. State 축의 해석
+
+Figma 컴포넌트 설명에 명시:
+> "state 축: Figma 설계용 — disabled/loading/pressed 상태별 시각 확인에 사용"
+
+따라서 코드는 다음 런타임 상태만 노출한다:
+
+| 코드 상태 | Figma state 매핑 |
+|---|---|
+| `isEnabled = true`, 정상 | `default` |
+| `isHighlighted = true` (터치 중) | `pressed` |
+| `isEnabled = false` | `disabled` |
+| `isLoading = true` | `loading` |
+| (없음) | `active` — 토글/선택 상태를 위한 설계용. Button 컴포넌트는 sticky-toggled 상태를 노출하지 않는다. |
+
+## 3. Layout (size별)
+
+> Figma 좌표/크기 (변하지 않는 cell-level 수치). 모든 size에서 `border-radius: 9999px` (= 완전 capsule, 높이의 절반).
+
+| size | height | minWidth | horizontalPadding (px) | textHorizontalPadding (text px) | contentSpacing (gap) | iconLength |
+|---|---|---|---|---|---|---|
+| xsmall | 24 | 20 | 4 | 3 | 0 (no gap) | 16 |
+| small | 30 | 24 | 6 | 3 | 0 (no gap) | 16 |
+| medium | 40 | 36 | 10 | 4 | 2 | 16 |
+| large | 44 | 44 | 12 | 4 | 2 | 16 |
+| xlarge | 54 | 54 | 20 | 4 | 2 | 16 |
+
+- **border-radius**: 모든 size에서 height의 절반 (완전 capsule).
+- **icon**: leadingIcon / trailingIcon은 텍스트 좌우에 배치, 16×16 고정.
+
+## 4. Typography (size별, Custom)
+
+> **Typography 적용 방식: Custom (Token 미적용)**.
+> Figma Button 텍스트 노드는 Foundation의 typography token(`Typography/heading/*` text style 또는 `heading/size/*` / `heading/line-height/*` variable)에 연결되어 있지 않다. 5개 size 모두 `get_variable_defs` 결과가 `label/font-family` (= `"Inter"`) + `label/letter-spacing` (= `0`)만 노출하며, font-size 와 line-height 는 raw 값으로 직접 적용되어 있다.
+>
+> **Custom 사유**: Figma Mobile Components Button(`1734:146`)이 typography token 매핑을 보유하고 있지 않은 상태. (디자이너 의도 — 디자인 시스템 typography token 매핑은 별도 진행 예정으로 추정되며, 현 시점 Button 의 SSOT 는 raw 값 자체.)
+
+공통값 (5 size 동일):
+- `font-family`: `Inter` (variable: `label/font-family`)
+- `font-weight`: `SemiBold` (600)
+- `letter-spacing`: `0` (variable: `label/letter-spacing`)
+
+size 별 raw 값:
+
+| size | fontSize | lineHeight |
+|---|---|---|
+| xsmall | 13 | 18 |
+| small | 14 | 18 |
+| medium | 15 | 20 |
+| large | 16 | 20 |
+| xlarge | 16 | 20 |
+
+> ⚠️ iOS BezierSwift V3 Typography는 regular/bold 이진 weight 시스템(`BTFontWeight`)을 사용한다. Figma SemiBold(600)는 iOS에서 `bold`로 매핑된다 (디자인 시스템 합의 사항).
+
+## 5. Color (variant × semantic × variant 별, default state)
+
+> 키는 Figma variable 경로. 괄호 안은 raw 값.
+
+| variant × semantic | background | text/icon | border |
+|---|---|---|---|
+| `filled` × `primary` | `color/fill/neutral/heaviest` (`#000000d9`) | `color/text/inverse` (`#ffffff`) | — |
+| `filled` × `secondary` | `color/fill/neutral/light` (`#0000000d`) | `color/text/neutral` (`#000000d9`) | — |
+| `filled` × `destructive` | `color/fill/accent/red/heavier` (`#e1535d`) | `color/text/inverse` (`#ffffff`) | — |
+| `outlined` × `primary` | — | `color/text/neutral/heaviest` (`#000000`) | `color/border/neutral` (`#00000014`) |
+| `outlined` × `secondary` | — | `color/text/neutral/light` (`#00000099`) | `color/border/neutral` (`#00000014`) |
+| `outlined` × `destructive` | — | `color/text/accent/red` (`#e1535d`) | `color/border/neutral` (`#00000014`) |
+| `ghost` × `primary` | — | `color/text/neutral/light` (`#00000099`) | — |
+| `ghost` × `secondary` | — | `color/text/neutral/lighter` (`#00000066`) | — |
+| `ghost` × `destructive` | — | `color/text/accent/red` (`#e1535d`) | — |
+
+- **border-width**: outlined 1px (모든 size 공통).
+- **outlined / ghost** variant는 background fill 없음 (clear).
+
+## 6. State 별 시각 동작
+
+> `pressed` / `active` 시각은 Figma SSOT에 별도 컬러 토큰이 없고 opacity 기반으로 표현된다.
+
+| state | 시각 처리 |
+|---|---|
+| `default` | 위 §5 색상 그대로 |
+| `pressed` | 본체 opacity를 낮춤 (터치 중에만 일시적) |
+| `active` | 코드 미노출 (Button은 토글 상태를 가지지 않음) |
+| `disabled` | 본체 전체 `opacity: 0.4` (Figma `opacity-40` 일치) |
+| `loading` | 라벨/아이콘 숨김 + 가운데 ActivityIndicator 표시. 사용자 입력 무시 |
+
+## 7. Loading Spinner Size (size별)
+
+> Figma `ActivityIndicator` 노드 크기.
+
+| size | spinner size |
+|---|---|
+| xsmall | 12 |
+| small | 14 |
+| medium | 16 |
+| large | 18 |
+| xlarge | 18 |
+
+스피너 색은 해당 variant × semantic의 foreground (`text/icon`) 컬러와 동일.

--- a/Sources/BezierSwift/MasterComponent/BezierButton/SUBezierButton.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierButton/SUBezierButton.swift
@@ -9,7 +9,6 @@ public struct SUBezierButton: View, Themeable {
   private let size: BezierButtonSize
   private let variant: BezierButtonVariant
   private let semantic: BezierButtonSemantic
-  private let resizing: BezierButtonResizing
   private let title: String?
   private let leadingIcon: Image?
   private let trailingIcon: Image?
@@ -23,7 +22,6 @@ public struct SUBezierButton: View, Themeable {
     size: BezierButtonSize,
     variant: BezierButtonVariant,
     semantic: BezierButtonSemantic,
-    resizing: BezierButtonResizing = .hug,
     title: String? = nil,
     leadingIcon: Image? = nil,
     trailingIcon: Image? = nil,
@@ -33,7 +31,6 @@ public struct SUBezierButton: View, Themeable {
     self.size = size
     self.variant = variant
     self.semantic = semantic
-    self.resizing = resizing
     self.title = title
     self.leadingIcon = leadingIcon
     self.trailingIcon = trailingIcon
@@ -53,11 +50,11 @@ public struct SUBezierButton: View, Themeable {
       }
       .padding(.horizontal, self.size.horizontalPadding)
       .frame(
-        minWidth: self.resizing == .fill ? nil : self.size.minWidth,
-        maxWidth: self.resizing == .fill ? .infinity : nil,
+        minWidth: self.size.minWidth,
         minHeight: self.size.height,
         maxHeight: self.size.height
       )
+      .fixedSize(horizontal: true, vertical: false)
     }
     .buttonStyle(
       SUBezierButtonStyle(
@@ -77,11 +74,22 @@ public struct SUBezierButton: View, Themeable {
       }
 
       if let title = self.title, !title.isEmpty {
+        let uiFont = BTGlobalToken.FontFamily.system.uiFont(
+          size: self.size.fontSize,
+          weight: self.size.fontWeight
+        )
+        let lineSpacing = max(0, self.size.lineHeight - uiFont.lineHeight)
+
         Text(title)
-          .applyBezierFontStyle(
-            self.size.typography,
-            semanticColorToken: self.variant.foregroundToken(self.semantic)
+          .font(
+            BTGlobalToken.FontFamily.system.font(
+              size: self.size.fontSize,
+              weight: self.size.fontWeight
+            )
           )
+          .lineSpacing(lineSpacing)
+          .padding(.vertical, lineSpacing / 2)
+          .foregroundColor(self.palette(self.variant.foregroundToken(self.semantic)))
           .padding(.horizontal, self.size.textHorizontalPadding)
           .fixedSize(horizontal: true, vertical: false)
       }
@@ -105,15 +113,11 @@ public struct SUBezierButton: View, Themeable {
     ProgressView()
       .progressViewStyle(.circular)
       .tint(self.palette(self.variant.foregroundToken(self.semantic)))
-      .scaleEffect(self.loadingScale)
+      .scaleEffect(self.size.spinnerLength / Self.progressViewBaseLength)
   }
 
-  private var loadingScale: CGFloat {
-    switch self.size {
-    case .xsmall, .small: return 0.6
-    case .medium, .large, .xlarge: return 0.8
-    }
-  }
+  // ProgressView().progressViewStyle(.circular) base size on iOS
+  private static let progressViewBaseLength: CGFloat = 20
 }
 
 private struct SUBezierButtonStyle: ButtonStyle, Themeable {
@@ -160,7 +164,7 @@ struct SUBezierButton_Previews: PreviewProvider {
       SUBezierButton(size: .small, variant: .outlined, semantic: .secondary, title: "Label") {}
       SUBezierButton(size: .medium, variant: .ghost, semantic: .destructive, title: "Label") {}
       SUBezierButton(size: .large, variant: .filled, semantic: .destructive, title: "Confirm", leadingIcon: Image(systemName: "trash")) {}
-      SUBezierButton(size: .xlarge, variant: .filled, semantic: .primary, resizing: .fill, title: "Continue", trailingIcon: Image(systemName: "arrow.right")) {}
+      SUBezierButton(size: .xlarge, variant: .filled, semantic: .primary, title: "Continue", trailingIcon: Image(systemName: "arrow.right")) {}
       SUBezierButton(size: .medium, variant: .filled, semantic: .primary, title: "Loading", isLoading: true) {}
     }
     .padding()

--- a/Sources/BezierSwift/MasterComponent/BezierButton/SUBezierButton.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierButton/SUBezierButton.swift
@@ -1,0 +1,168 @@
+//
+//  SUBezierButton.swift
+//  BezierSwift
+//
+
+import SwiftUI
+
+public struct SUBezierButton: View, Themeable {
+  private let size: BezierButtonSize
+  private let variant: BezierButtonVariant
+  private let semantic: BezierButtonSemantic
+  private let resizing: BezierButtonResizing
+  private let title: String?
+  private let leadingIcon: Image?
+  private let trailingIcon: Image?
+  private let isLoading: Bool
+  private let action: () -> Void
+
+  @Environment(\.isEnabled) private var isEnabled
+  @Environment(\.colorScheme) public var colorScheme
+
+  public init(
+    size: BezierButtonSize,
+    variant: BezierButtonVariant,
+    semantic: BezierButtonSemantic,
+    resizing: BezierButtonResizing = .hug,
+    title: String? = nil,
+    leadingIcon: Image? = nil,
+    trailingIcon: Image? = nil,
+    isLoading: Bool = false,
+    action: @escaping () -> Void
+  ) {
+    self.size = size
+    self.variant = variant
+    self.semantic = semantic
+    self.resizing = resizing
+    self.title = title
+    self.leadingIcon = leadingIcon
+    self.trailingIcon = trailingIcon
+    self.isLoading = isLoading
+    self.action = action
+  }
+
+  public var body: some View {
+    Button(action: { if !self.isLoading { self.action() } }) {
+      ZStack {
+        self.contentStack
+          .opacity(self.isLoading ? 0 : 1)
+
+        if self.isLoading {
+          self.loadingIndicator
+        }
+      }
+      .padding(.horizontal, self.size.horizontalPadding)
+      .frame(
+        minWidth: self.resizing == .fill ? nil : self.size.minWidth,
+        maxWidth: self.resizing == .fill ? .infinity : nil,
+        minHeight: self.size.height,
+        maxHeight: self.size.height
+      )
+    }
+    .buttonStyle(
+      SUBezierButtonStyle(
+        size: self.size,
+        variant: self.variant,
+        semantic: self.semantic,
+        isLoading: self.isLoading
+      )
+    )
+    .opacity(self.isEnabled ? 1 : BezierButtonConstant.disabledOpacity)
+  }
+
+  private var contentStack: some View {
+    HStack(spacing: self.size.contentSpacing) {
+      if let leadingIcon = self.leadingIcon {
+        self.iconView(leadingIcon)
+      }
+
+      if let title = self.title, !title.isEmpty {
+        Text(title)
+          .applyBezierFontStyle(
+            self.size.typography,
+            semanticColorToken: self.variant.foregroundToken(self.semantic)
+          )
+          .padding(.horizontal, self.size.textHorizontalPadding)
+          .fixedSize(horizontal: true, vertical: false)
+      }
+
+      if let trailingIcon = self.trailingIcon {
+        self.iconView(trailingIcon)
+      }
+    }
+  }
+
+  private func iconView(_ image: Image) -> some View {
+    image
+      .renderingMode(.template)
+      .resizable()
+      .scaledToFit()
+      .frame(width: self.size.iconLength, height: self.size.iconLength)
+      .foregroundColor(self.palette(self.variant.foregroundToken(self.semantic)))
+  }
+
+  private var loadingIndicator: some View {
+    ProgressView()
+      .progressViewStyle(.circular)
+      .tint(self.palette(self.variant.foregroundToken(self.semantic)))
+      .scaleEffect(self.loadingScale)
+  }
+
+  private var loadingScale: CGFloat {
+    switch self.size {
+    case .xsmall, .small: return 0.6
+    case .medium, .large, .xlarge: return 0.8
+    }
+  }
+}
+
+private struct SUBezierButtonStyle: ButtonStyle, Themeable {
+  let size: BezierButtonSize
+  let variant: BezierButtonVariant
+  let semantic: BezierButtonSemantic
+  let isLoading: Bool
+
+  @Environment(\.colorScheme) var colorScheme
+
+  func makeBody(configuration: Configuration) -> some View {
+    configuration.label
+      .background(self.backgroundShape)
+      .clipShape(Capsule())
+      .overlay(self.borderShape)
+      .opacity(configuration.isPressed && !self.isLoading ? BezierButtonConstant.pressedOpacity : 1)
+  }
+
+  @ViewBuilder
+  private var backgroundShape: some View {
+    if let token = self.variant.backgroundToken(self.semantic) {
+      Capsule().fill(self.palette(token))
+    } else {
+      Color.clear
+    }
+  }
+
+  @ViewBuilder
+  private var borderShape: some View {
+    if let token = self.variant.borderToken(self.semantic) {
+      Capsule()
+        .strokeBorder(
+          self.palette(token),
+          lineWidth: BezierButtonConstant.borderWidth
+        )
+    }
+  }
+}
+
+struct SUBezierButton_Previews: PreviewProvider {
+  static var previews: some View {
+    VStack(spacing: 12) {
+      SUBezierButton(size: .xsmall, variant: .filled, semantic: .primary, title: "Label") {}
+      SUBezierButton(size: .small, variant: .outlined, semantic: .secondary, title: "Label") {}
+      SUBezierButton(size: .medium, variant: .ghost, semantic: .destructive, title: "Label") {}
+      SUBezierButton(size: .large, variant: .filled, semantic: .destructive, title: "Confirm", leadingIcon: Image(systemName: "trash")) {}
+      SUBezierButton(size: .xlarge, variant: .filled, semantic: .primary, resizing: .fill, title: "Continue", trailingIcon: Image(systemName: "arrow.right")) {}
+      SUBezierButton(size: .medium, variant: .filled, semantic: .primary, title: "Loading", isLoading: true) {}
+    }
+    .padding()
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierDialog/BezierDialog.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierDialog/BezierDialog.swift
@@ -31,7 +31,7 @@ struct BezierDialog: View, Themeable {
   struct ViewState {
     let title: String
     let description: String
-    let buttons: [BezierButton]
+    let buttons: [LegacyBezierButton]
     let buttonAxis: Axis
     
     init(param: BezierDialogParam) {

--- a/Sources/BezierSwift/MasterComponent/BezierDialog/BezierDialogParam.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierDialog/BezierDialogParam.swift
@@ -27,8 +27,8 @@ public struct BezierDialogParam {
 }
 
 public enum BezierDialogButtonInfo {
-  case vertical([BezierButton])
-  case horizontal([BezierButton])
+  case vertical([LegacyBezierButton])
+  case horizontal([LegacyBezierButton])
 }
 
 public enum BezierDialogPriority {

--- a/Sources/BezierSwift/MasterComponent/BezierIconButton/BezierIconButton.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierIconButton/BezierIconButton.swift
@@ -1,0 +1,196 @@
+//
+//  BezierIconButton.swift
+//  BezierSwift
+//
+
+import UIKit
+
+public final class BezierIconButton: UIControl, BezierComponentable {
+  // MARK: - BezierComponentable
+
+  public var colorTheme: BezierColorTheme { .systemBezierColorTheme() }
+  public var componentTheme: BezierComponentTheme = .normal {
+    didSet { self.refreshAppearance() }
+  }
+
+  // MARK: - Public Properties
+
+  public var size: BezierIconButtonSize = .medium {
+    didSet { if oldValue != self.size { self.refreshLayout() } }
+  }
+
+  public var variant: BezierIconButtonVariant = .ghost {
+    didSet { if oldValue != self.variant { self.refreshAppearance() } }
+  }
+
+  public var icon: UIImage? {
+    didSet { self.refreshContent() }
+  }
+
+  public var isLoading: Bool = false {
+    didSet { if oldValue != self.isLoading { self.refreshLoading() } }
+  }
+
+  public override var isEnabled: Bool {
+    didSet { if oldValue != self.isEnabled { self.refreshEnabled() } }
+  }
+
+  public override var isHighlighted: Bool {
+    didSet { if oldValue != self.isHighlighted { self.refreshAppearance() } }
+  }
+
+  /// Toggle ON 상태(SPEC §4의 `active`). ghost variant에서만 시각 변화 발생.
+  public override var isSelected: Bool {
+    didSet { if oldValue != self.isSelected { self.refreshAppearance() } }
+  }
+
+  // MARK: - Subviews
+
+  private let iconImageView: UIImageView = {
+    let imageView = UIImageView()
+    imageView.contentMode = .scaleAspectFit
+    imageView.translatesAutoresizingMaskIntoConstraints = false
+    return imageView
+  }()
+
+  private let activityIndicator: UIActivityIndicatorView = {
+    let indicator = UIActivityIndicatorView(style: .medium)
+    indicator.hidesWhenStopped = true
+    indicator.translatesAutoresizingMaskIntoConstraints = false
+    return indicator
+  }()
+
+  // MARK: - Layout Constraints (mutable)
+
+  private var widthConstraint: NSLayoutConstraint?
+  private var heightConstraint: NSLayoutConstraint?
+  private var iconWidthConstraint: NSLayoutConstraint?
+  private var iconHeightConstraint: NSLayoutConstraint?
+
+  // MARK: - Init
+
+  public init(
+    size: BezierIconButtonSize = .medium,
+    variant: BezierIconButtonVariant = .ghost
+  ) {
+    self.size = size
+    self.variant = variant
+    super.init(frame: .zero)
+    self.setUp()
+  }
+
+  public required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    self.setUp()
+  }
+
+  // MARK: - Setup
+
+  private func setUp() {
+    self.translatesAutoresizingMaskIntoConstraints = false
+    self.layer.masksToBounds = true
+    self.layer.borderWidth = 0
+
+    self.addSubview(self.iconImageView)
+    self.addSubview(self.activityIndicator)
+
+    let widthConstraint = self.widthAnchor.constraint(equalToConstant: self.size.length)
+    let heightConstraint = self.heightAnchor.constraint(equalToConstant: self.size.length)
+    let iconWidthConstraint = self.iconImageView.widthAnchor.constraint(equalToConstant: self.size.iconLength)
+    let iconHeightConstraint = self.iconImageView.heightAnchor.constraint(equalToConstant: self.size.iconLength)
+
+    NSLayoutConstraint.activate([
+      widthConstraint,
+      heightConstraint,
+      iconWidthConstraint,
+      iconHeightConstraint,
+      self.iconImageView.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+      self.iconImageView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+      self.activityIndicator.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+      self.activityIndicator.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+    ])
+
+    self.widthConstraint = widthConstraint
+    self.heightConstraint = heightConstraint
+    self.iconWidthConstraint = iconWidthConstraint
+    self.iconHeightConstraint = iconHeightConstraint
+
+    self.refreshLayout()
+    self.refreshContent()
+    self.refreshAppearance()
+    self.refreshLoading()
+    self.refreshEnabled()
+  }
+
+  // MARK: - Layout Update
+
+  public override func layoutSubviews() {
+    super.layoutSubviews()
+    self.layer.cornerRadius = self.bounds.height / 2
+  }
+
+  public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    self.refreshAppearance()
+  }
+
+  // MARK: - Refresh
+
+  private func refreshLayout() {
+    self.widthConstraint?.constant = self.size.length
+    self.heightConstraint?.constant = self.size.length
+    self.iconWidthConstraint?.constant = self.size.iconLength
+    self.iconHeightConstraint?.constant = self.size.iconLength
+
+    let baseSize = self.activityIndicator.intrinsicContentSize.width
+    if baseSize > 0 {
+      let scale = self.size.spinnerLength / baseSize
+      self.activityIndicator.transform = CGAffineTransform(scaleX: scale, y: scale)
+    }
+
+    self.setNeedsLayout()
+    self.invalidateIntrinsicContentSize()
+  }
+
+  private func refreshContent() {
+    self.iconImageView.image = self.icon?.withRenderingMode(.alwaysTemplate)
+  }
+
+  private func refreshAppearance() {
+    let baseBackground: UIColor = self.variant.backgroundToken?.palette(self) ?? .clear
+    let isInteractionOverlayActive = self.isHighlighted || self.isSelected
+
+    if self.variant == .ghost && isInteractionOverlayActive {
+      // SPEC §4: ghost의 pressed / active 상태는 raw rgba(0,0,0,0.05) overlay 적용
+      self.backgroundColor = UIColor(white: 0, alpha: BezierIconButtonConstant.ghostOverlayAlpha)
+    } else {
+      self.backgroundColor = baseBackground
+    }
+
+    let foregroundColor = self.variant.foregroundToken.palette(self)
+    self.iconImageView.tintColor = foregroundColor
+    self.activityIndicator.color = foregroundColor
+  }
+
+  private func refreshLoading() {
+    self.isUserInteractionEnabled = !self.isLoading
+    if self.isLoading {
+      self.iconImageView.isHidden = true
+      self.activityIndicator.startAnimating()
+    } else {
+      self.iconImageView.isHidden = false
+      self.activityIndicator.stopAnimating()
+    }
+  }
+
+  private func refreshEnabled() {
+    self.alpha = self.isEnabled ? 1 : BezierIconButtonConstant.disabledOpacity
+  }
+
+  // MARK: - Touch
+
+  public override func sendAction(_ action: Selector, to target: Any?, for event: UIEvent?) {
+    guard !self.isLoading else { return }
+    super.sendAction(action, to: target, for: event)
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierIconButton/BezierIconButtonSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierIconButton/BezierIconButtonSpec.swift
@@ -1,0 +1,72 @@
+//
+//  BezierIconButtonSpec.swift
+//  BezierSwift
+//
+
+import CoreGraphics
+
+public enum BezierIconButtonSize: String, CaseIterable {
+  case xsmall
+  case small
+  case medium
+  case large
+
+  public var length: CGFloat {
+    switch self {
+    case .xsmall: return 20
+    case .small:  return 24
+    case .medium: return 32
+    case .large:  return 44
+    }
+  }
+
+  public var padding: CGFloat {
+    switch self {
+    case .xsmall: return 2
+    case .small:  return 4
+    case .medium: return 6
+    case .large:  return 12
+    }
+  }
+
+  public var iconLength: CGFloat {
+    self.length - self.padding * 2
+  }
+
+  public var spinnerLength: CGFloat {
+    switch self {
+    case .xsmall: return 12
+    case .small:  return 14
+    case .medium: return 16
+    case .large:  return 18
+    }
+  }
+}
+
+public enum BezierIconButtonVariant: String, CaseIterable {
+  case filled
+  case ghost
+}
+
+extension BezierIconButtonVariant {
+  var backgroundToken: BCSemanticToken? {
+    switch self {
+    case .filled: return .fillNeutralLight
+    case .ghost:  return nil
+    }
+  }
+
+  var foregroundToken: BCSemanticToken {
+    switch self {
+    case .filled: return .iconNeutralHeavy
+    case .ghost:  return .iconNeutral
+    }
+  }
+}
+
+enum BezierIconButtonConstant {
+  static let disabledOpacity: CGFloat = 0.4
+  /// Ghost variant의 pressed / active overlay 색상.
+  /// bezier-tokens에 등록되지 않은 임시값 — Variable 등록 시 교체 예정.
+  static let ghostOverlayAlpha: CGFloat = 0.05
+}

--- a/Sources/BezierSwift/MasterComponent/BezierIconButton/SPEC.md
+++ b/Sources/BezierSwift/MasterComponent/BezierIconButton/SPEC.md
@@ -1,0 +1,153 @@
+# BezierIconButton Spec
+
+> Figma: [🚧 Mobile Components / IconButton](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/?node-id=1735-442)
+> Design spec: [bezier-v3/component-spec/IconButton-spec.md](https://github.com/channel-io/design-team/blob/main/docs/bezier-v3/component-spec/IconButton-spec.md)
+
+아이콘만으로 액션을 표현하는 원형 버튼. 텍스트 레이블이 필요한 경우 `BezierButton` 사용.
+
+- **모양**: 원형 (`cornerRadius = length / 2`)
+- **Accessibility**: `accessibilityLabel` 필수
+- **인접 배치**: 같은 variant로 통일 (예: ghost ↔ ghost / filled ↔ filled)
+
+---
+
+## 1. Component Properties (4축 구조)
+
+Figma 컴포넌트가 정의하는 property와 옵션은 다음 4개가 전부다.
+
+| Property | 값 | 비고 |
+|---|---|---|
+| **Size** | `xsmall` / `small` / `medium` / `large` | 컨테이너 크기 결정 |
+| **variant** | `ghost` / `filled` | 배경 유무 |
+| **semantic** | `secondary` | **단일 값** — 현재 IconButton은 `secondary` 외 semantic을 정의하지 않는다 |
+| **state** | `default` / `pressed` / `active` / `disabled` / `loading` | 상호작용 상태 |
+
+총 instance: `4 × 2 × 1 × 5 = 40개` (Figma 노출 인스턴스 수와 일치)
+
+---
+
+## 2. Size 별 Spec
+
+| Size | Length (W=H) | Padding | Icon Length | Spinner (loading) |
+|---|---|---|---|---|
+| `xsmall` | **20pt** | 2pt | 16pt | 12pt |
+| `small`  | **24pt** | 4pt | 16pt | 14pt |
+| `medium` | **32pt** | 6pt | 20pt | 16pt |
+| `large`  | **44pt** | 12pt | 20pt | 18pt |
+
+- `iconLength = length - padding × 2`
+- `cornerRadius = length / 2` (완전 원형)
+- 모든 사이즈에서 `min-width = length` (contents에 의해 줄어들지 않음)
+
+---
+
+## 3. Variant 별 컬러 토큰
+
+`semantic = secondary` 단일 값이므로 매트릭스는 variant 축만으로 결정된다.
+
+### Background (배경)
+
+| Variant | Background | Figma Variable | Raw |
+|---|---|---|---|
+| `filled` | `fillNeutralLight` | `color/fill/neutral/light` | `#0000000D` (5% black) |
+| `ghost`  | — *(transparent)* | — | — |
+
+### Foreground (아이콘 색)
+
+| Variant | Foreground | Figma Variable | Raw |
+|---|---|---|---|
+| `filled` | `iconNeutralHeavy` | `color/icon/neutral/heavy` | `#00000099` (60% black) |
+| `ghost`  | `iconNeutral` | `color/icon/neutral` | `#00000066` (40% black) |
+
+---
+
+## 4. Typography
+
+이 컴포넌트에 텍스트 없음 — IconButton은 아이콘만 표시한다. 텍스트 레이블이 필요한 경우 `BezierButton`을 사용한다.
+
+---
+
+## 5. State 별 시각 동작
+
+| State | Ghost 변경점 | Filled 변경점 | 인터랙션 |
+|---|---|---|---|
+| `default` | 기본 (배경 없음) | 기본 (배경 `fillNeutralLight`) | 활성 |
+| `pressed` | 배경 `rgba(0,0,0,0.05)` 오버레이 *(임시)* | **default와 동일** *(추가 변경 없음)* | 활성 |
+| `active`  | 배경 `rgba(0,0,0,0.05)` 오버레이 *(임시)* | **default와 동일** *(추가 변경 없음)* | 토글 ON 상태 표현 |
+| `disabled` | opacity **0.4** | opacity **0.4** | 비활성 (`isEnabled = false`) |
+| `loading`  | 아이콘 숨김 + spinner 표시 *(배경은 default와 동일)* | 아이콘 숨김 + spinner 표시 *(배경은 default와 동일)* | 비활성 (사용자 입력 차단) |
+
+> ⚠️ **HOVER-MIGRATION**: `ghost` variant의 `pressed` / `active` 오버레이 색상은 현재 `bezier-tokens`에 공식 등록되지 않아 raw `rgba(0,0,0,0.05)`를 사용한다. 토큰 등록 시 Variable로 일괄 교체 예정.
+>
+> ℹ️ `filled` variant는 Figma상 `default = pressed = active = loading` 모두 동일한 배경(`fillNeutralLight`)을 사용하며, **상호작용에 따른 추가 overlay가 적용되지 않는다**.
+
+### State 별 구현 가이드
+
+- `filled`의 `pressed` / `active`: 추가 overlay 없음 — `default`와 동일하게 렌더링
+- `disabled`: opacity `0.4` 적용
+- `loading`: OS 표준 ActivityIndicator 사용 (UIKit: `UIActivityIndicatorView` / SwiftUI: `ProgressView`). 컴포넌트 크기는 위 표의 Spinner 값에 맞춰 적용
+
+---
+
+## 6. Loading Indicator
+
+| Size | Spinner | 배치 |
+|---|---|---|
+| `xsmall` | 12pt | 컨테이너 중앙, 아이콘 자리를 invisible 처리 후 absolute 중앙 정렬 |
+| `small`  | 14pt | 동일 |
+| `medium` | 16pt | 동일 |
+| `large`  | 18pt | 동일 |
+
+### Spinner 색상
+
+| 요소 | Figma | Token | Raw |
+|---|---|---|---|
+| Indicator (회전 부분) | foreground 색과 동일 | `iconNeutral` (ghost) / `iconNeutralHeavy` (filled) | #00000066 / #00000099 |
+| Track (배경 호) | `color/border/neutral` | `borderNeutral` | `#00000014` (8% black) |
+
+> ℹ️ OS 표준 ActivityIndicator(UIKit `UIActivityIndicatorView` / SwiftUI `ProgressView` `.circular`)는 indicator와 track 색을 분리 지정할 수 없다. 따라서 구현에서는 indicator만 foreground 색으로 적용하고, track의 `borderNeutral` 표현은 시각적으로 누락됨(OS 한계). 정밀한 트랙 표현이 필요하면 커스텀 spinner 도입 협의가 필요.
+
+### 기타
+- Loading 시에도 컨테이너 자체 사이즈는 유지 (layout shift 없음)
+- Filled 배경은 그대로 유지, Ghost는 배경 없음 유지
+
+---
+
+## 7. 디자이너 가이드라인 (Figma 컴포넌트 노트)
+
+- **ghost** — 기본값. 투명 배경 위 보조 액션 (닫기, 더보기, 편집, 뒤로가기 등)
+- **filled** — 배경 구분이 필요한 맥락 (카드 위, 미디어 오버레이)
+- **size 가이드**: large(44px) / medium(32px) / small(24px) / xsmall(20px)
+- **state 축**은 Figma 설계용 — disabled/loading/pressed 시각 확인 용도
+- 텍스트 레이블이 필요하면 `BezierButton` 사용
+- 인접 배치 시 동일 variant로 통일
+
+---
+
+## 8. 매핑되는 코드 심볼
+
+| 정의 | 파일 |
+|---|---|
+| UIKit 구현 | `BezierIconButton.swift` |
+| SwiftUI 구현 | `SUBezierIconButton.swift` |
+| size / variant 정의 | `BezierIconButtonSpec.swift` |
+
+> 코드 측에 본 spec의 SSOT(Figma)와 어긋나는 정의가 존재한다면, 그것은 코드 측의 정리 대상이며 spec에 반영하지 않는다.
+
+---
+
+## 9. Variant 매트릭스
+
+총 instance: 4 sizes × 2 variants × 5 states = **40개**
+
+```text
+Size   x variant x state        = Node
+─────────────────────────────────────────────────
+xsmall x ghost   x default      = 1735:347
+xsmall x ghost   x pressed      = 2534:724
+xsmall x ghost   x active       = 2534:796
+xsmall x ghost   x disabled     = 2534:868
+xsmall x ghost   x loading      = 2534:940
+xsmall x filled  x default      = 2635:1665
+... (동일 패턴으로 small / medium / large 각각 10개씩)
+```

--- a/Sources/BezierSwift/MasterComponent/BezierIconButton/SUBezierIconButton.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierIconButton/SUBezierIconButton.swift
@@ -1,0 +1,135 @@
+//
+//  SUBezierIconButton.swift
+//  BezierSwift
+//
+
+import SwiftUI
+
+public struct SUBezierIconButton: View, Themeable {
+  private let size: BezierIconButtonSize
+  private let variant: BezierIconButtonVariant
+  private let icon: Image
+  private let isActive: Bool
+  private let isLoading: Bool
+  private let action: () -> Void
+
+  @Environment(\.isEnabled) private var isEnabled
+  @Environment(\.colorScheme) public var colorScheme
+
+  public init(
+    size: BezierIconButtonSize = .medium,
+    variant: BezierIconButtonVariant = .ghost,
+    icon: Image,
+    isActive: Bool = false,
+    isLoading: Bool = false,
+    action: @escaping () -> Void
+  ) {
+    self.size = size
+    self.variant = variant
+    self.icon = icon
+    self.isActive = isActive
+    self.isLoading = isLoading
+    self.action = action
+  }
+
+  public var body: some View {
+    Button(action: { if !self.isLoading { self.action() } }) {
+      ZStack {
+        self.iconView
+          .opacity(self.isLoading ? 0 : 1)
+
+        if self.isLoading {
+          self.loadingIndicator
+        }
+      }
+      .frame(width: self.size.length, height: self.size.length)
+    }
+    .buttonStyle(
+      SUBezierIconButtonStyle(
+        variant: self.variant,
+        isActive: self.isActive,
+        isLoading: self.isLoading
+      )
+    )
+    .opacity((self.isLoading || self.isEnabled) ? 1 : BezierIconButtonConstant.disabledOpacity)
+    .disabled(self.isLoading)
+  }
+
+  private var iconView: some View {
+    self.icon
+      .renderingMode(.template)
+      .resizable()
+      .scaledToFit()
+      .frame(width: self.size.iconLength, height: self.size.iconLength)
+      .foregroundColor(self.palette(self.variant.foregroundToken))
+  }
+
+  private var loadingIndicator: some View {
+    // ProgressView(.circular) 기본 크기 = 20pt 기준으로 SPEC §5의 spinner 크기 적용
+    ProgressView()
+      .progressViewStyle(.circular)
+      .tint(self.palette(self.variant.foregroundToken))
+      .scaleEffect(self.size.spinnerLength / 20)
+      .frame(width: self.size.spinnerLength, height: self.size.spinnerLength)
+  }
+}
+
+private struct SUBezierIconButtonStyle: ButtonStyle, Themeable {
+  let variant: BezierIconButtonVariant
+  let isActive: Bool
+  let isLoading: Bool
+
+  @Environment(\.colorScheme) var colorScheme
+
+  func makeBody(configuration: Configuration) -> some View {
+    let isInteractionOverlayActive = (configuration.isPressed && !self.isLoading) || self.isActive
+    configuration.label
+      .background(self.backgroundShape(isOverlayActive: isInteractionOverlayActive))
+      .clipShape(Circle())
+  }
+
+  @ViewBuilder
+  private func backgroundShape(isOverlayActive: Bool) -> some View {
+    if self.variant == .ghost && isOverlayActive {
+      // SPEC §4: ghost의 pressed / active overlay (raw rgba(0,0,0,0.05))
+      Circle().fill(Color.black.opacity(BezierIconButtonConstant.ghostOverlayAlpha))
+    } else if let token = self.variant.backgroundToken {
+      Circle().fill(self.palette(token))
+    } else {
+      Color.clear
+    }
+  }
+}
+
+struct SUBezierIconButton_Previews: PreviewProvider {
+  static var previews: some View {
+    VStack(spacing: 16) {
+      HStack(spacing: 12) {
+        SUBezierIconButton(size: .xsmall, variant: .ghost, icon: Image(systemName: "xmark")) {}
+        SUBezierIconButton(size: .small, variant: .ghost, icon: Image(systemName: "xmark")) {}
+        SUBezierIconButton(size: .medium, variant: .ghost, icon: Image(systemName: "xmark")) {}
+        SUBezierIconButton(size: .large, variant: .ghost, icon: Image(systemName: "xmark")) {}
+      }
+
+      HStack(spacing: 12) {
+        SUBezierIconButton(size: .xsmall, variant: .filled, icon: Image(systemName: "xmark")) {}
+        SUBezierIconButton(size: .small, variant: .filled, icon: Image(systemName: "xmark")) {}
+        SUBezierIconButton(size: .medium, variant: .filled, icon: Image(systemName: "xmark")) {}
+        SUBezierIconButton(size: .large, variant: .filled, icon: Image(systemName: "xmark")) {}
+      }
+
+      HStack(spacing: 12) {
+        SUBezierIconButton(size: .medium, variant: .ghost, icon: Image(systemName: "xmark"), isActive: true) {}
+        SUBezierIconButton(size: .medium, variant: .filled, icon: Image(systemName: "xmark"), isActive: true) {}
+      }
+
+      HStack(spacing: 12) {
+        SUBezierIconButton(size: .medium, variant: .ghost, icon: Image(systemName: "xmark"), isLoading: true) {}
+        SUBezierIconButton(size: .large, variant: .filled, icon: Image(systemName: "xmark"), isLoading: true) {}
+        SUBezierIconButton(size: .medium, variant: .filled, icon: Image(systemName: "xmark")) {}
+          .disabled(true)
+      }
+    }
+    .padding()
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/LegacyBezierButton/LegacyBezierButton.swift
+++ b/Sources/BezierSwift/MasterComponent/LegacyBezierButton/LegacyBezierButton.swift
@@ -1,0 +1,732 @@
+//
+//  LegacyBezierButton.swift
+//  
+//
+//  Created by Jam on 2023/02/09.
+//
+
+import SwiftUI
+
+private enum Metric {
+  static let textLeadingTrailing = CGFloat(2)
+}
+
+private enum Constant {
+  static let disalbedOpacity = CGFloat(0.4)
+}
+
+public enum LegacyButtonSize {
+  case xsmall
+  case small
+  case medium
+  case large
+  case xlarge
+  
+  var height: CGFloat {
+    switch self {
+    case .xsmall:
+      return 24
+    case .small:
+      return 30
+    case .medium:
+      return 40
+    case .large:
+      return 44
+    case .xlarge:
+      return 54
+    }
+  }
+  
+  var stackSpacing: CGFloat {
+    switch self {
+    case .xsmall, .small, .medium:
+      return 4
+    case .large:
+      return 5
+    case .xlarge:
+      return 6
+    }
+  }
+  
+  var imageLength: CGFloat {
+    switch self {
+    case .xsmall:
+      return 16
+    case .small:
+      return 20
+    case .medium, .large, .xlarge:
+      return 24
+    }
+  }
+  
+  var font: Font {
+    self.bezierFont.font
+  }
+  
+  var bezierFont: BezierFont {
+    switch self {
+    case .xsmall:
+      return BezierFont.bold13
+    case .small:
+      return BezierFont.bold14
+    case .medium:
+      return BezierFont.bold15
+    case .large, .xlarge:
+      return BezierFont.bold16
+    }
+  }
+  
+  var minLeadingTrailingPadding: CGFloat {
+    switch self {
+    case .xsmall, .small:
+      return 6
+    case .medium:
+      return 8
+    case .large:
+      return 10
+    case .xlarge:
+      return 12
+    }
+  }
+  
+  var topBottomPadding: CGFloat {
+    return (self.height - self.imageLength) / CGFloat(2)
+  }
+  
+  func cornerRadius(type: LegacyButtonType) -> BezierCornerRadius {
+    switch type {
+    case .primary, .secondary, .tertiary:
+      switch self {
+      case .xsmall:
+        return .round6
+      case .small:
+        return .round8
+      case .medium:
+        return .round12
+      case .large:
+        return .round12
+      case .xlarge:
+        return .round16
+      }
+    case .floating:
+      return .roundHalf(length: self.height)
+    }
+  }
+}
+
+public enum LegacyButtonColor: String {
+  case blue
+  case red
+  case green
+  case yellow
+  case cobalt
+  case monochrome // TODO: 레거시. monochromeLight / Dark 논의 이후에 색상 치환할 것.
+  case monochromeLight
+  case monochromeDark
+  case absoulteWhite
+  case orange
+}
+
+public enum LegacyButtonType: Equatable {
+  case primary(LegacyButtonColor)
+  case secondary(LegacyButtonColor)
+  case tertiary(LegacyButtonColor)
+  case floating(LegacyButtonColor)
+  
+  public static func == (lhs: Self, rhs: Self) -> Bool {
+    switch (lhs, rhs) {
+    case (let .primary(lhsColor), let .primary(rhsColor)):
+      return lhsColor == rhsColor
+    case (let .secondary(lhsColor), let .secondary(rhsColor)):
+      return lhsColor == rhsColor
+    case (let .tertiary(lhsColor), let .tertiary(rhsColor)):
+      return lhsColor == rhsColor
+    case (let .floating(lhsColor), let .floating(rhsColor)):
+      return lhsColor == rhsColor
+    default:
+      return false
+    }
+  }
+  
+  func textColor(_ size: LegacyButtonSize) -> BCSemanticToken {
+    switch self {
+    case .primary(let buttonColor):
+      switch buttonColor {
+      case .monochromeLight, .monochromeDark: return .textAbsoluteWhite
+      default: return .textAbsoluteWhite
+      }
+    case .secondary(let color), .tertiary(let color):
+      switch color {
+      case .blue:
+        return .textAccentBlue
+      case .red:
+        return .textAccentRed
+      case .green:
+        return .textAccentGreen
+      case .yellow:
+        return .textAccentYellow
+      case .cobalt:
+        return .textAccentCobalt
+      case .orange:
+        return .textAccentOrange
+      case .monochrome:
+        switch size {
+        case .xsmall, .small:
+          return .textNeutralLight
+        case .medium, .large, .xlarge:
+          return .textNeutral
+        }
+      case .monochromeLight:
+        return .textNeutralLight
+      case .monochromeDark:
+        return .textNeutral
+      case .absoulteWhite:
+        return .textAbsoluteWhite
+      }
+    case .floating(let color):
+      switch color {
+      case .blue, .red, .green, .yellow, .cobalt, .absoulteWhite, .orange:
+        return .textAbsoluteWhite
+      case .monochrome, .monochromeLight, .monochromeDark:
+        return .textNeutral
+      }
+    }
+  }
+  
+  func imageTintColor(_ size: LegacyButtonSize) -> BCSemanticToken {
+    switch self {
+    case .primary(let buttonColor):
+      switch buttonColor {
+      case .monochromeLight, .monochromeDark: return .iconAbsoluteWhite
+      default: return .iconAbsoluteWhite
+      }
+    case .secondary(let color), .tertiary(let color):
+      switch color {
+      case .blue:
+        return .iconAccentBlue
+      case .red:
+        return .iconAccentRed
+      case .green:
+        return .iconAccentGreen
+      case .yellow:
+        return .iconAccentYellow
+      case .cobalt:
+        return .iconAccentCobalt
+      case .orange:
+        return .iconAccentOrange
+      case .monochrome:
+        switch size {
+        case .xsmall, .small:
+          return .iconNeutral
+        case .medium, .large, .xlarge:
+          return .iconNeutralHeavy
+        }
+      case .monochromeLight:
+        return .iconNeutral
+      case .monochromeDark:
+        return .iconNeutralHeavy
+      case .absoulteWhite:
+        return .iconAbsoluteWhite
+      }
+    case .floating(let color):
+      switch color {
+      case .blue, .red, .green, .yellow, .cobalt, .absoulteWhite, .orange:
+        return .iconAbsoluteWhite
+      case .monochrome, .monochromeLight, .monochromeDark:
+        return .iconNeutralHeavy
+      }
+    }
+  }
+  
+  func backgroundColor(state: LegacyButtonState) -> BCSemanticToken {
+    switch self {
+    case .primary(let color):
+      switch color {
+      case .blue:
+        switch state {
+        case .default, .disabled:
+          return .fillAccentBlueHeavier
+        case .pressed:
+          return .fillAccentBlueHeavier
+        }
+      case .red:
+        switch state {
+        case .default, .disabled:
+          return .fillAccentRedHeavier
+        case .pressed:
+          return .fillAccentRedHeavier
+        }
+      case .green:
+        switch state {
+        case .default, .disabled:
+          return .fillAccentGreenHeavier
+        case .pressed:
+          return .fillAccentGreenHeavier
+        }
+      case .yellow:
+        switch state {
+        case .default, .disabled:
+          return .fillAccentYellowHeavier
+        case .pressed:
+          return .fillAccentYellowHeavier
+        }
+      case .cobalt:
+        switch state {
+        case .default, .disabled:
+          return .fillAccentCobaltHeavier
+        case .pressed:
+          return .fillAccentCobaltHeavier
+        }
+      case .orange:
+        switch state {
+        case .default, .disabled:
+          return .fillAccentOrangeHeavier
+        case .pressed:
+          return .fillAccentOrangeHeavier
+        }
+      case .monochrome:
+        switch state {
+        case .default, .disabled:
+          return .fillAbsoluteBlackLight
+        case .pressed:
+          return .dimAbsoluteBlack
+        }
+      case .monochromeLight:
+        return .fillNeutralHeavier
+      case .monochromeDark:
+        return .fillNeutralHeaviest
+      case .absoulteWhite:
+        return .fillNeutralTransparent
+      }
+    case .secondary(let color):
+      switch color {
+      case .blue:
+        switch state {
+        case .default, .disabled:
+          return .fillAccentBlue
+        case .pressed:
+          return .fillAccentBlueHeavy
+        }
+      case .red:
+        switch state {
+        case .default, .disabled:
+          return .fillAccentRed
+        case .pressed:
+          return .fillAccentRedHeavy
+        }
+      case .green:
+        switch state {
+        case .default, .disabled:
+          return .fillAccentGreen
+        case .pressed:
+          return .fillAccentGreenHeavy
+        }
+      case .yellow:
+        switch state {
+        case .default, .disabled:
+          return .fillAccentYellow
+        case .pressed:
+          return .fillAccentYellowHeavy
+        }
+      case .cobalt:
+        switch state {
+        case .default, .disabled:
+          return .fillAccentCobalt
+        case .pressed:
+          return .fillAccentCobaltHeavy
+        }
+      case .orange:
+        switch state {
+        case .default, .disabled:
+          return .fillAccentOrange
+        case .pressed:
+          return .fillAccentOrangeHeavy
+        }
+      case .monochrome, .monochromeLight, .monochromeDark:
+        switch state {
+        case .default, .disabled:
+          return .fillNeutralLighter
+        case .pressed:
+          return .fillNeutralLight
+        }
+      case .absoulteWhite:
+        return .fillNeutralTransparent
+      }
+    case .tertiary(let color):
+      switch color {
+      case .blue:
+        switch state {
+        case .default, .disabled:
+          return .fillNeutralTransparent
+        case .pressed:
+          return .fillAccentBlue
+        }
+      case .red:
+        switch state {
+        case .default, .disabled:
+          return .fillNeutralTransparent
+        case .pressed:
+          return .fillAccentRed
+        }
+      case .green:
+        switch state {
+        case .default, .disabled:
+          return .fillNeutralTransparent
+        case .pressed:
+          return .fillAccentGreen
+        }
+      case .yellow:
+        switch state {
+        case .default, .disabled:
+          return .fillNeutralTransparent
+        case .pressed:
+          return .fillAccentYellow
+        }
+      case .cobalt:
+        switch state {
+        case .default, .disabled:
+          return .fillNeutralTransparent
+        case .pressed:
+          return .fillAccentCobalt
+        }
+      case .orange:
+        switch state {
+        case .default, .disabled:
+          return .fillNeutralTransparent
+        case .pressed:
+          return .fillAccentOrange
+        }
+      case .monochrome, .monochromeLight, .monochromeDark:
+        switch state {
+        case .default, .disabled:
+          return .fillNeutralTransparent
+        case .pressed:
+          return .fillNeutralLighter
+        }
+      case .absoulteWhite:
+        return .fillNeutralTransparent
+      }
+    case .floating(let color):
+      switch color {
+      case .blue:
+        switch state {
+        case .default, .disabled:
+          return .fillAccentBlueHeavier
+        case .pressed:
+          return .fillAccentBlueHeavier
+        }
+      case .red:
+        switch state {
+        case .default, .disabled:
+          return .fillAccentRedHeavier
+        case .pressed:
+          return .fillAccentRedHeavier
+        }
+      case .green:
+        switch state {
+        case .default, .disabled:
+          return .fillAccentGreenHeavier
+        case .pressed:
+          return .fillAccentGreenHeavier
+        }
+      case .yellow:
+        switch state {
+        case .default, .disabled:
+          return .fillAccentYellowHeavier
+        case .pressed:
+          return .fillAccentYellowHeavier
+        }
+      case .cobalt:
+        switch state {
+        case .default, .disabled:
+          return .fillAccentCobaltHeavier
+        case .pressed:
+          return .fillAccentCobaltHeavier
+        }
+      case .orange:
+        switch state {
+        case .default, .disabled:
+          return .fillAccentOrangeHeavier
+        case .pressed:
+          return .fillAccentOrangeHeavier
+        }
+      case .monochrome, .monochromeLight, .monochromeDark:
+        switch state {
+        case .default, .disabled:
+          return .surfaceHighest
+        case .pressed:
+          return .surfaceHigh
+        }
+      case .absoulteWhite:
+        return .fillNeutralTransparent
+      }
+    }
+  }
+}
+
+enum LegacyButtonState {
+  case `default`
+  case pressed
+  case disabled
+}
+
+public enum LegacyButtonResizing {
+  case hug
+  case fill
+}
+
+public struct LegacyBezierButton: View, Themeable {
+  private var size: LegacyButtonSize
+  private var type: LegacyButtonType
+  private var resizing: LegacyButtonResizing
+  
+  private let action: () -> Void
+  private let title: String?
+  private let leftImage: Image?
+  private let rightImage: Image?
+  
+  @Environment(\.colorScheme) public var colorScheme
+  
+  private init(
+    size: LegacyButtonSize,
+    type: LegacyButtonType,
+    resizing: LegacyButtonResizing,
+    titleContent: String? = nil,
+    leftContent: Image? = nil,
+    rightContent: Image? = nil,
+    action: @escaping () -> Void
+  ) {
+    self.size = size
+    self.type = type
+    self.resizing = resizing
+    self.action = action
+    self.title = titleContent
+    self.leftImage = leftContent
+    self.rightImage = rightContent
+  }
+  
+  public init(
+    size: LegacyButtonSize,
+    type: LegacyButtonType,
+    resizing: LegacyButtonResizing,
+    title: String,
+    leftImage: Image,
+    rightImage: Image,
+    action: @escaping () -> Void
+  ) {
+    self.init(
+      size: size,
+      type: type,
+      resizing: resizing,
+      titleContent: title,
+      leftContent: leftImage,
+      rightContent: rightImage,
+      action: action
+    )
+  }
+  
+  public init(
+    size: LegacyButtonSize,
+    type: LegacyButtonType,
+    resizing: LegacyButtonResizing,
+    title: String,
+    leftImage: Image,
+    action: @escaping () -> Void
+  ) {
+    self.init(
+      size: size,
+      type: type,
+      resizing: resizing,
+      titleContent: title,
+      leftContent: leftImage,
+      action: action
+    )
+  }
+  
+  public init(
+    size: LegacyButtonSize,
+    type: LegacyButtonType,
+    resizing: LegacyButtonResizing,
+    title: String,
+    rightImage: Image,
+    action: @escaping () -> Void
+  ) {
+    self.init(
+      size: size,
+      type: type,
+      resizing: resizing,
+      titleContent: title,
+      rightContent: rightImage,
+      action: action
+    )
+  }
+  
+  public init(
+    size: LegacyButtonSize,
+    type: LegacyButtonType,
+    resizing: LegacyButtonResizing,
+    centerImage: Image,
+    action: @escaping () -> Void
+  ) {
+    self.init(
+      size: size,
+      type: type,
+      resizing: resizing,
+      leftContent: centerImage,
+      action: action
+    )
+  }
+  
+  public init(
+    size: LegacyButtonSize,
+    type: LegacyButtonType,
+    resizing: LegacyButtonResizing,
+    title: String,
+    action: @escaping () -> Void
+  ) {
+    self.init(
+      size: size,
+      type: type,
+      resizing: resizing,
+      titleContent: title,
+      action: action
+    )
+  }
+  
+  public var body: some View {
+    Button {
+      self.action()
+    } label: {
+      HStack(alignment: .center, spacing: self.size.stackSpacing) {
+        if self.resizing == .fill {
+          Spacer(minLength: 0)
+        }
+        
+        if let leftImage {
+          leftImage
+            .applyBaseImageStyle()
+            .foregroundColor(self.palette(self.type.imageTintColor(self.size)))
+            .frame(width: self.size.imageLength, height: self.size.imageLength)
+        }
+        
+        if let title {
+          Text(title)
+            .applyBezierFontStyle(
+              self.size.bezierFont,
+              semanticColorToken: self.type.textColor(self.size)
+            )
+            .padding(.horizontal, Metric.textLeadingTrailing)
+        }
+        
+        if let rightImage {
+          rightImage
+            .applyBaseImageStyle()
+            .foregroundColor(self.palette(self.type.imageTintColor(self.size)))
+            .frame(width: self.size.imageLength, height: self.size.imageLength)
+        }
+        
+        if self.resizing == .fill {
+          Spacer(minLength: 0)
+        }
+      }
+      .padding(.horizontal, self.minLeadingTrailing)
+    }
+    .buttonStyle(
+      LegacyBezierButtonStyle(
+        size: size,
+        type: type,
+        resizing: resizing
+      )
+    )
+  }
+  
+  private var minLeadingTrailing: CGFloat {
+    let isImageOnly = self.title.isNil
+    && (
+      (self.leftImage.isNotNil || self.rightImage.isNil)
+      || (self.leftImage.isNil || self.rightImage.isNotNil)
+    )
+    let minLeadingTrailing = isImageOnly
+    ? self.size.topBottomPadding : self.size.minLeadingTrailingPadding
+    
+    return minLeadingTrailing
+  }
+}
+
+private extension Image {
+  func applyBaseImageStyle() -> some View {
+    self
+      .renderingMode(.template)
+      .resizable()
+      .scaledToFit()
+  }
+}
+
+private struct LegacyBezierButtonStyle: ButtonStyle, Themeable {
+  @Environment(\.colorScheme) var colorScheme
+  
+  private let size: LegacyButtonSize
+  private let type: LegacyButtonType
+  private let resizing: LegacyButtonResizing
+  
+  @Environment(\.isEnabled) var isEnabled: Bool
+  
+  init(
+    size: LegacyButtonSize,
+    type: LegacyButtonType,
+    resizing: LegacyButtonResizing
+  ) {
+    self.size = size
+    self.type = type
+    self.resizing = resizing
+  }
+  
+  func makeBody(configuration: Configuration) -> some View {
+    let buttonState: LegacyButtonState = self.getState(configuration: configuration, isEnabled: self.isEnabled)
+    configuration.label
+      .frame(height: self.size.height)
+      .disabled(!self.isEnabled)
+      .background(self.palette(self.type.backgroundColor(state: buttonState)))
+      .applyBezierCornerRadius(type: self.size.cornerRadius(type: self.type))
+      .opacity(self.isEnabled ? 1 : Constant.disalbedOpacity)
+  }
+  
+  private func getState(configuration: Configuration, isEnabled: Bool) -> LegacyButtonState {
+    return configuration.isPressed ? .pressed : isEnabled ? .default : .disabled
+  }
+}
+
+struct LegacyBezierButton_Previews: PreviewProvider {
+  static var previews: some View {
+    VStack {
+      LegacyBezierButton(size: .large, type: .primary(.green), resizing: .fill, title: "Get started", leftImage: Image(systemName: "trash")) {
+        print("")
+      }
+
+      LegacyBezierButton(size: .large, type: .primary(.blue), resizing: .hug, title: "Get started", leftImage: Image(systemName: "trash"), rightImage: Image(systemName: "trash")) {
+        print("")
+      }
+      
+      LegacyBezierButton(size: .large, type: .primary(.red), resizing: .hug, title: "Get started", leftImage: Image(systemName: "trash"), rightImage: Image(systemName: "trash")) {
+        print("")
+      }
+      
+      LegacyBezierButton(size: .large, type: .secondary(.red), resizing: .hug, title: "Get started", leftImage: Image(systemName: "trash"), rightImage: Image(systemName: "trash")) {
+        print("")
+      }
+      
+      LegacyBezierButton(size: .large, type: .tertiary(.red), resizing: .hug, title: "Get started", leftImage: Image(systemName: "trash"), rightImage: Image(systemName: "trash")) {
+        print("")
+      }
+      
+      LegacyBezierButton(size: .large, type: .floating(.cobalt), resizing: .hug, title: "Get started", leftImage: Image(systemName: "trash"), rightImage: Image(systemName: "trash")) {
+        print("")
+      }
+      
+      LegacyBezierButton(size: .large, type: .primary(.yellow), resizing: .hug, centerImage: Image(systemName: "trash")) {
+        print("")
+      }
+      
+    }.padding()
+  }
+}


### PR DESCRIPTION
## Summary

V3 컴포넌트 첫 배치(`feature/bezier-3-components`)를 `develop`에 반영합니다.

### 포함된 변경사항

- #119 [MOB-4876] V3 BezierButton 추가 (SwiftUI/UIKit) + V1 LegacyBezierButton 분리
- #120 [MOB-4878] V3 BezierBadge 추가 (SwiftUI/UIKit) + Figma SSOT 정합
- #121 [MOB-4877] V3 BezierIconButton 추가 (SwiftUI/UIKit)
- #122 [MOB-4914] BezierButton Figma SSOT 정렬 (Spec/Resizing/Spinner/Typography)

### 주요 내용

- **BezierButton (V3)**: SwiftUI(`SUBezierButton`)/UIKit(`BezierButton`) 신규 구현, Figma SSOT 기반 Spec/Resizing/Spinner/Typography 정합
- **LegacyBezierButton**: 기존 V1 BezierButton을 `LegacyBezierButton`으로 분리
- **BezierBadge (V3)**: SwiftUI(`SUBezierBadge`)/UIKit(`BezierBadge`) 신규 구현, Figma SSOT 정합
- **BezierIconButton (V3)**: SwiftUI(`SUBezierIconButton`)/UIKit(`BezierIconButton`) 신규 구현
- SwiftUIExample / UIKitExample 카탈로그에 TestView 추가

## Test plan

- [ ] SwiftUIExample 앱에서 BezierButton / BezierBadge / BezierIconButton TestView 동작 확인
- [ ] UIKitExample 앱에서 BezierButton / BezierBadge / BezierIconButton TestViewController 동작 확인
- [ ] LegacyBezierButton 사용처 영향 없는지 확인 (ch-desk-ios)
- [ ] Figma SSOT와 Spec(BezierButtonSpec/BezierBadgeSpec/BezierIconButtonSpec) 정합성 재확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Badge 컴포넌트 추가: 다양한 크기와 스타일의 뱃지 UI 지원
  * IconButton 컴포넌트 추가: 아이콘 기반 버튼 컴포넌트 구현
  * 컴포넌트 테스트 화면 추가: SwiftUI 및 UIKit 예제에 모든 컴포넌트 탐색 화면 포함

* **리팩토링**
  * BezierButton 구조 개선: 레거시 호환성 유지

* **문서**
  * 각 컴포넌트의 상세 사양 문서 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/channel-io/BezierSwift/pull/125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->