### PR TITLE
[MOB-4881] V3 BezierAvatarGroup 추가 (SwiftUI/UIKit)

### DIFF
--- a/Examples/SwiftUIExample/SwiftUIExample.xcodeproj/project.pbxproj
+++ b/Examples/SwiftUIExample/SwiftUIExample.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		BB48760D2B11FE0100000003 /* BezierBadgeTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB48760C2B11FE0100000003 /* BezierBadgeTestView.swift */; };
 		BB48760D2B11FE0100000004 /* BezierTagTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB48760C2B11FE0100000004 /* BezierTagTestView.swift */; };
 		BB48760D2B11FE0100000005 /* BezierAvatarTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB48760C2B11FE0100000005 /* BezierAvatarTestView.swift */; };
+		2D122907FF204DA89587EA9E /* BezierAvatarGroupTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CBB9C2A00BF4BA68A35491A /* BezierAvatarGroupTestView.swift */; };
 		E2789E4D2A737BC700B98B8D /* BezierElevationTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2789E4C2A737BC700B98B8D /* BezierElevationTestView.swift */; };
 		E28212322A4B32F700018327 /* SwiftUIExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28212312A4B32F700018327 /* SwiftUIExampleApp.swift */; };
 		E28212342A4B32F700018327 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28212332A4B32F700018327 /* ContentView.swift */; };
@@ -30,6 +31,7 @@
 		BB48760C2B11FE0100000003 /* BezierBadgeTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierBadgeTestView.swift; sourceTree = "<group>"; };
 		BB48760C2B11FE0100000004 /* BezierTagTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierTagTestView.swift; sourceTree = "<group>"; };
 		BB48760C2B11FE0100000005 /* BezierAvatarTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierAvatarTestView.swift; sourceTree = "<group>"; };
+		2CBB9C2A00BF4BA68A35491A /* BezierAvatarGroupTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierAvatarGroupTestView.swift; sourceTree = "<group>"; };
 		E2789E4C2A737BC700B98B8D /* BezierElevationTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierElevationTestView.swift; sourceTree = "<group>"; };
 		E282122E2A4B32F700018327 /* SwiftUIExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftUIExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E28212312A4B32F700018327 /* SwiftUIExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIExampleApp.swift; sourceTree = "<group>"; };
@@ -61,6 +63,7 @@
 				BB48760C2B11FE0100000003 /* BezierBadgeTestView.swift */,
 				BB48760C2B11FE0100000004 /* BezierTagTestView.swift */,
 				BB48760C2B11FE0100000005 /* BezierAvatarTestView.swift */,
+				2CBB9C2A00BF4BA68A35491A /* BezierAvatarGroupTestView.swift */,
 			);
 			path = TestViews;
 			sourceTree = "<group>";
@@ -191,6 +194,7 @@
 				BB48760D2B11FE0100000003 /* BezierBadgeTestView.swift in Sources */,
 				BB48760D2B11FE0100000004 /* BezierTagTestView.swift in Sources */,
 				BB48760D2B11FE0100000005 /* BezierAvatarTestView.swift in Sources */,
+				2D122907FF204DA89587EA9E /* BezierAvatarGroupTestView.swift in Sources */,
 				E28212322A4B32F700018327 /* SwiftUIExampleApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Examples/SwiftUIExample/SwiftUIExample/ContentView.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/ContentView.swift
@@ -35,6 +35,9 @@ struct ContentView: View, Themeable {
         NavigationLink("Avatar") {
           BezierAvatarTestView()
         }
+        NavigationLink("AvatarGroup") {
+          BezierAvatarGroupTestView()
+        }
         NavigationLink("Elevation Test") {
           BezierElevationTestView()
         }

--- a/Examples/SwiftUIExample/SwiftUIExample/TestViews/BezierAvatarGroupTestView.swift
+++ b/Examples/SwiftUIExample/SwiftUIExample/TestViews/BezierAvatarGroupTestView.swift
@@ -1,0 +1,104 @@
+//
+//  BezierAvatarGroupTestView.swift
+//  SwiftUIExample
+//
+
+import SwiftUI
+import BezierSwift
+
+struct BezierAvatarGroupTestView: View {
+  @State private var size: BezierAvatarGroupSize = .size24
+  @State private var ellipsisType: BezierAvatarGroupEllipsisType = .icon
+  @State private var avatarCount: Double = 5
+
+  private let sampleImage = Image("AvatarSample")
+
+  private var avatars: [Image?] {
+    Array(repeating: self.sampleImage, count: Int(self.avatarCount))
+  }
+
+  var body: some View {
+    Form {
+      Section("Preview") {
+        HStack {
+          Spacer()
+          SUBezierAvatarGroup(
+            avatars: self.avatars,
+            size: self.size,
+            ellipsisType: self.ellipsisType
+          )
+          Spacer()
+        }
+        .padding(.vertical, 16)
+      }
+
+      Section("Size") {
+        Picker("Size", selection: self.$size) {
+          ForEach(BezierAvatarGroupSize.allCases, id: \.self) { size in
+            Text(size.rawValue).tag(size)
+          }
+        }
+      }
+
+      Section("Ellipsis Type") {
+        Picker("EllipsisType", selection: self.$ellipsisType) {
+          ForEach(BezierAvatarGroupEllipsisType.allCases, id: \.self) { type in
+            Text(type.rawValue).tag(type)
+          }
+        }
+        .pickerStyle(.segmented)
+      }
+
+      Section("Avatar Count: \(Int(self.avatarCount))") {
+        Slider(value: self.$avatarCount, in: 0...10, step: 1)
+      }
+
+      Section("Catalog (4 variant × count)") {
+        ScrollView(.vertical) {
+          VStack(alignment: .leading, spacing: 24) {
+            ForEach(BezierAvatarGroupSize.allCases, id: \.self) { size in
+              ForEach(BezierAvatarGroupEllipsisType.allCases, id: \.self) { type in
+                self.catalogRow(size: size, type: type)
+              }
+            }
+          }
+          .padding(.vertical, 8)
+        }
+        .frame(height: 480)
+      }
+    }
+    .navigationTitle("AvatarGroup (SwiftUI)")
+  }
+
+  private func catalogRow(size: BezierAvatarGroupSize, type: BezierAvatarGroupEllipsisType) -> some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Text("size=\(size.rawValue), ellipsisType=\(type.rawValue)")
+        .font(.caption.weight(.semibold))
+        .foregroundColor(.secondary)
+      ScrollView(.horizontal, showsIndicators: false) {
+        HStack(alignment: .top, spacing: 24) {
+          ForEach([1, 2, 3, 4, 5, 8, 12], id: \.self) { count in
+            VStack(alignment: .leading, spacing: 4) {
+              Text("\(count)")
+                .font(.caption2)
+                .foregroundColor(.secondary)
+              SUBezierAvatarGroup(
+                avatars: Array(repeating: self.sampleImage, count: count),
+                size: size,
+                ellipsisType: type
+              )
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+struct BezierAvatarGroupTestView_Previews: PreviewProvider {
+  static var previews: some View {
+    NavigationView {
+      BezierAvatarGroupTestView()
+    }
+  }
+}

--- a/Examples/UIKitExample/UIKitExample.xcodeproj/project.pbxproj
+++ b/Examples/UIKitExample/UIKitExample.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		BB48761C2B11FE0200000004 /* BezierBadgeTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB48761D2B11FE0200000004 /* BezierBadgeTestViewController.swift */; };
 		BB4876202B11FE0200000005 /* BezierTagTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB4876212B11FE0200000005 /* BezierTagTestViewController.swift */; };
 		BB4876202B11FE0200000006 /* BezierAvatarTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB4876212B11FE0200000006 /* BezierAvatarTestViewController.swift */; };
