### PR TITLE
[MOB-6018] BezierBadge intrinsicContentSize 오버라이드로 압축 시 collapse 방지

### DIFF
--- a/Examples/BezierExamples/BezierExamples/Components/BadgeCatalog.swift
+++ b/Examples/BezierExamples/BezierExamples/Components/BadgeCatalog.swift
@@ -7,6 +7,7 @@ struct BadgeCatalog: View {
   @State private var variant: BezierBadgeVariant = .default
   @State private var label: String = "Label"
   @State private var hasLeadingIcon: Bool = false
+  @State private var rowWidth: CGFloat = 200
 
   var body: some View {
     CatalogScreen(title: "Badge") {
@@ -19,7 +20,58 @@ struct BadgeCatalog: View {
         .textCase(.uppercase)
       CatalogSection(.swiftUI) { self.swiftUIVariantGrid }
       CatalogSection(.uiKit) { self.uiKitVariantGrid }
+      self.compressionSection
     }
+  }
+
+  private var compressionSection: some View {
+    VStack(alignment: .leading, spacing: 10) {
+      Text("Compression Resistance (MOB-6018)")
+        .font(.system(size: 13, weight: .semibold))
+        .foregroundStyle(.secondary)
+        .textCase(.uppercase)
+      Text("메시지 셀처럼 [이름 · 배지 여러 개 · 타임스탬프]로 구성한 가로 스택. 폭을 줄이면 이름이 먼저 truncate되고 배지들은 자연폭을 유지해야 정상. UIKit·SwiftUI 모두 확인.")
+        .font(.caption)
+        .foregroundStyle(.secondary)
+      HStack(spacing: 8) {
+        Text("Row width").font(.caption).foregroundStyle(.secondary).frame(width: 72, alignment: .leading)
+        Slider(value: self.$rowWidth, in: 150...340)
+        Text("\(Int(self.rowWidth))pt").font(.caption.monospacedDigit()).frame(width: 44, alignment: .trailing)
+      }
+      CatalogSection(.uiKit) { self.uiKitCompressionDemo }
+      CatalogSection(.swiftUI) { self.swiftUICompressionDemo }
+    }
+  }
+
+  private var uiKitCompressionDemo: some View {
+    UIKitWrap(
+      { BadgeCompressionRowView() },
+      update: { $0.setWidth(self.rowWidth) }
+    )
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .padding(.vertical, 8)
+  }
+
+  private var swiftUICompressionDemo: some View {
+    HStack(spacing: 4) {
+      Text("김채널 프로덕트 디자이너")
+        .font(.system(size: 13, weight: .medium))
+        .lineLimit(1)
+        .truncationMode(.tail)
+        .layoutPriority(-1)
+      SUBezierBadge(size: .xsmall, variant: .blue, label: "bot")
+      SUBezierBadge(size: .xsmall, variant: .green, label: "lead")
+      SUBezierBadge(size: .xsmall, variant: .red, label: "차단")
+      Text("오후 5:29")
+        .font(.system(size: 11))
+        .foregroundStyle(.secondary)
+        .lineLimit(1)
+        .fixedSize()
+    }
+    .frame(width: self.rowWidth, alignment: .leading)
+    .clipped()
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .padding(.vertical, 8)
   }
 
   private var controls: some View {
@@ -93,5 +145,73 @@ struct BadgeCatalog: View {
         .fixedSize()
       }
     }
+  }
+}
+
+// MARK: - Compression Demo Row (MOB-6018)
+
+/// ChatMessagePersonInfoView 를 모사한 한 행: [이름 라벨(.defaultLow) · 배지 3개(.required) · 타임스탬프] 를
+/// 폭이 통제된 UIStackView(.fill) 에 배치. 폭이 좁아져도 배지들은 collapse 되지 않고,
+/// 이름 라벨이 먼저 truncate 되어야 한다.
+private final class BadgeCompressionRowView: UIView {
+  private let nameLabel = UILabel()
+  private let timeLabel = UILabel()
+  private var widthConstraint: NSLayoutConstraint?
+
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+
+    self.nameLabel.text = "김채널 프로덕트 디자이너"
+    self.nameLabel.font = .systemFont(ofSize: 13, weight: .medium)
+    self.nameLabel.lineBreakMode = .byTruncatingTail
+    self.nameLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+    self.timeLabel.text = "오후 5:29"
+    self.timeLabel.font = .systemFont(ofSize: 11)
+    self.timeLabel.textColor = .secondaryLabel
+    self.timeLabel.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+
+    let stack = UIStackView(arrangedSubviews: [
+      self.nameLabel,
+      Self.makeBadge("bot", .blue),
+      Self.makeBadge("lead", .green),
+      Self.makeBadge("차단", .red),
+      self.timeLabel,
+    ])
+    stack.axis = .horizontal
+    stack.spacing = 4
+    stack.distribution = .fill
+    stack.alignment = .center
+    stack.translatesAutoresizingMaskIntoConstraints = false
+    self.addSubview(stack)
+
+    let widthConstraint = self.widthAnchor.constraint(equalToConstant: 200)
+    self.widthConstraint = widthConstraint
+
+    NSLayoutConstraint.activate([
+      stack.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+      stack.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+      stack.topAnchor.constraint(equalTo: self.topAnchor),
+      stack.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+      widthConstraint,
+    ])
+  }
+
+  required init?(coder: NSCoder) {
+    super.init(coder: coder)
+  }
+
+  private static func makeBadge(_ text: String, _ variant: BezierBadgeVariant) -> BezierBadge {
+    let badge = BezierBadge(size: .xsmall, variant: variant)
+    badge.label = text
+    badge.setContentCompressionResistancePriority(.required, for: .horizontal)
+    return badge
+  }
+
+  func setWidth(_ width: CGFloat) {
+    self.widthConstraint?.constant = width
+    self.setNeedsLayout()
+    self.layoutIfNeeded()
+    self.invalidateIntrinsicContentSize()
   }
 }

