### PR TITLE
[MOB-5169] V3 컴포넌트 토큰 바인딩 업데이트 (Button/IconButton/Badge/Tag/AvatarGroup)

### DIFF
--- a/Sources/BezierSwift/Foundation/Opacity/BOGlobalToken.swift
+++ b/Sources/BezierSwift/Foundation/Opacity/BOGlobalToken.swift
@@ -1,0 +1,13 @@
+//
+//  BOGlobalToken.swift
+//  BezierSwift
+//
+
+import CoreGraphics
+
+/// Bezier Opacity V3 Global Token
+/// Figma `opacity/*` 변수 대응. internal — 컴포넌트 내부에서만 참조하며 외부로 노출하지 않는다.
+enum BOGlobalToken {
+  /// Figma `opacity/disabled` = 40% → 0.4
+  static let disabled: CGFloat = 0.4
+}

--- a/Sources/BezierSwift/MasterComponent/BezierAvatarGroup/BezierAvatarGroupSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierAvatarGroup/BezierAvatarGroupSpec.swift
@@ -28,11 +28,11 @@ public enum BezierAvatarGroupSize: String, CaseIterable {
     }
   }
 
-  /// SPEC §2.3 / §2.5: count variant stride. size=20은 7pt overlap, size=24는 6pt overlap (Figma SSOT).
+  /// SPEC §2.3 / §2.5: count variant stride. size20·size24 모두 7pt overlap (Figma SSOT).
   public var countVariantStride: CGFloat {
     switch self {
     case .size20: return 13
-    case .size24: return 18
+    case .size24: return 17
     }
   }
 

--- a/Sources/BezierSwift/MasterComponent/BezierBadge/BezierBadgeSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBadge/BezierBadgeSpec.swift
@@ -36,37 +36,36 @@ public enum BezierBadgeSize: String, CaseIterable {
 
   public var iconLength: CGFloat { 16 }
 
-  // MARK: - Typography (Figma raw, see SPEC §3)
+  // MARK: - Typography
   //
-  // TYPO-MIGRATION: Figma component description의 `📌 TYPO-MIGRATION: Text Style
-  // 미적용` 상태에 따라 raw 값을 직접 사용한다. xsmall/small은 BTSemanticToken
-  // (.textXSmall / .textMedium)과 정합하지만, medium/large는 lineHeight·letterSpacing
-  // 이 token(.textLarge / .textXLarge)과 일치하지 않으므로 token을 우회하고 raw 값을
-  // 적용한다. 디자인팀의 로컬 typography 스타일 일괄 바인딩이 끝나 raw가 token과
-  // 정합되면 BTSemanticToken 기반 API로 통합 예정.
+  // Figma `text/*` 변수 바인딩. size 차원(fontSize·letterSpacing)과 lineHeight 차원이
+  // 엇갈리게 매핑된다(예: medium = size/large + line-height/medium). BTSemanticToken 의
+  // 차원별 raw 값을 조합해 Figma SSOT 와 정합시킨다.
 
   public var fontSize: CGFloat {
     switch self {
-    case .xsmall: return 12
-    case .small:  return 14
-    case .medium: return 15
-    case .large:  return 16
+    case .xsmall: return BTSemanticToken.textXSmall().fontSize
+    case .small:  return BTSemanticToken.textMedium().fontSize
+    case .medium: return BTSemanticToken.textLarge().fontSize
+    case .large:  return BTSemanticToken.textXLarge().fontSize
     }
   }
 
   public var lineHeight: CGFloat {
     switch self {
-    case .xsmall: return 16
-    case .small:  return 18
-    case .medium: return 18
-    case .large:  return 20
+    case .xsmall: return BTSemanticToken.textXSmall().lineHeight
+    case .small:  return BTSemanticToken.textMedium().lineHeight
+    case .medium: return BTSemanticToken.textMedium().lineHeight
+    case .large:  return BTSemanticToken.textLarge().lineHeight
     }
   }
 
   public var letterSpacing: CGFloat {
     switch self {
-    case .xsmall, .small, .medium: return 0
-    case .large: return -0.1
+    case .xsmall: return BTSemanticToken.textXSmall().letterSpacing
+    case .small:  return BTSemanticToken.textMedium().letterSpacing
+    case .medium: return BTSemanticToken.textLarge().letterSpacing
+    case .large:  return BTSemanticToken.textXLarge().letterSpacing
     }
   }
 

--- a/Sources/BezierSwift/MasterComponent/BezierButton/BezierButtonSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierButton/BezierButtonSpec.swift
@@ -68,19 +68,25 @@ public enum BezierButtonSize: String, CaseIterable {
     }
   }
 