+		11E7156BFCAB4B6189F19BF0 /* BezierAvatarGroupTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FBCD40EF27543478ABE817D /* BezierAvatarGroupTestViewController.swift */; };
 		E28212432A4B3C0900018327 /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E28212422A4B3C0900018327 /* BaseViewController.swift */; };
 		A1B2C3E12A737BD700C99C9E /* BezierIconCatalogViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3E02A737BD700C99C9E /* BezierIconCatalogViewController.swift */; };
 		E2C2C3D32A4B2DE700A7E5E6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2C2C3D22A4B2DE700A7E5E6 /* AppDelegate.swift */; };
@@ -28,6 +29,7 @@
 		BB48761D2B11FE0200000004 /* BezierBadgeTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierBadgeTestViewController.swift; sourceTree = "<group>"; };
 		BB4876212B11FE0200000005 /* BezierTagTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierTagTestViewController.swift; sourceTree = "<group>"; };
 		BB4876212B11FE0200000006 /* BezierAvatarTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierAvatarTestViewController.swift; sourceTree = "<group>"; };
+		4FBCD40EF27543478ABE817D /* BezierAvatarGroupTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierAvatarGroupTestViewController.swift; sourceTree = "<group>"; };
 		E28212422A4B3C0900018327 /* BaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
 		A1B2C3E02A737BD700C99C9E /* BezierIconCatalogViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierIconCatalogViewController.swift; sourceTree = "<group>"; };
 		E2C2C3CF2A4B2DE700A7E5E6 /* UIKitExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = UIKitExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -88,6 +90,7 @@
 				BB48761D2B11FE0200000004 /* BezierBadgeTestViewController.swift */,
 				BB4876212B11FE0200000005 /* BezierTagTestViewController.swift */,
 				BB4876212B11FE0200000006 /* BezierAvatarTestViewController.swift */,
+				4FBCD40EF27543478ABE817D /* BezierAvatarGroupTestViewController.swift */,
 				E2C2C3DB2A4B2DE800A7E5E6 /* Assets.xcassets */,
 				E2C2C3DD2A4B2DE800A7E5E6 /* LaunchScreen.storyboard */,
 				E2C2C3E02A4B2DE800A7E5E6 /* Info.plist */,
@@ -176,6 +179,7 @@
 				BB48761C2B11FE0200000004 /* BezierBadgeTestViewController.swift in Sources */,
 				BB4876202B11FE0200000005 /* BezierTagTestViewController.swift in Sources */,
 				BB4876202B11FE0200000006 /* BezierAvatarTestViewController.swift in Sources */,
+				11E7156BFCAB4B6189F19BF0 /* BezierAvatarGroupTestViewController.swift in Sources */,
 				E2C2C3D32A4B2DE700A7E5E6 /* AppDelegate.swift in Sources */,
 				E2C2C3D52A4B2DE700A7E5E6 /* SceneDelegate.swift in Sources */,
 			);