--- a/Sources/BezierSwift/MasterComponent/BezierBadge/BezierBadge.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBadge/BezierBadge.swift
@@ -136,6 +136,17 @@ public final class BezierBadge: UIView, BezierComponentable {
     self.layer.cornerRadius = self.bounds.height / 2
   }
 
+  public override var intrinsicContentSize: CGSize {
+    var width = self.size.horizontalPadding * 2
+    if !self.leadingImageView.isHidden {
+      width += self.size.iconLength
+    }
+    if !self.titleLabel.isHidden {
+      width += self.titleLabel.intrinsicContentSize.width
+    }
+    return CGSize(width: width, height: self.size.height)
+  }
+
   public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
     super.traitCollectionDidChange(previousTraitCollection)
     self.refreshAppearance()
@@ -187,6 +198,8 @@ public final class BezierBadge: UIView, BezierComponentable {
       self.titleLabel.attributedText = nil
       self.titleLabel.isHidden = true
     }
+
+    self.invalidateIntrinsicContentSize()
   }
 
   private func refreshAppearance() {

--- a/Tests/BezierSwiftTests/BezierBadgeLayoutTests.swift
+++ b/Tests/BezierSwiftTests/BezierBadgeLayoutTests.swift
@@ -1,0 +1,194 @@
+import Testing
+import UIKit
+@testable import BezierSwift
+
+// MARK: - BezierBadge 레이아웃 / 압축 저항 테스트 (MOB-6018)
+//
+// 재현 대상: 가로 UIStackView(.fill) 안에서 공간이 부족할 때, BezierBadge 가
+// 자연폭보다 작게 압축(collapse)되는 버그. 근본 원인은 BezierBadge 가
+// intrinsicContentSize 를 노출하지 않아 setContentCompressionResistancePriority(.required)
+// 가 무효화되는 것.
+
+@Suite("BezierBadge Layout - Compression Resistance", .serialized)
+@MainActor
+struct BezierBadgeLayoutTests {
+  /// 좁은 .fill 스택에서, 압축 저항이 낮은 형제(UILabel, .defaultLow)가 먼저 압축되고
+  /// .required 로 설정한 BezierBadge 는 자연폭을 사수해야 한다.
+  @Test("좁은 .fill 스택에서 xsmall 배지가 자연폭 미만으로 압축되지 않는다")
+  func badgeDoesNotCollapseInFillStack() {
+    let badge = BezierBadge(size: .xsmall)
+    badge.label = "bot"
+    badge.setContentCompressionResistancePriority(.required, for: .horizontal)
+
+    // 배지 단독 자연폭. 내부 contentStack leading/trailing(required equalTo) 제약으로 계산된다.
+    let badgeNatural = badge.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).width
+    #expect(badgeNatural > 0)
+
+    // 형제: 압축 저항이 낮은 긴 텍스트 라벨 → 공간 부족 시 이쪽이 먼저 줄어들어야 정상.
+    let sibling = UILabel()
+    sibling.text = "매우 긴 형제 라벨 텍스트입니다 정말로 깁니다"
+    sibling.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+    let siblingNatural = sibling.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).width
+
+    let stack = UIStackView(arrangedSubviews: [badge, sibling])
+    stack.axis = .horizontal
+    stack.distribution = .fill
+    stack.alignment = .center
+    stack.spacing = 0
+    stack.translatesAutoresizingMaskIntoConstraints = false
+
+    // 두 자연폭 합보다 40pt 부족한 컨테이너 폭. 형제(.defaultLow)가 흡수할 만큼만 부족하게 만든다.
+    let deficit: CGFloat = 40
+    let containerWidth = badgeNatural + siblingNatural - deficit
+
+    // 실제 렌더 계층(window)에 붙여 detached 레이아웃 아티팩트를 배제한다.
+    let container = UIView(frame: CGRect(x: 0, y: 0, width: containerWidth, height: 40))
+    let window = UIWindow(frame: container.bounds)
+    window.addSubview(container)
+    container.addSubview(stack)
+
+    NSLayoutConstraint.activate([
+      stack.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+      stack.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+      stack.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+    ])
+
+    window.setNeedsLayout()
+    window.layoutIfNeeded()
+
+    #expect(
+      badge.frame.width >= badgeNatural - 0.5,
+      "배지 폭 \(badge.frame.width)pt 가 자연폭 \(badgeNatural)pt 미만으로 압축됨 (형제 폭 \(sibling.frame.width)pt / 형제 자연폭 \(siblingNatural)pt, 컨테이너 \(containerWidth)pt)"
+    )
+  }
+
+  /// intrinsicContentSize 가 실제 콘텐츠 폭(패딩 + 라벨)을 노출해야 한다.
+  /// systemLayoutSizeFitting 으로 얻는 자연폭과 일치해야 표준 UIKit 압축 메커니즘에 편입된다.
+  @Test("BezierBadge 는 콘텐츠 기반 intrinsicContentSize 를 노출한다")
+  func badgeExposesIntrinsicContentSize() {
+    let badge = BezierBadge(size: .xsmall)
+    badge.label = "bot"
+
+    let fitting = badge.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
+    let intrinsic = badge.intrinsicContentSize
+
+    #expect(intrinsic.width > 0)
+    #expect(abs(intrinsic.width - fitting.width) < 0.5)
+    #expect(abs(intrinsic.height - BezierBadgeSize.xsmall.height) < 0.5)
+  }
+
+  /// label 변경 시 intrinsicContentSize 가 갱신되어야 한다(invalidate 경로 검증).
+  @Test("label 변경이 intrinsicContentSize 에 반영된다")
+  func intrinsicUpdatesOnLabelChange() {
+    let badge = BezierBadge(size: .xsmall)
+    badge.label = "a"
+    let shortWidth = badge.intrinsicContentSize.width
+
+    badge.label = "aaaaaaaaaaaaaaaaaaaa"
+    let longWidth = badge.intrinsicContentSize.width
+
+    #expect(longWidth > shortWidth)
+  }
+
+  /// 실제 메시지 셀 구조([이름 · 배지 3개 · 타임스탬프])에서, 폭이 배지 자연폭 합 수준으로
+  /// 좁아져도 배지들은 각자 자연폭을 유지하고 이름 라벨만 압축을 흡수해야 한다.
+  @Test("여러 배지 복합 행에서 모든 배지가 자연폭을 유지하고 이름만 줄어든다")
+  func multipleBadgesSurviveCompression() {
+    func makeBadge(_ text: String, _ variant: BezierBadgeVariant) -> BezierBadge {
+      let badge = BezierBadge(size: .xsmall, variant: variant)
+      badge.label = text
+      badge.setContentCompressionResistancePriority(.required, for: .horizontal)
+      return badge
+    }
+    let badges = [makeBadge("bot", .blue), makeBadge("lead", .green), makeBadge("차단", .red)]
+    let naturals = badges.map { $0.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).width }
+
+    let nameLabel = UILabel()
+    nameLabel.text = "김채널 프로덕트 디자이너"
+    nameLabel.font = .systemFont(ofSize: 13, weight: .medium)
+    nameLabel.lineBreakMode = .byTruncatingTail
+    nameLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+    let nameNatural = nameLabel.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).width
+
+    let stack = UIStackView(arrangedSubviews: [nameLabel] + badges)
+    stack.axis = .horizontal
+    stack.spacing = 4
+    stack.distribution = .fill
+    stack.alignment = .center
+    stack.translatesAutoresizingMaskIntoConstraints = false
+
+    // 배지 자연폭 합 + 여유 60pt. 이름 자연폭(~150)보다 훨씬 좁아 이름이 압축을 흡수한다.
+    let containerWidth = naturals.reduce(0, +) + 60
+    let container = UIView(frame: CGRect(x: 0, y: 0, width: containerWidth, height: 40))
+    let window = UIWindow(frame: container.bounds)
+    window.addSubview(container)
+    container.addSubview(stack)
+
+    NSLayoutConstraint.activate([
+      stack.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+      stack.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+      stack.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+    ])
+
+    window.setNeedsLayout()
+    window.layoutIfNeeded()
+
+    for (badge, natural) in zip(badges, naturals) {
+      #expect(
+        badge.frame.width >= natural - 0.5,
+        "배지 '\(badge.label ?? "")' 폭 \(badge.frame.width)pt 가 자연폭 \(natural)pt 미만으로 압축됨"
+      )
+    }
+    #expect(
+      nameLabel.frame.width < nameNatural,
+      "이름 라벨이 압축을 흡수하지 않음 (폭 \(nameLabel.frame.width)pt / 자연폭 \(nameNatural)pt)"
+    )
+  }
+
+  /// 접근 A(라이브러리 무변경): 호출부에서 compressionResistance 를 낮추면, 표준 UIKit 메커니즘에 따라
+  /// 배지가 자연폭 미만으로 축소되고 내부 라벨이 tail truncation 조건(표시폭 < 콘텐츠폭)에 들어간다.
+  /// 즉 별도 API 없이 UIKit 표준만으로 "어느 정도 축소 허용 + 말줄임"이 가능하다.
+  @Test("compressionResistance를 낮추면 배지가 축소되고 라벨이 truncate 조건에 들어간다")
+  func loweringResistanceAllowsTruncation() {
+    let badge = BezierBadge(size: .xsmall)
+    badge.label = "botbotbot"
+    badge.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+    let natural = badge.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).width
+
+    let targetWidth = (natural * 0.6).rounded()
+    let container = UIView(frame: CGRect(x: 0, y: 0, width: targetWidth, height: 40))
+    let window = UIWindow(frame: container.bounds)
+    window.addSubview(container)
+    badge.translatesAutoresizingMaskIntoConstraints = false
+    container.addSubview(badge)
+
+    NSLayoutConstraint.activate([
+      badge.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+      badge.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+      badge.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+    ])
+
+    window.setNeedsLayout()
+    window.layoutIfNeeded()
+
+    // 우선순위가 낮으면 배지가 컨테이너 폭(자연폭 미만)으로 축소된다.
+    #expect(badge.frame.width < natural)
+    #expect(abs(badge.frame.width - targetWidth) < 1.0)
+
+    // 내부 라벨이 자연폭보다 좁은 영역에 배치되어 tail truncation 이 성립한다.
+    let titleLabel = Self.firstLabel(in: badge)
+    #expect(titleLabel != nil)
+    if let titleLabel {
+      #expect(titleLabel.numberOfLines == 1)
+      #expect(titleLabel.bounds.width < titleLabel.intrinsicContentSize.width)
+    }
+  }
+
+  private static func firstLabel(in view: UIView) -> UILabel? {
+    for subview in view.subviews {
+      if let label = subview as? UILabel { return label }
+      if let found = firstLabel(in: subview) { return found }
+    }
+    return nil
+  }
+}


