### PR TITLE
[MOB-5168] V3 Foundation Token Figma SSOT 동기화

### DIFF
--- a/Examples/BezierExamples/BezierExamples/Foundation/ColorTokenCatalog.swift
+++ b/Examples/BezierExamples/BezierExamples/Foundation/ColorTokenCatalog.swift
@@ -51,6 +51,7 @@ private struct ColorTokenGroup: Identifiable {
       ColorTokenSpec(.fillAbsoluteWhiteLight, "fill-absolute-white-light"),
     ]),
     ColorTokenGroup(title: "Fill (Neutral)", tokens: [
+      ColorTokenSpec(.fillNeutral,          "fill-neutral"),
       ColorTokenSpec(.fillNeutralLightest,  "fill-neutral-lightest"),
       ColorTokenSpec(.fillNeutralLighter,   "fill-neutral-lighter"),
       ColorTokenSpec(.fillNeutralLight,     "fill-neutral-light"),
@@ -105,6 +106,26 @@ private struct ColorTokenGroup: Identifiable {
       ColorTokenSpec(.dimAbsoluteBlackHeavy, "dim-absolute-black-heavy"),
       ColorTokenSpec(.dimAbsoluteWhite,      "dim-absolute-white"),
       ColorTokenSpec(.dimAbsoluteWhiteHeavy, "dim-absolute-white-heavy"),
+    ]),
+    ColorTokenGroup(title: "State", tokens: [
+      ColorTokenSpec(.stateAction,       "state-action"),
+      ColorTokenSpec(.stateActionLight,  "state-action-light"),
+      ColorTokenSpec(.stateActive,       "state-active"),
+      ColorTokenSpec(.stateDefault,      "state-default"),
+      ColorTokenSpec(.stateWarning,      "state-warning"),
+      ColorTokenSpec(.stateWarningLight, "state-warning-light"),
+    ]),
+    ColorTokenGroup(title: "Chart", tokens: [
+      ColorTokenSpec(.chartThemeDefault01, "chart-theme-default-01"),
+      ColorTokenSpec(.chartThemeDefault02, "chart-theme-default-02"),
+      ColorTokenSpec(.chartThemeDefault03, "chart-theme-default-03"),
+      ColorTokenSpec(.chartThemeDefault04, "chart-theme-default-04"),
+      ColorTokenSpec(.chartThemeDefault05, "chart-theme-default-05"),
+      ColorTokenSpec(.chartThemeDefault06, "chart-theme-default-06"),
+      ColorTokenSpec(.chartThemeDefault07, "chart-theme-default-07"),
+      ColorTokenSpec(.chartThemeDefault08, "chart-theme-default-08"),
+      ColorTokenSpec(.chartThemeDefault09, "chart-theme-default-09"),
+      ColorTokenSpec(.chartThemeDefault10, "chart-theme-default-10"),
     ]),
   ]
 }