--- a/Examples/UIKitExample/UIKitExample/BezierAvatarGroupTestViewController.swift
+++ b/Examples/UIKitExample/UIKitExample/BezierAvatarGroupTestViewController.swift
@@ -1,0 +1,248 @@
+//
+//  BezierAvatarGroupTestViewController.swift
+//  UIKitExample
+//
+
+import UIKit
+import BezierSwift
+
+final class BezierAvatarGroupTestViewController: BaseViewController {
+  // MARK: - State
+
+  private var size: BezierAvatarGroupSize = .size24
+  private var ellipsisType: BezierAvatarGroupEllipsisType = .icon
+  private var avatarCount: Int = 5
+
+  private let sampleImage: UIImage? = UIImage(named: "AvatarSample")
+
+  // MARK: - Subviews
+
+  private let scrollView: UIScrollView = {
+    let scrollView = UIScrollView()
+    scrollView.translatesAutoresizingMaskIntoConstraints = false
+    return scrollView
+  }()
+
+  private let containerStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    stackView.spacing = 16
+    stackView.alignment = .fill
+    stackView.layoutMargins = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+    stackView.isLayoutMarginsRelativeArrangement = true
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    return stackView
+  }()
+
+  private let previewContainer: UIView = {
+    let view = UIView()
+    view.backgroundColor = .secondarySystemBackground
+    view.layer.cornerRadius = 12
+    view.translatesAutoresizingMaskIntoConstraints = false
+    return view
+  }()
+
+  private lazy var previewAvatarGroup: BezierAvatarGroup = {
+    BezierAvatarGroup(
+      avatars: Array(repeating: self.sampleImage, count: self.avatarCount),
+      size: self.size,
+      ellipsisType: self.ellipsisType
+    )
+  }()
+
+  private lazy var sizeControl: UISegmentedControl = {
+    let titles = BezierAvatarGroupSize.allCases.map { $0.rawValue }
+    let control = UISegmentedControl(items: titles)
+    control.selectedSegmentIndex = BezierAvatarGroupSize.allCases.firstIndex(of: self.size) ?? 0
+    control.addTarget(self, action: #selector(self.onSizeChanged(_:)), for: .valueChanged)
+    return control
+  }()
+
+  private lazy var ellipsisTypeControl: UISegmentedControl = {
+    let titles = BezierAvatarGroupEllipsisType.allCases.map { $0.rawValue }
+    let control = UISegmentedControl(items: titles)
+    control.selectedSegmentIndex = BezierAvatarGroupEllipsisType.allCases.firstIndex(of: self.ellipsisType) ?? 0
+    control.addTarget(self, action: #selector(self.onEllipsisTypeChanged(_:)), for: .valueChanged)
+    return control
+  }()
+
+  private lazy var countSlider: UISlider = {
+    let slider = UISlider()
+    slider.minimumValue = 0
+    slider.maximumValue = 10
+    slider.value = Float(self.avatarCount)
+    slider.isContinuous = true
+    slider.addTarget(self, action: #selector(self.onCountChanged(_:)), for: .valueChanged)
+    return slider
+  }()
+
+  private lazy var countLabel: UILabel = {
+    let label = UILabel()
+    label.text = "Avatar count: \(self.avatarCount)"
+    label.font = .preferredFont(forTextStyle: .footnote)
+    label.textColor = .secondaryLabel
+    return label
+  }()
+
+  // MARK: - Lifecycle
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    self.title = "AvatarGroup (UIKit)"
+    self.view.backgroundColor = .systemBackground
+    self.setUpLayout()
+  }
+
+  private func setUpLayout() {
+    self.view.addSubview(self.scrollView)
+    self.scrollView.addSubview(self.containerStackView)
+
+    NSLayoutConstraint.activate([
+      self.scrollView.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor),
+      self.scrollView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+      self.scrollView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+      self.scrollView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor),
+
+      self.containerStackView.topAnchor.constraint(equalTo: self.scrollView.contentLayoutGuide.topAnchor),
+      self.containerStackView.leadingAnchor.constraint(equalTo: self.scrollView.contentLayoutGuide.leadingAnchor),
+      self.containerStackView.trailingAnchor.constraint(equalTo: self.scrollView.contentLayoutGuide.trailingAnchor),
+      self.containerStackView.bottomAnchor.constraint(equalTo: self.scrollView.contentLayoutGuide.bottomAnchor),
+      self.containerStackView.widthAnchor.constraint(equalTo: self.scrollView.frameLayoutGuide.widthAnchor),
+    ])
+
+    self.containerStackView.addArrangedSubview(self.makeSectionTitle("Preview"))
+    self.containerStackView.addArrangedSubview(self.makePreviewSection())
+    self.containerStackView.addArrangedSubview(self.makeSectionTitle("Size"))
+    self.containerStackView.addArrangedSubview(self.sizeControl)
+    self.containerStackView.addArrangedSubview(self.makeSectionTitle("Ellipsis Type"))
+    self.containerStackView.addArrangedSubview(self.ellipsisTypeControl)
+    self.containerStackView.addArrangedSubview(self.countLabel)
+    self.containerStackView.addArrangedSubview(self.countSlider)
+    self.containerStackView.addArrangedSubview(self.makeSectionTitle("Catalog (4 variant × count)"))
+    self.containerStackView.addArrangedSubview(self.makeCatalogSection())
+  }
+
+  private func makePreviewSection() -> UIView {
+    let stack = UIStackView()
+    stack.axis = .vertical
+    stack.alignment = .center
+    stack.spacing = 12
+    stack.isLayoutMarginsRelativeArrangement = true
+    stack.layoutMargins = UIEdgeInsets(top: 24, left: 16, bottom: 24, right: 16)
+    stack.translatesAutoresizingMaskIntoConstraints = false
+
+    self.previewContainer.addSubview(stack)
+    NSLayoutConstraint.activate([
+      stack.topAnchor.constraint(equalTo: self.previewContainer.topAnchor),
+      stack.leadingAnchor.constraint(equalTo: self.previewContainer.leadingAnchor),
+      stack.trailingAnchor.constraint(equalTo: self.previewContainer.trailingAnchor),
+      stack.bottomAnchor.constraint(equalTo: self.previewContainer.bottomAnchor),
+    ])
+
+    stack.addArrangedSubview(self.previewAvatarGroup)
+    return self.previewContainer
+  }
+
+  private func makeCatalogSection() -> UIView {
+    let container = UIStackView()
+    container.axis = .vertical
+    container.spacing = 20
+    container.alignment = .fill
+
+    let counts = [1, 2, 3, 4, 5, 8, 12]
+
+    for size in BezierAvatarGroupSize.allCases {
+      for type in BezierAvatarGroupEllipsisType.allCases {
+        let title = UILabel()
+        title.text = "size=\(size.rawValue), ellipsisType=\(type.rawValue)"
+        title.font = .preferredFont(forTextStyle: .footnote)
+        title.textColor = .secondaryLabel
+        container.addArrangedSubview(title)
+        container.addArrangedSubview(self.makeCatalogRow(size: size, type: type, counts: counts))
+      }
+    }
+    return container
+  }
+
+  private func makeCatalogRow(
+    size: BezierAvatarGroupSize,
+    type: BezierAvatarGroupEllipsisType,
+    counts: [Int]
+  ) -> UIView {
+    let scroll = UIScrollView()
+    scroll.showsHorizontalScrollIndicator = false
+    scroll.translatesAutoresizingMaskIntoConstraints = false
+
+    let row = UIStackView()
+    row.axis = .horizontal
+    row.alignment = .top
+    row.spacing = 24
+    row.translatesAutoresizingMaskIntoConstraints = false
+
+    for count in counts {
+      let column = UIStackView()
+      column.axis = .vertical
+      column.spacing = 4
+      column.alignment = .leading
+
+      let countLabel = UILabel()
+      countLabel.text = "\(count)"
+      countLabel.font = .preferredFont(forTextStyle: .caption2)
+      countLabel.textColor = .secondaryLabel
+      column.addArrangedSubview(countLabel)
+
+      let group = BezierAvatarGroup(
+        avatars: Array(repeating: self.sampleImage, count: count),
+        size: size,
+        ellipsisType: type
+      )
+      column.addArrangedSubview(group)
+      row.addArrangedSubview(column)
+    }
+
+    scroll.addSubview(row)
+    NSLayoutConstraint.activate([
+      row.topAnchor.constraint(equalTo: scroll.contentLayoutGuide.topAnchor),
+      row.leadingAnchor.constraint(equalTo: scroll.contentLayoutGuide.leadingAnchor),
+      row.trailingAnchor.constraint(equalTo: scroll.contentLayoutGuide.trailingAnchor),
+      row.bottomAnchor.constraint(equalTo: scroll.contentLayoutGuide.bottomAnchor),
+      row.heightAnchor.constraint(equalTo: scroll.frameLayoutGuide.heightAnchor),
+      scroll.heightAnchor.constraint(equalToConstant: size.avatarLength + 28),
+    ])
+    return scroll
+  }
+
+  private func makeSectionTitle(_ text: String) -> UILabel {
+    let label = UILabel()
+    label.text = text
+    label.font = .preferredFont(forTextStyle: .footnote)
+    label.textColor = .secondaryLabel
+    return label
+  }
+
+  // MARK: - Refresh
+
+  private func refreshPreview() {
+    self.previewAvatarGroup.avatars = Array(repeating: self.sampleImage, count: self.avatarCount)
+    self.previewAvatarGroup.size = self.size
+    self.previewAvatarGroup.ellipsisType = self.ellipsisType
+    self.countLabel.text = "Avatar count: \(self.avatarCount)"
+  }
+
+  // MARK: - Actions
+
+  @objc private func onSizeChanged(_ sender: UISegmentedControl) {
+    self.size = BezierAvatarGroupSize.allCases[sender.selectedSegmentIndex]
+    self.refreshPreview()
+  }
+
+  @objc private func onEllipsisTypeChanged(_ sender: UISegmentedControl) {
+    self.ellipsisType = BezierAvatarGroupEllipsisType.allCases[sender.selectedSegmentIndex]
+    self.refreshPreview()
+  }
+
+  @objc private func onCountChanged(_ sender: UISlider) {
+    self.avatarCount = Int(sender.value.rounded())
+    self.refreshPreview()
+  }
+}

--- a/Examples/UIKitExample/UIKitExample/ViewController.swift
+++ b/Examples/UIKitExample/UIKitExample/ViewController.swift
@@ -16,15 +16,17 @@ final class ViewController: BaseViewController {
     case bezierBadge
     case bezierTag
     case bezierAvatar
+    case bezierAvatarGroup
 
     var title: String {
       switch self {
-      case .bezierIconCatalog: return "Bezier Icon Catalog"
-      case .bezierButton:      return "Button"
-      case .bezierIconButton:  return "IconButton"
-      case .bezierBadge:       return "Badge"
-      case .bezierTag:         return "Tag"
-      case .bezierAvatar:      return "Avatar"
+      case .bezierIconCatalog:  return "Bezier Icon Catalog"
+      case .bezierButton:       return "Button"
+      case .bezierIconButton:   return "IconButton"
+      case .bezierBadge:        return "Badge"
+      case .bezierTag:          return "Tag"
+      case .bezierAvatar:       return "Avatar"
+      case .bezierAvatarGroup:  return "AvatarGroup"
       }
     }
   }