+  // MARK: - Typography
+  //
+  // Figma 변수 바인딩: xsmall·small·medium 은 `label/*` semantic, large·xlarge 는
+  // `font-size/16` + `line-height/24` global. BezierSwift 에는 16/24 조합의 label/text
+  // semantic 토큰이 없으므로 (내부 참조 가능한) BTGlobalToken raw 값을 직접 사용한다.
   public var fontSize: CGFloat {
     switch self {
-    case .xsmall: return 13
-    case .small:  return 14
-    case .medium: return 15
-    case .large, .xlarge: return 16
+    case .xsmall: return BTGlobalToken.FontSize.size13
+    case .small:  return BTGlobalToken.FontSize.size14
+    case .medium: return BTGlobalToken.FontSize.size15
+    case .large, .xlarge: return BTGlobalToken.FontSize.size16
     }
   }
 
   public var lineHeight: CGFloat {
     switch self {
-    case .xsmall, .small: return 18
-    case .medium, .large, .xlarge: return 20
+    case .xsmall: return BTGlobalToken.LineHeight.height18
+    case .small, .medium: return BTGlobalToken.LineHeight.height20
+    case .large, .xlarge: return BTGlobalToken.LineHeight.height24
     }
   }
 
@@ -102,7 +108,7 @@ public enum BezierButtonSemantic: String, CaseIterable {
 
 enum BezierButtonConstant {
   static let borderWidth: CGFloat = 1
-  static let disabledOpacity: CGFloat = 0.4
+  static let disabledOpacity: CGFloat = BOGlobalToken.disabled
   static let pressedOpacity: CGFloat = 0.7
 }
 

--- a/Sources/BezierSwift/MasterComponent/BezierIconButton/BezierIconButtonSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierIconButton/BezierIconButtonSpec.swift
@@ -65,7 +65,7 @@ extension BezierIconButtonVariant {
 }
 
 enum BezierIconButtonConstant {
-  static let disabledOpacity: CGFloat = 0.4
+  static let disabledOpacity: CGFloat = BOGlobalToken.disabled
   /// Ghost variant의 pressed / active overlay 색상.
   /// bezier-tokens에 등록되지 않은 임시값 — Variable 등록 시 교체 예정.
   static let ghostOverlayAlpha: CGFloat = 0.05

--- a/Sources/BezierSwift/MasterComponent/BezierTag/BezierTagSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierTag/BezierTagSpec.swift
@@ -36,33 +36,36 @@ public enum BezierTagSize: String, CaseIterable {
 
   public var closeIconLength: CGFloat { 16 }
 
-  // MARK: - Typography (Figma raw, see SPEC §3)
+  // MARK: - Typography
   //
-  // TYPO-MIGRATION: Figma component description의 `📌 TYPO-MIGRATION: Text Style
-  // 미적용` 상태에 따라 raw 값을 직접 사용한다. 디자인팀의 로컬 typography 스타일
-  // 일괄 바인딩이 끝나 raw가 token과 정합되면 BTSemanticToken 기반 API로 통합 예정.
+  // Figma `text/*` 변수 바인딩. size 차원(fontSize·letterSpacing)과 lineHeight 차원이
+  // 엇갈리게 매핑된다(예: medium = size/large + line-height/medium). BTSemanticToken 의
+  // 차원별 raw 값을 조합해 Figma SSOT 와 정합시킨다.
 
   public var fontSize: CGFloat {
     switch self {
-    case .xsmall: return 12
-    case .small:  return 14
-    case .medium: return 15
-    case .large:  return 16
+    case .xsmall: return BTSemanticToken.textXSmall().fontSize
+    case .small:  return BTSemanticToken.textMedium().fontSize
+    case .medium: return BTSemanticToken.textLarge().fontSize
+    case .large:  return BTSemanticToken.textXLarge().fontSize
     }
   }
 
   public var lineHeight: CGFloat {
     switch self {
-    case .xsmall: return 16
-    case .small, .medium: return 18
-    case .large: return 20
+    case .xsmall: return BTSemanticToken.textXSmall().lineHeight
+    case .small:  return BTSemanticToken.textMedium().lineHeight
+    case .medium: return BTSemanticToken.textMedium().lineHeight
+    case .large:  return BTSemanticToken.textLarge().lineHeight
     }
   }
 
   public var letterSpacing: CGFloat {
     switch self {
-    case .xsmall, .small: return 0
-    case .medium, .large: return -0.1
+    case .xsmall: return BTSemanticToken.textXSmall().letterSpacing
+    case .small:  return BTSemanticToken.textMedium().letterSpacing
+    case .medium: return BTSemanticToken.textLarge().letterSpacing
+    case .large:  return BTSemanticToken.textXLarge().letterSpacing
     }
   }
 


### PR DESCRIPTION
## 변경 사항
Figma SSOT 변수 바인딩 정리에 맞춰 V3 컴포넌트의 토큰 바인딩을 업데이트합니다.

### Button
- typography를 하드코딩 → `BTGlobalToken` 직접 참조 (xsmall·small·medium = `label/*` 값, large·xlarge = `font-size/16` + `line-height/24`)
- disabled opacity를 `BOGlobalToken.disabled` 토큰 참조로

### IconButton
- disabled opacity를 `BOGlobalToken.disabled` 토큰 참조로

### Badge / Tag
- fontSize / lineHeight / letterSpacing을 `BTSemanticToken` raw 값으로 바인딩
- size 차원(fontSize·letterSpacing)과 lineHeight 차원이 엇갈린 Figma 매핑을 반영 (예: medium = `size/large` + `line-height/medium`)

### AvatarGroup
- size24 count variant stride 18 → 17 (icon과 7pt overlap 통일)

### Foundation
- `BOGlobalToken` (opacity/disabled, internal) 신규 추가

## ⚠️ 시각 변화 동반 (QA 포인트)
토큰 바인딩 과정에서 Figma 새 값 반영으로 아래 셀의 실제 값이 변경됩니다:
- Button `small` lineHeight 18 → 20
- Button `large` / `xlarge` lineHeight 20 → 24
- Badge `medium` letterSpacing 0 → -0.1
- AvatarGroup `size24 · count` stride 18 → 17

## 검증
- `xcodebuild -scheme BezierSwift clean build` → **BUILD SUCCEEDED**
- BezierExamples 앱 시뮬레이터(iPhone 16, iOS 18.6) 실행 확인
- Figma SSOT 전 셀 대조 — 불일치 0건 (subagent 검증)

## 후속 (별도 티켓 권장)
- `BezierAvatarSpec.disabledOpacity`(현재 리터럴 0.4)도 `BOGlobalToken.disabled`로 통일

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 아바타 그룹 컴포넌트의 요소 간격 값을 수정했습니다.

* **개선사항**
  * 배지, 버튼, 아이콘 버튼, 태그 컴포넌트의 타이포그래피 및 비활성화 상태 스타일을 디자인 토큰 기반으로 통일하여 시각적 일관성을 향상시켰습니다.
  * 전역 불투명도 토큰을 추가하여 디자인 시스템 표준화를 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->