--- a/Sources/BezierSwift/Foundation/Color/V3/BCGlobalToken.swift
+++ b/Sources/BezierSwift/Foundation/Color/V3/BCGlobalToken.swift
@@ -23,6 +23,7 @@ public enum BCGlobalToken {
   case black60
   case black70
   case black8
+  case black80
   case black85
   case blue100
   case blue200
@@ -274,6 +275,8 @@ public enum BCGlobalToken {
       return ColorComponentsWithAlpha(red: 0x00, green: 0x00, blue: 0x00, alpha: 0.70)
     case .black8:
       return ColorComponentsWithAlpha(red: 0x00, green: 0x00, blue: 0x00, alpha: 0.08)
+    case .black80:
+      return ColorComponentsWithAlpha(red: 0x00, green: 0x00, blue: 0x00, alpha: 0.80)
     case .black85:
       return ColorComponentsWithAlpha(red: 0x00, green: 0x00, blue: 0x00, alpha: 0.85)
     case .blue100:

--- a/Sources/BezierSwift/Foundation/Color/V3/BCSemanticToken.swift
+++ b/Sources/BezierSwift/Foundation/Color/V3/BCSemanticToken.swift
@@ -120,6 +120,7 @@ public enum BCSemanticToken: Equatable {
   case fillHighlightLight
   case fillHighlightLighter
   case fillHighlightTransparent
+  case fillNeutral
   case fillNeutralHeavier
   case fillNeutralHeaviest
   case fillNeutralHeavy
@@ -174,6 +175,7 @@ public enum BCSemanticToken: Equatable {
   // MARK: - State
   case stateAction
   case stateActionLight
+  case stateActive
   case stateDefault
   case stateWarning
   case stateWarningLight
@@ -213,6 +215,18 @@ public enum BCSemanticToken: Equatable {
   case textSuccess
   case textWarning
   case textInverse
+
+  // MARK: - Chart
+  case chartThemeDefault01
+  case chartThemeDefault02
+  case chartThemeDefault03
+  case chartThemeDefault04
+  case chartThemeDefault05
+  case chartThemeDefault06
+  case chartThemeDefault07
+  case chartThemeDefault08
+  case chartThemeDefault09
+  case chartThemeDefault10
 
   case custom(light: ColorComponentsWithAlpha, dark: ColorComponentsWithAlpha)
 }
@@ -433,6 +447,8 @@ extension BCSemanticToken {
       return (light: BCGlobalToken.cobalt400_10.value, dark: BCGlobalToken.cobalt300_18.value)
     case .fillHighlightTransparent:
       return (light: BCGlobalToken.cobalt400_0.value, dark: BCGlobalToken.cobalt300_0.value)
+    case .fillNeutral:
+      return (light: BCGlobalToken.black8.value, dark: BCGlobalToken.white12.value)
     case .fillNeutralHeavier:
       return (light: BCGlobalToken.black40.value, dark: BCGlobalToken.white40.value)
     case .fillNeutralHeaviest:
@@ -533,6 +549,8 @@ extension BCSemanticToken {
       return (light: BCGlobalToken.blue400.value, dark: BCGlobalToken.blue300.value)
     case .stateActionLight:
       return (light: BCGlobalToken.blue400_30.value, dark: BCGlobalToken.blue300_45.value)
+    case .stateActive:
+      return (light: BCGlobalToken.black80.value, dark: BCGlobalToken.white80.value)
     case .stateDefault:
       return (light: BCGlobalToken.black15.value, dark: BCGlobalToken.white20.value)
     case .stateWarning:
@@ -607,8 +625,35 @@ extension BCSemanticToken {
       return (light: BCGlobalToken.orange400.value, dark: BCGlobalToken.orange300.value)
     case .textInverse:
       return (light: BCGlobalToken.white100.value, dark: BCGlobalToken.black85.value)
+    // MARK: - Chart
+    // Figma SSOT에서 chart 토큰은 global 토큰 alias 없이 직접 색상값으로 정의됨 (light/dark 동일).
+    case .chartThemeDefault01:
+      return Self.chartColor(0x7C, 0x72, 0xFD)
+    case .chartThemeDefault02:
+      return Self.chartColor(0x81, 0xDF, 0xDD)
+    case .chartThemeDefault03:
+      return Self.chartColor(0xFC, 0x97, 0x83)
+    case .chartThemeDefault04:
+      return Self.chartColor(0xB1, 0x59, 0x6A)
+    case .chartThemeDefault05:
+      return Self.chartColor(0xFE, 0x71, 0xBA)
+    case .chartThemeDefault06:
+      return Self.chartColor(0xC9, 0x71, 0xEC)
+    case .chartThemeDefault07:
+      return Self.chartColor(0x4A, 0x75, 0xE3)
+    case .chartThemeDefault08:
+      return Self.chartColor(0x80, 0xB6, 0xFD)
+    case .chartThemeDefault09:
+      return Self.chartColor(0xFB, 0x90, 0xF1)
+    case .chartThemeDefault10:
+      return Self.chartColor(0xB4, 0xD6, 0xE5)
     case .custom(let light, let dark):
       return (light: light, dark: dark)
     }
+  }
+
+  private static func chartColor(_ r: Double, _ g: Double, _ b: Double) -> PaletteSet {
+    let color = ColorComponentsWithAlpha(red: r, green: g, blue: b, alpha: 1)
+    return (light: color, dark: color)
   }
 }

--- a/Sources/BezierSwift/Foundation/Typography/V3/BTSemanticToken+Style.swift
+++ b/Sources/BezierSwift/Foundation/Typography/V3/BTSemanticToken+Style.swift
@@ -20,9 +20,9 @@ extension BTSemanticToken {
     case .textSmall:                        return BTGlobalToken.FontSize.size13
     case .textXSmall:                       return BTGlobalToken.FontSize.size12
     case .textXXSmall:                      return BTGlobalToken.FontSize.size11
-    case .labelLarge:                       return BTGlobalToken.FontSize.size14
-    case .labelMedium:                      return BTGlobalToken.FontSize.size13
-    case .labelSmall:                       return BTGlobalToken.FontSize.size12
+    case .labelLarge:                       return BTGlobalToken.FontSize.size15
+    case .labelMedium:                      return BTGlobalToken.FontSize.size14
+    case .labelSmall:                       return BTGlobalToken.FontSize.size13
     case .captionMedium:                    return BTGlobalToken.FontSize.size12
     case .captionSmall:                     return BTGlobalToken.FontSize.size11
     case .codeMedium:                       return BTGlobalToken.FontSize.size14
@@ -48,9 +48,9 @@ extension BTSemanticToken {
     case .textSmall:                        return BTGlobalToken.LineHeight.height18
     case .textXSmall:                       return BTGlobalToken.LineHeight.height16
     case .textXXSmall:                      return BTGlobalToken.LineHeight.height16
-    case .labelLarge:                       return BTGlobalToken.LineHeight.height18
-    case .labelMedium:                      return BTGlobalToken.LineHeight.height18
-    case .labelSmall:                       return BTGlobalToken.LineHeight.height16
+    case .labelLarge:                       return BTGlobalToken.LineHeight.height20
+    case .labelMedium:                      return BTGlobalToken.LineHeight.height20
+    case .labelSmall:                       return BTGlobalToken.LineHeight.height18
     case .captionMedium:                    return BTGlobalToken.LineHeight.height16
     case .captionSmall:                     return BTGlobalToken.LineHeight.height16
     case .codeMedium:                       return BTGlobalToken.LineHeight.height18


### PR DESCRIPTION
## 개요
Figma Variables export(global·semantic light/dark·typography)를 SSOT로 Foundation v3 토큰을 전수 대조하고, 누락/불일치를 동기화했습니다.

## 변경 사항
### 색상
- **`BCGlobalToken`**: `black80`(#000000 @ 0.80) 추가 — `stateActive` light 값에 필요
- **`BCSemanticToken`**:
  - `fillNeutral` (base, suffix 없는 기준값) 추가 — light `black8` / dark `white12`
  - `stateActive` 추가 — light `black80` / dark `white80`
  - `chartThemeDefault01`~`10` 신규 카테고리 추가 (SSOT에 global alias 없는 직접 색상값, light=dark)

### 타이포그래피
- **`BTSemanticToken+Style`**: label 3종 size/lineHeight를 SSOT로 정정
  - `labelLarge` 14/18 → **15/20**
  - `labelMedium` 13/18 → **14/20**
  - `labelSmall` 12/16 → **13/18**
  - (primitive 추가 불필요, 매핑만 변경)

### Examples
- `ColorTokenCatalog`에 `fill-neutral` 행 + `State`/`Chart` 그룹 추가 (신규 토큰 노출용)

## 제외 (별도 결정/에셋 필요)
- **bold weight**: SSOT는 display/heading/text/caption bold = 600(semibold), label = 700. 현재 repo는 binary 400/700 유지 → `BTFontWeight.semibold` 도입은 별도 논의.
- **font-family**: SSOT는 Inter(+ code Source Code Pro). 현재 system/monospace 치환 유지 → 폰트 번들/라이선스 결정 필요.

## 검증
- `xcodebuild clean build` (BezierSwift / BezierExamples) **BUILD SUCCEEDED**
- export ↔ repo enum 1:1 재대조: global 234/234 값 일치, semantic 공통 매핑 mismatch 0, label SSOT 일치
- Example 앱 시뮬레이터 실행 → 신규 토큰(fill-neutral / state-active / chart 10색) 시각 렌더 확인
- **다운스트림 호환**: 제거/rename 0건 + 추가만. 소비자(ch-desk-ios)는 BezierSwift 버전 핀 + `BCSemanticToken` 값 사용(exhaustive switch 없음)이라 빌드 영향 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 스크린샷 — Example 앱 시각 검증

| 메인 메뉴 (진입) | Color Token 카탈로그 |
|:--:|:--:|
| <img width="350" alt="main-menu" src="https://github.com/user-attachments/assets/3383254a-7c79-40fb-a932-d802f6506b97" /> | <img width="350" alt="color-token-catalog" src="https://github.com/user-attachments/assets/5dd1f203-df08-4bad-89c2-ec4d4f998a8f" /> |
| **`fill-neutral` (base) 추가**<br/>Fill (Neutral) 최상단 | **`state-active` (검정 80%) + Chart 상단** |
| <img width="350" alt="fill-neutral-base" src="https://github.com/user-attachments/assets/03451682-ca43-483f-b40e-6de00611ccd1" /> | <img width="350" alt="state-active-and-chart" src="https://github.com/user-attachments/assets/b7207ddd-a41a-4056-9e62-f3d8e9c8a512" /> |
| **`chartThemeDefault01~10` (10색)** | — |
| <img width="350" alt="chart-theme-default-01-10" src="https://github.com/user-attachments/assets/c998e170-2fac-4fe8-b2f3-c2bf3dd548e6" /> | |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 차트 테마, 상태 표시, 중립적 채우기 색상 토큰이 추가되었습니다.
  * 디자인 시스템 색상 카탈로그가 확장되었습니다.

* **개선 사항**
  * 레이블 크기 타이포그래피 토큰이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->