@@ -82,6 +84,8 @@ extension ViewController: UITableViewDataSource, UITableViewDelegate {
       self.navigationController?.pushViewController(BezierTagTestViewController(), animated: true)
     case .bezierAvatar:
       self.navigationController?.pushViewController(BezierAvatarTestViewController(), animated: true)
+    case .bezierAvatarGroup:
+      self.navigationController?.pushViewController(BezierAvatarGroupTestViewController(), animated: true)
     }
   }
 }

--- a/Sources/BezierSwift/MasterComponent/BezierAvatarGroup/BezierAvatarGroup.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierAvatarGroup/BezierAvatarGroup.swift
@@ -1,0 +1,207 @@
+//
+//  BezierAvatarGroup.swift
+//  BezierSwift
+//
+
+import UIKit
+
+public final class BezierAvatarGroup: UIView, BezierComponentable {
+  // MARK: - BezierComponentable
+
+  public var colorTheme: BezierColorTheme { .systemBezierColorTheme() }
+  public var componentTheme: BezierComponentTheme = .normal {
+    didSet { self.refresh() }
+  }
+
+  // MARK: - Public Properties
+
+  public var avatars: [UIImage?] = [] {
+    didSet { self.refresh() }
+  }
+
+  public var size: BezierAvatarGroupSize = .size20 {
+    didSet { if oldValue != self.size { self.refresh() } }
+  }
+
+  public var ellipsisType: BezierAvatarGroupEllipsisType = .icon {
+    didSet { if oldValue != self.ellipsisType { self.refresh() } }
+  }
+
+  // MARK: - Private State
+
+  private var managedSubviews: [UIView] = []
+
+  private var widthConstraint: NSLayoutConstraint?
+  private var heightConstraint: NSLayoutConstraint?
+
+  // MARK: - Init
+
+  public init(
+    avatars: [UIImage?] = [],
+    size: BezierAvatarGroupSize = .size20,
+    ellipsisType: BezierAvatarGroupEllipsisType = .icon
+  ) {
+    self.avatars = avatars
+    self.size = size
+    self.ellipsisType = ellipsisType
+    super.init(frame: .zero)
+    self.setUp()
+  }
+
+  public required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    self.setUp()
+  }
+
+  // MARK: - Setup
+
+  private func setUp() {
+    self.translatesAutoresizingMaskIntoConstraints = false
+    self.clipsToBounds = false
+
+    let width = self.widthAnchor.constraint(equalToConstant: 0)
+    let height = self.heightAnchor.constraint(equalToConstant: 0)
+    NSLayoutConstraint.activate([width, height])
+    self.widthConstraint = width
+    self.heightConstraint = height
+
+    self.refresh()
+  }
+
+  public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    self.refresh()
+  }
+
+  // MARK: - Refresh
+
+  private func refresh() {
+    for view in self.managedSubviews { view.removeFromSuperview() }
+    self.managedSubviews.removeAll()
+
+    let maxVisible = BezierAvatarGroupConstant.maxVisibleAvatars
+    let visibleCount = min(self.avatars.count, maxVisible)
+    let hasOverflow = self.avatars.count > maxVisible
+    let stride: CGFloat
+    switch self.ellipsisType {
+    case .icon:  stride = self.size.iconVariantStride
+    case .count: stride = self.size.countVariantStride
+    }
+    let avatarLength = self.size.avatarLength
+
+    var totalWidth: CGFloat = 0
+
+    for index in 0..<visibleCount {
+      let avatar = BezierAvatar(image: self.avatars[index], size: self.size.avatarSize, showBorder: false)
+      self.addSubview(avatar)
+      NSLayoutConstraint.activate([
+        avatar.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: CGFloat(index) * stride),
+        avatar.topAnchor.constraint(equalTo: self.topAnchor),
+      ])
+      self.managedSubviews.append(avatar)
+    }
+
+    if hasOverflow {
+      switch self.ellipsisType {
+      case .icon:
+        let ellipsisLeft = CGFloat(maxVisible) * stride
+        let ellipsisAvatar = BezierAvatar(
+          image: self.avatars[maxVisible],
+          size: self.size.avatarSize,
+          showBorder: false
+        )
+        self.addSubview(ellipsisAvatar)
+        NSLayoutConstraint.activate([
+          ellipsisAvatar.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: ellipsisLeft),
+          ellipsisAvatar.topAnchor.constraint(equalTo: self.topAnchor),
+        ])
+        self.managedSubviews.append(ellipsisAvatar)
+
+        let overlay = UIView()
+        overlay.backgroundColor = BCSemanticToken.dimAbsoluteBlack.palette(self)
+        overlay.layer.cornerRadius = self.size.avatarSize.cornerRadius
+        overlay.layer.masksToBounds = true
+        overlay.translatesAutoresizingMaskIntoConstraints = false
+        overlay.isUserInteractionEnabled = false
+        self.addSubview(overlay)
+        NSLayoutConstraint.activate([
+          overlay.leadingAnchor.constraint(equalTo: ellipsisAvatar.leadingAnchor),
+          overlay.topAnchor.constraint(equalTo: ellipsisAvatar.topAnchor),
+          overlay.widthAnchor.constraint(equalToConstant: avatarLength),
+          overlay.heightAnchor.constraint(equalToConstant: avatarLength),
+        ])
+        self.managedSubviews.append(overlay)
+
+        let icon = UIImageView()
+        icon.image = BezierIcon.more.uiImage?.withRenderingMode(.alwaysTemplate)
+        icon.tintColor = .white
+        icon.contentMode = .scaleAspectFit
+        icon.translatesAutoresizingMaskIntoConstraints = false
+        overlay.addSubview(icon)
+        NSLayoutConstraint.activate([
+          icon.leadingAnchor.constraint(equalTo: overlay.leadingAnchor, constant: self.size.moreIconInset),
+          icon.topAnchor.constraint(equalTo: overlay.topAnchor, constant: self.size.moreIconInset),
+          icon.widthAnchor.constraint(equalToConstant: self.size.moreIconLength),
+          icon.heightAnchor.constraint(equalToConstant: self.size.moreIconLength),
+        ])
+
+        let borderView = UIView()
+        borderView.translatesAutoresizingMaskIntoConstraints = false
+        borderView.isUserInteractionEnabled = false
+        borderView.layer.borderColor = BCSemanticToken.surface.palette(self).cgColor
+        borderView.layer.borderWidth = self.size.avatarSize.borderWidth
+        borderView.layer.cornerRadius = self.size.avatarSize.cornerRadius
+        self.addSubview(borderView)
+        NSLayoutConstraint.activate([
+          borderView.leadingAnchor.constraint(equalTo: ellipsisAvatar.leadingAnchor),
+          borderView.topAnchor.constraint(equalTo: ellipsisAvatar.topAnchor),
+          borderView.widthAnchor.constraint(equalToConstant: avatarLength),
+          borderView.heightAnchor.constraint(equalToConstant: avatarLength),
+        ])
+        self.managedSubviews.append(borderView)
+
+        totalWidth = ellipsisLeft + avatarLength
+
+      case .count:
+        let overflowCount = self.avatars.count - maxVisible
+        let attributedString = self.size.countTextToken.attributedString(
+          self,
+          text: "+\(overflowCount)",
+          semanticColorToken: .textNeutralLighter,
+          alignment: .center
+        )
+
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textAlignment = .center
+        label.numberOfLines = 1
+        label.attributedText = attributedString
+        self.addSubview(label)
+        self.managedSubviews.append(label)
+
+        let intrinsicTextWidth = ceil(attributedString.size().width)
+        let labelWidth = self.size.countTextContainerFixedWidth ?? intrinsicTextWidth
+
+        let lastAvatarRight = CGFloat(visibleCount - 1) * stride + avatarLength
+        let labelLeft = lastAvatarRight + self.size.countTextSpacing
+
+        NSLayoutConstraint.activate([
+          label.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: labelLeft),
+          label.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+          label.widthAnchor.constraint(equalToConstant: labelWidth),
+          label.heightAnchor.constraint(equalToConstant: avatarLength),
+        ])
+
+        totalWidth = labelLeft + labelWidth
+      }
+    } else if visibleCount > 0 {
+      totalWidth = CGFloat(visibleCount - 1) * stride + avatarLength
+    }
+
+    self.widthConstraint?.constant = totalWidth
+    self.heightConstraint?.constant = avatarLength
+
+    self.invalidateIntrinsicContentSize()
+    self.setNeedsLayout()
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierAvatarGroup/BezierAvatarGroupSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierAvatarGroup/BezierAvatarGroupSpec.swift
@@ -1,0 +1,82 @@
+//
+//  BezierAvatarGroupSpec.swift
+//  BezierSwift
+//
+
+import CoreGraphics
+
+// MARK: - AvatarGroup Size
+
+public enum BezierAvatarGroupSize: String, CaseIterable {
+  case size20
+  case size24
+
+  public var avatarSize: BezierAvatarSize {
+    switch self {
+    case .size20: return .size20
+    case .size24: return .size24
+    }
+  }
+
+  public var avatarLength: CGFloat { self.avatarSize.length }
+
+  /// SPEC §2.2 / §2.4: icon variant stride (7pt overlap)
+  public var iconVariantStride: CGFloat {
+    switch self {
+    case .size20: return 13
+    case .size24: return 17
+    }
+  }
+
+  /// SPEC §2.3 / §2.5: count variant stride. size=20은 7pt overlap, size=24는 6pt overlap (Figma SSOT).
+  public var countVariantStride: CGFloat {
+    switch self {
+    case .size20: return 13
+    case .size24: return 18
+    }
+  }
+
+  /// SPEC §2.3 / §2.5: count text 와 마지막 avatar 사이 간격
+  public var countTextSpacing: CGFloat { 4 }
+
+  /// SPEC §5.1: overlay 내부 more 아이콘 length
+  public var moreIconLength: CGFloat {
+    switch self {
+    case .size20: return 12
+    case .size24: return 16
+    }
+  }
+
+  /// SPEC §5.1: overlay edge 로부터 more 아이콘까지의 inset
+  public var moreIconInset: CGFloat { 4 }
+
+  /// SPEC §4: count text typography token
+  public var countTextToken: BTSemanticToken {
+    switch self {
+    case .size20: return .textXSmall(weight: .bold)
+    case .size24: return .textSmall(weight: .bold)
+    }
+  }
+
+  /// SPEC §2.3: size=20 count variant 의 text container 는 16pt 고정 폭. size=24는 intrinsic.
+  public var countTextContainerFixedWidth: CGFloat? {
+    switch self {
+    case .size20: return 16
+    case .size24: return nil
+    }
+  }
+}
+
+// MARK: - Ellipsis Type
+
+public enum BezierAvatarGroupEllipsisType: String, CaseIterable {
+  case icon
+  case count
+}
+
+// MARK: - Constants
+
+public enum BezierAvatarGroupConstant {
+  /// SPEC §I-1: Figma instance preview 기준 3개까지 노출하고 초과분을 ellipsis 로 표시.
+  public static let maxVisibleAvatars: Int = 3
+}