### PR DESCRIPTION
## 배경

ch-desk-ios `ChatMessagePersonInfoView`(메시지 셀의 이름/뱃지/타임스탬프 행)에서 `BezierBadge`(size: .xsmall)가 좁은 공간에서 압축될 때 배지가 자연폭보다 심하게 줄어들거나 사실상 사라지는(collapse) 버그가 있었습니다. (관련: [MOB-6008](https://linear.app/channel/issue/MOB-6008))

## 원인

`BezierBadge`가 `intrinsicContentSize`를 오버라이드하지 않아 `UIView` 기본값 `noIntrinsicMetric(-1)`을 반환했습니다.

- compression resistance priority는 "intrinsicContentSize를 지키려는 저항"인데, 지킬 고유 크기 자체가 없어 `.required`로 설정해도 무효였습니다.
- 크기를 `contentStackView`의 leading/trailing required `equalTo` 제약으로만 잡아, 부모가 폭을 줄이면 내부 `titleLabel`(기본 저항 750)이 대신 압축됐습니다.
- `refreshLayout()`의 `invalidateIntrinsicContentSize()` 호출도 오버라이드가 없어 no-op이었습니다.

호출부에서 wrapper/floor로 우회해도 실패했던 이유가 이것입니다 — 배지 인스턴스 자신이 압축 가능한 상태라 외부 floor로는 내부 축소를 막을 수 없었습니다.

## 변경사항

- `intrinsicContentSize` 오버라이드: `horizontalPadding*2 + (아이콘 표시 시 iconLength) + titleLabel.intrinsicContentSize.width`, height = `size.height`
- `refreshContent()`에 `invalidateIntrinsicContentSize()` 추가 → `label`/`leadingIcon` 변경이 크기에 반영
- 재현/검증 유닛 테스트 5개 (`BezierBadgeLayoutTests`)
- `BadgeCatalog`에 압축 데모 섹션 추가 (실제 셀 구조 `[이름 · 배지 3개 · 타임스탬프]`, UIKit·SwiftUI 복합 행 + 폭 슬라이더)

## 검증

**유닛 테스트 5개 통과** (clean build + 전체 스위트 회귀 없음). UIKit Auto Layout 특성상 `UIWindow` 계층 + `@MainActor` + `.serialized`로 작성.

1. 좁은 `.fill` 스택에서 배지가 자연폭 미만으로 압축되지 않음
2. 콘텐츠 기반 `intrinsicContentSize` 노출
3. `label` 변경이 `intrinsicContentSize`에 반영
4. 배지 여러 개 복합 행에서 모든 배지 자연폭 유지 + 이름만 압축 흡수
5. `compressionResistance`를 낮추면 배지가 축소되고 라벨이 truncate 조건에 들어감

**시뮬레이터 확인**: 폭 150~340pt 전 구간에서 배지들은 자연폭을 유지하고 이름 라벨이 먼저 truncate됨 (UIKit·SwiftUI 동일).

## 참고

- **SwiftUI (`SUBezierBadge`)**: SwiftUI 레이아웃 모델 차이 + `.fixedSize(horizontal: true)`로 이미 안전해 수정 불필요. 데모로 동등 동작 실증.
- **외부에서 축소 허용**: 별도 옵션 API를 추가하지 않고, 호출부에서 UIKit 표준 `setContentCompressionResistancePriority`로 처리 가능합니다(우선순위를 낮추면 배지 축소 + 라벨 tail truncation). 테스트 5번으로 검증.
- 후속: BezierSwift 반영 후 ch-desk-ios `ChatMessagePersonInfoView`의 임시 구현(`ExperimentBadgeLabel`)을 `BezierBadge`로 되돌리는 것 검토 ([MOB-6008](https://linear.app/channel/issue/MOB-6008)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 배지 레이아웃이 콘텐츠 길이에 맞춰 더 자연스럽게 크기를 조절하도록 개선되었습니다.
  * 새로운 데모 섹션에서 가로 공간이 좁아질 때 배지가 어떻게 압축되는지 확인할 수 있습니다.

* **Bug Fixes**
  * 배지의 실제 표시 내용이 바뀌면 크기 계산이 즉시 다시 반영되도록 수정했습니다.
  * 좁은 화면에서도 이름이 먼저 줄어들고, 배지와 타임스탬프는 더 안정적으로 유지되도록 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->