--- a/Sources/BezierSwift/MasterComponent/BezierAvatarGroup/SPEC.md
+++ b/Sources/BezierSwift/MasterComponent/BezierAvatarGroup/SPEC.md
@@ -1,0 +1,220 @@
+# BezierAvatarGroup Spec
+
+> Figma: [🚧 Mobile Components — AvatarGroup](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=1088-38)
+> Design spec doc: [design-team/specs/components/AvatarGroup-spec.md](https://github.com/channel-io/design-team/blob/main/specs/components/AvatarGroup-spec.md)
+
+복수의 Avatar를 겹쳐 표시하고 초과분을 ellipsis 인디케이터로 나타내는 그룹 컴포넌트.
+
+- **모양**: 좌측부터 우측으로 Avatar가 일정 stride로 겹쳐 배치되며, 마지막 슬롯이 ellipsis (overflow) 인디케이터.
+- **사용처 가이드**:
+  - `size=20`: 텍스트 인라인 보조 — 타이핑 인디케이터, 레퍼런스
+  - `size=24`: 리스트·카드·패널 표준 — 담당자, 팔로워, 참여자
+  - `ellipsisType=icon`: 초과 인원 수가 비중요할 때 (3-dot more 아이콘으로 표시)
+  - `ellipsisType=count`: 초과 인원 수 파악이 중요할 때 (`+N` 텍스트로 표시)
+- **Children 제약**: BezierAvatar 컴포넌트만 사용.
+
+---
+
+## 1. Component Properties
+
+Figma 컴포넌트가 정의하는 property와 옵션은 다음이 전부다.
+
+| Property | 값 | 비고 |
+|---|---|---|
+| **size** | `20` / `24` | 그룹 내 모든 Avatar에 일괄 적용 |
+| **ellipsisType** | `icon` / `count` | 마지막 슬롯의 overflow 표현 방식 |
+| **moreText** | string | `count` 일 때 노출되는 `+N` 텍스트 (Figma preview = `+2`) |
+
+총 Figma instance: `2 size × 2 ellipsisType = 4개`
+
+| Node ID | size | ellipsisType | Frame |
+|---|---|---|---|
+| `2695:62` | 20 | icon | 59 × 20 |
+| `2695:39` | 20 | count | 66 × 20 |
+| `2693:15` | 24 | icon | 75 × 24 |
+| `1087:3` | 24 | count | 81 × 24 |
+
+---
+
+## 2. Size 별 Layout
+
+### 2.1. 공통 — Avatar instance
+
+각 슬롯의 Avatar는 다음 BezierAvatar property로 렌더링된다.
+
+| Spec | 값 |
+|---|---|
+| `size` | `20` 또는 `24` (그룹 size 그대로 전달) |
+| `cornerRadius` | size × 0.42 (BezierAvatar SPEC 준수) — `20 → 8.4`, `24 → 10.08` |
+| `borderWidth` (showBorder=true 일 때) | `20 → 1pt`, `24 → 1.5pt` (BezierAvatar SPEC 준수) |
+
+### 2.2. `size=20`, `ellipsisType=icon` (frame 59 × 20)
+
+| Index | 슬롯 | left | size | 외곽 border |
+|---|---|---|---|---|
+| 0 | avatar | 0 | 20 × 20 | 없음 |
+| 1 | avatar | 13 | 20 × 20 | 없음 |
+| 2 | avatar | 26 | 20 × 20 | 없음 |
+| 3 | ellipsis avatar (image + overlay + more icon + border outline) | 39 | 20 × 20 | **있음** (`1pt`, overlay 위 outline §5) |
+
+- **Stride**: `13pt` (각 avatar 사이 7pt overlap).
+- **Total width**: `39 + 20 = 59pt`.
+- 모든 슬롯은 `position: absolute`로 좌상단 기준 배치.
+
+### 2.3. `size=20`, `ellipsisType=count` (frame 66 × 20)
+
+| Index | 슬롯 | left | size | showBorder |
+|---|---|---|---|---|
+| 0 | avatar | 0 | 20 × 20 | false |
+| 1 | avatar | 13 | 20 × 20 | false |
+| 2 | avatar | 26 | 20 × 20 | false |
+| 3 | count text container | 50 | 16 × 20 | — |
+
+- **Stride (avatars)**: `13pt` (7pt overlap, 2.2와 동일).
+- **Avatar→count text 간격**: avatar 끝(46pt) → count 컨테이너 시작(50pt) = `4pt` gap.
+- **count text 컨테이너**: width `16pt`, height `20pt`, `justify-content: center`, horizontal padding `4pt`.
+- **Total width**: `50 + 16 = 66pt`.
+
+### 2.4. `size=24`, `ellipsisType=icon` (frame 75 × 24)
+
+| Index | 슬롯 | left | size | 외곽 border |
+|---|---|---|---|---|
+| 0 | avatar | 0 | 24 × 24 | 없음 |
+| 1 | avatar | 17 | 24 × 24 | 없음 |
+| 2 | avatar | 34 | 24 × 24 | 없음 |
+| 3 | ellipsis avatar (image + overlay + more icon + border outline) | 51 | 24 × 24 | **있음** (`1.5pt`, overlay 위 outline §5) |
+
+- **Stride**: `17pt` (각 avatar 사이 7pt overlap).
+- **Total width**: `51 + 24 = 75pt`.
+
+### 2.5. `size=24`, `ellipsisType=count` (frame 81 × 24)
+
+| Index | 슬롯 | left (cumulative) | size | showBorder |
+|---|---|---|---|---|
+| 0 | avatar | 0 | 24 × 24 | false |
+| 1 | avatar | 18 | 24 × 24 | false |
+| 2 | avatar | 36 | 24 × 24 | false |
+| spacer | spacer | 60 (width 4) | 4 × 24 | — |
+| 3 | count text | 64 | (intrinsic) × 24 | — |
+
+- **Stride (avatars)**: `18pt` (6pt overlap; Figma `mr=-6`).
+- **Avatar→count text 간격**: spacer `4pt` (Figma 명시적 spacer 노드 `1087:21`).
+- **Total width**: `81pt` (Figma frame width와 일치).
+
+> ℹ️ **2.3 vs 2.5의 stride 차이**: `size=20` count는 7pt overlap, `size=24` count는 6pt overlap (Figma SSOT 그대로 반영).
+
+---
+
+## 3. Color 토큰
+
+### 3.1. Avatar 자체
+
+BezierAvatar SPEC 참조. AvatarGroup 자체는 avatar 컬러를 변경하지 않는다.
+
+### 3.2. Ellipsis avatar (icon variant) — border / overlay / more 아이콘
+
+| 위치 | Token | Figma Variable | Raw |
+|---|---|---|---|
+| Avatar border (size=20: 1pt / size=24: 1.5pt) | `surface` | `color/surface` | `#FFFFFF` |
+| Overlay 배경 | `dimAbsoluteBlack` | `color/dim/absolute/black` | `#00000066` (rgba 0,0,0,0.4) |
+| Overlay 내부 `more` 아이콘 | (raw 자산 색 inherit) | — | 자산 raw `#FFFFFF` |
+
+- Overlay는 ellipsis avatar 이미지 위에 동일 크기·동일 cornerRadius로 덮인다.
+
+### 3.3. Count text (count variant)
+
+| 위치 | Token | Figma Variable | Raw |
+|---|---|---|---|
+| `+N` 텍스트 | `textNeutralLighter` | `color/text/neutral/lighter` | `#00000066` (rgba 0,0,0,0.4) |
+
+---
+
+## 4. Typography (count variant)
+
+| Size | Token | Font Size | Line Height | Weight | Family |
+|---|---|---|---|---|---|
+| `20` | `text/xsmall-bold` | 12pt | 16pt | 600 (semi bold) | `Inter` (`text/font-family`) |
+| `24` | `text/small-bold` | 13pt | 18pt | 600 (semi bold) | `Inter` (`text/font-family`) |
+
+- Letter spacing: `0` (`text/letter-spacing`).
+- Italic: 없음.
+
+---
+
+## 5. Ellipsis Indicator — Icon Variant
+
+`ellipsisType=icon` 일 때 마지막 슬롯은 다음 4개 layer 를 *아래에서 위로* 쌓아 렌더링한다.
+
+| z-order | Layer | 내용 | 비고 |
+|---|---|---|---|
+| 1 (bottom) | Avatar image | 일반 avatar와 동일한 이미지 표시 | 자체 border 없음 |
+| 2 | Overlay | Avatar 위에 덮인 반투명 darker layer | 색 §3.2, 크기 = avatar length, 동일 cornerRadius |
+| 3 | More icon | Overlay 중앙 정렬 horizontal 3-dot 아이콘 | 자산 §5.1 |
+| 4 (top) | Border outline | Avatar 외곽 stroke | 색 §3.2, 두께 size=20 → 1pt / size=24 → 1.5pt, 동일 cornerRadius |
+
+> Border가 overlay 보다 *위*에 그려져야 한다. Avatar(이미지) 자체의 border 레이어를 사용하면 overlay 가 border 를 가려 흐려 보이므로, 구현은 BezierAvatar `showBorder=false` 로 그리고 별도 outline layer 를 가장 위에 추가한다 (§I-2 참조).
+
+### 5.1. More 아이콘 자산
+
+| Size 컨텍스트 | 아이콘 length | Overlay 내부 위치 (top-left) | Figma node | Figma data-name |
+|---|---|---|---|---|
+| `size=20` | 12 × 12 | (4, 4) | `2695:89` | `icon/more` (horizontal 3-dot) |
+| `size=24` | 16 × 16 | (4, 4) | `2693:54` | `icon/more` (horizontal 3-dot) |
+
+---
+
+## 6. Ellipsis Indicator — Count Variant
+
+`ellipsisType=count` 일 때 마지막 슬롯은 다음 구성으로 렌더링된다.
+
+| 항목 | 값 |
+|---|---|
+| 텍스트 | `+N` 형식 (예: `+2`, `+12`) |
+| 텍스트 스타일 | §4 typography |
+| 텍스트 색 | §3.3 |
+| Container 정렬 | (`size=20`) 컨테이너 16×20, justify-center, px=4 / (`size=24`) intrinsic width, vertical-center |
+
+---
+
+## 7. State
+
+해당 없음. AvatarGroup 자체는 state property를 갖지 않는다 (default/pressed/active/disabled/loading 분기 없음).
+
+내부 Avatar의 state(default/disabled)는 각 Avatar 인스턴스 단위로 전달되며 그룹 차원의 상태 분기는 없다.
+
+---
+
+# Implementation Notes (Figma 외 — implementation 규칙)
+
+## I-1. 동적 표시 동작
+
+Figma 컴포넌트는 instance preview용으로 항상 *3 visible avatar + 1 ellipsis slot* 으로 그려져 있다. 실제 동적 동작은 다음과 같이 implement한다.
+
+| 입력 avatar 수 | 표시 |
+|---|---|
+| `≤ 3` | 모든 avatar 표시, ellipsis slot 미표시 |
+| `> 3` | 첫 3개 avatar 표시 + 4번째 슬롯에 ellipsis indicator (icon 또는 count) |
+| count variant 의 `+N` | `N = (입력 수) - 3` |
+
+- Visible cap = `3` (Figma instance preview 기준).
+- Ellipsis avatar(icon variant)의 이미지는 4번째 입력 avatar의 이미지를 사용 (Figma instance에서 4번째 avatar 이미지 위에 overlay).
+
+## I-2. BezierSwift 코드 매핑
+
+| Spec 항목 | 코드 심볼 |
+|---|---|
+| Typography size=20 count text | `BTSemanticToken.textXSmall(weight: .bold)` |
+| Typography size=24 count text | `BTSemanticToken.textSmall(weight: .bold)` |
+| Overlay 배경 색 | `BCSemanticToken.dimAbsoluteBlack` |
+| Count text 색 | `BCSemanticToken.textNeutralLighter` |
+| Avatar border 색 | `BCSemanticToken.surface` |
+| More 아이콘 | `BezierIcon.more` (raw value `"icon-more"`) |
+| Avatar 컴포넌트 | `BezierAvatar` / `SUBezierAvatar` (size·cornerRadius·borderWidth는 BezierAvatar SPEC 준수) |
+| Ellipsis avatar border (icon variant) | BezierAvatar 자체 `showBorder` 미사용. 별도 outline layer (UIKit: `borderView` / SwiftUI: `RoundedRectangle().strokeBorder`) 를 overlay·more icon 보다 z-order 위에 추가. |
+
+- More 아이콘은 `BezierIcon.more`만 사용. SF Symbol (`UIImage(systemName:)` / `Image(systemName:)`) fallback 금지.
+
+## I-3. Accessibility
+
+- `size=20`, `size=24` 모두 시각 보조용 정보 표시. 인터랙션 없음.
+- 사용 컨텍스트(예: 담당자 목록)는 상위 화면에서 별도 label 제공 권장.

--- a/Sources/BezierSwift/MasterComponent/BezierAvatarGroup/SUBezierAvatarGroup.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierAvatarGroup/SUBezierAvatarGroup.swift
@@ -1,0 +1,178 @@
+//
+//  SUBezierAvatarGroup.swift
+//  BezierSwift
+//
+
+import SwiftUI
+
+public struct SUBezierAvatarGroup: View, Themeable {
+  private let avatars: [Image?]
+  private let size: BezierAvatarGroupSize
+  private let ellipsisType: BezierAvatarGroupEllipsisType
+
+  @Environment(\.colorScheme) public var colorScheme
+
+  public init(
+    avatars: [Image?] = [],
+    size: BezierAvatarGroupSize = .size20,
+    ellipsisType: BezierAvatarGroupEllipsisType = .icon
+  ) {
+    self.avatars = avatars
+    self.size = size
+    self.ellipsisType = ellipsisType
+  }
+
+  public var body: some View {
+    let maxVisible = BezierAvatarGroupConstant.maxVisibleAvatars
+    let visibleCount = min(self.avatars.count, maxVisible)
+    let hasOverflow = self.avatars.count > maxVisible
+    let stride: CGFloat = {
+      switch self.ellipsisType {
+      case .icon:  return self.size.iconVariantStride
+      case .count: return self.size.countVariantStride
+      }
+    }()
+    let avatarLength = self.size.avatarLength
+
+    let totalWidth = self.totalWidth(visibleCount: visibleCount, hasOverflow: hasOverflow, stride: stride)
+
+    return ZStack(alignment: .topLeading) {
+      ForEach(0..<visibleCount, id: \.self) { index in
+        SUBezierAvatar(image: self.avatars[index], size: self.size.avatarSize, showBorder: false)
+          .offset(x: CGFloat(index) * stride, y: 0)
+      }
+
+      if hasOverflow {
+        switch self.ellipsisType {
+        case .icon:
+          self.ellipsisIconView
+            .offset(x: CGFloat(maxVisible) * stride, y: 0)
+        case .count:
+          self.ellipsisCountView
+            .offset(x: CGFloat(visibleCount - 1) * stride + avatarLength + self.size.countTextSpacing, y: 0)
+        }
+      }
+    }
+    .frame(width: totalWidth, height: avatarLength, alignment: .topLeading)
+  }
+
+  // MARK: - Width Calculation
+
+  private func totalWidth(visibleCount: Int, hasOverflow: Bool, stride: CGFloat) -> CGFloat {
+    let avatarLength = self.size.avatarLength
+    if hasOverflow {
+      switch self.ellipsisType {
+      case .icon:
+        return CGFloat(BezierAvatarGroupConstant.maxVisibleAvatars) * stride + avatarLength
+      case .count:
+        let overflowCount = self.avatars.count - BezierAvatarGroupConstant.maxVisibleAvatars
+        let labelWidth = self.size.countTextContainerFixedWidth ?? self.intrinsicCountTextWidth(overflowCount: overflowCount)
+        let lastAvatarRight = CGFloat(visibleCount - 1) * stride + avatarLength
+        return lastAvatarRight + self.size.countTextSpacing + labelWidth
+      }
+    } else if visibleCount > 0 {
+      return CGFloat(visibleCount - 1) * stride + avatarLength
+    }
+    return 0
+  }
+
+  private func intrinsicCountTextWidth(overflowCount: Int) -> CGFloat {
+    let attributedString = self.size.countTextToken.attributedString(
+      placeholderComponent(),
+      text: "+\(overflowCount)",
+      semanticColorToken: .textNeutralLighter,
+      alignment: .center
+    )
+    return ceil(attributedString.size().width)
+  }
+
+  // MARK: - Ellipsis Layers
+
+  private var ellipsisIconView: some View {
+    ZStack(alignment: .topLeading) {
+      SUBezierAvatar(image: self.avatars[BezierAvatarGroupConstant.maxVisibleAvatars], size: self.size.avatarSize, showBorder: false)
+
+      RoundedRectangle(cornerRadius: self.size.avatarSize.cornerRadius, style: .continuous)
+        .fill(self.palette(BCSemanticToken.dimAbsoluteBlack))
+        .frame(width: self.size.avatarLength, height: self.size.avatarLength)
+
+      BezierIcon.more.image
+        .renderingMode(.template)
+        .resizable()
+        .scaledToFit()
+        .frame(width: self.size.moreIconLength, height: self.size.moreIconLength)
+        .foregroundColor(.white)
+        .offset(x: self.size.moreIconInset, y: self.size.moreIconInset)
+
+      RoundedRectangle(cornerRadius: self.size.avatarSize.cornerRadius, style: .continuous)
+        .strokeBorder(self.palette(BCSemanticToken.surface), lineWidth: self.size.avatarSize.borderWidth)
+        .frame(width: self.size.avatarLength, height: self.size.avatarLength)
+    }
+    .frame(width: self.size.avatarLength, height: self.size.avatarLength, alignment: .topLeading)
+  }
+
+  private var ellipsisCountView: some View {
+    let overflowCount = self.avatars.count - BezierAvatarGroupConstant.maxVisibleAvatars
+    let labelWidth = self.size.countTextContainerFixedWidth ?? self.intrinsicCountTextWidth(overflowCount: overflowCount)
+    return Text("+\(overflowCount)")
+      .applyBezierFontStyle(self.size.countTextToken, semanticColorToken: .textNeutralLighter)
+      .multilineTextAlignment(.center)
+      .frame(width: labelWidth, height: self.size.avatarLength, alignment: .center)
+  }
+}
+
+// MARK: - Helper
+
+/// SwiftUI 컨텍스트에서 NSAttributedString 사이즈 계산용 dummy component.
+private func placeholderComponent() -> BezierComponentable {
+  return SUBezierAvatarGroupSizingProxy()
+}
+
+private final class SUBezierAvatarGroupSizingProxy: BezierComponentable {
+  var colorTheme: BezierColorTheme { .systemBezierColorTheme() }
+  var componentTheme: BezierComponentTheme = .normal
+}
+
+// MARK: - Preview
+
+struct SUBezierAvatarGroup_Previews: PreviewProvider {
+  static var previews: some View {
+    let sampleAvatars: [Image] = [
+      Image(systemName: "person.crop.circle.fill"),
+      Image(systemName: "person.crop.circle.fill"),
+      Image(systemName: "person.crop.circle.fill"),
+      Image(systemName: "person.crop.circle.fill"),
+      Image(systemName: "person.crop.circle.fill"),
+    ]
+    ScrollView {
+      VStack(alignment: .leading, spacing: 24) {
+        Text("size=20, icon").font(.caption.weight(.semibold))
+        SUBezierAvatarGroup(avatars: sampleAvatars, size: .size20, ellipsisType: .icon)
+
+        Text("size=20, count").font(.caption.weight(.semibold))
+        SUBezierAvatarGroup(avatars: sampleAvatars, size: .size20, ellipsisType: .count)
+
+        Text("size=24, icon").font(.caption.weight(.semibold))
+        SUBezierAvatarGroup(avatars: sampleAvatars, size: .size24, ellipsisType: .icon)
+
+        Text("size=24, count").font(.caption.weight(.semibold))
+        SUBezierAvatarGroup(avatars: sampleAvatars, size: .size24, ellipsisType: .count)
+
+        Text("size=24, count, +12").font(.caption.weight(.semibold))
+        SUBezierAvatarGroup(
+          avatars: sampleAvatars + Array(repeating: Image(systemName: "person.crop.circle.fill"), count: 10),
+          size: .size24,
+          ellipsisType: .count
+        )
+
+        Text("size=24, ≤3 avatars (no ellipsis)").font(.caption.weight(.semibold))
+        SUBezierAvatarGroup(
+          avatars: Array(sampleAvatars.prefix(2)),
+          size: .size24,
+          ellipsisType: .count
+        )
+      }
+      .padding()
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- V3 `BezierAvatarGroup` 컴포넌트를 SwiftUI / UIKit 양쪽으로 추가했습니다. Figma SSOT 검증 사이클 (Spec → 7-차원 검증 → 구현 검증) 을 거쳐 4 variant (2 size × 2 ellipsisType) 가 디자인과 1:1 정합합니다.
- 새 파일: `Sources/BezierSwift/MasterComponent/BezierAvatarGroup/` 에 `SPEC.md` / `BezierAvatarGroupSpec.swift` / `BezierAvatarGroup.swift` / `SUBezierAvatarGroup.swift`.
- 두 Examples 앱 (`SwiftUIExample` / `UIKitExample`) 에 카탈로그 + 인터랙티브 테스트 화면을 추가하고 메뉴에 라우팅했습니다.

## 디자인 정합

Figma: [🚧 Mobile Components — AvatarGroup](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=1088-38)

| Variant | Frame | Stride / Overlap |
|---|---|---|
| size=20, icon | 59 × 20 | 13pt stride (7pt overlap) |
| size=20, count | 66 × 20 | 13pt stride, 4pt gap, 16pt fixed text container |
| size=24, icon | 75 × 24 | 17pt stride (7pt overlap) |
| size=24, count | 81 × 24 | 18pt stride (6pt overlap), 4pt spacer, intrinsic text |

## 핵심 구현 결정

- **Visible cap = 3** (Figma instance preview 기준). 입력 ≤ 3 이면 모두 표시 + ellipsis 슬롯 미표시, > 3 이면 첫 3 avatar + 4번째 슬롯에 ellipsis indicator.
- **Icon variant ellipsis avatar 의 border 는 별도 outline layer 로 분리** — Avatar 의 `showBorder` 를 사용하면 overlay 가 border 를 가려 흐려지는 시각 이슈가 있어 overlay/icon 위에 z-order 최상위 stroke 으로 그립니다 (UIKit: `borderView`, SwiftUI: `RoundedRectangle().strokeBorder(...)`).
- **More 아이콘은 `BezierIcon.more` 단일 자산** — SF Symbol `UIImage(systemName:)` / `Image(systemName:)` fallback 금지.
- **토큰 매핑**: overlay = `dimAbsoluteBlack`, count text = `textNeutralLighter`, border = `surface`, typography = `textXSmall(weight: .bold)` (size=20) / `textSmall(weight: .bold)` (size=24).

## 스크린샷

| UIKit | SwiftUI |
|:---:|:---:|
|<img width="370" alt="Simulator Screenshot - iPhone 16 - 2026-05-21 at 18 53 14" src="https://github.com/user-attachments/assets/e585590b-0a62-4911-b542-1231f504e1e5" />|<img width="370" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-21 at 18 53 19" src="https://github.com/user-attachments/assets/b6041fad-adeb-44d2-b8ba-48d36ffe829a" />|

## Test plan

- [x] BezierSwift / Examples workspace 빌드 통과 (SwiftUIExample → iPhone 17 Pro / UIKitExample → iPhone 16)
- [x] Figma SSOT 검증 7 차원 PASS (Properties / Layout / Color / Typography / Asset / Noise / ImplRef)
- [x] Implementation Validator (UIKit / SwiftUI) PASS
- [x] 두 시뮬레이터에서 동시 실행 → 카탈로그 4 variant × 입력 수 매트릭스 시각 확인
- [x] Border z-order 시각 이슈 (overlay 에 의해 가려짐) 수정 후 재검증
- [ ] 리뷰어 시각 확인 (특히 ellipsis avatar 의 흰색 외곽선이 overlay 위에 선명히 보이는지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 아바타 그룹 컴포넌트 추가: 여러 개의 아바타 이미지를 가로로 배치하고, 초과분은 아이콘(+) 또는 "+N" 텍스트로 오버플로우 표시
  * 2가지 크기 옵션(20, 24) 및 오버플로우 표시 방식(아이콘/개수) 선택 가능

* **문서화**
  * 아바타 그룹 컴포넌트 명세서 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/channel-io/BezierSwift/pull/128?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->