### PR TITLE
[MOB-6226] SUBezierTag 라벨 단일 라인 truncate

### DIFF
--- a/Sources/BezierSwift/MasterComponent/BezierTag/SUBezierTag.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierTag/SUBezierTag.swift
@@ -39,7 +39,8 @@ public struct SUBezierTag: View, Themeable {
           .padding(.vertical, self.size.verticalLineSpacing)
           .foregroundColor(self.palette(self.variant.foregroundToken))
           .padding(.horizontal, self.size.textHorizontalPadding)
-          .fixedSize(horizontal: true, vertical: false)
+          .lineLimit(1)
+          .truncationMode(.tail)
       }
       if let onDelete = self.onDelete {
         Button(action: onDelete) {


### PR DESCRIPTION
## 요약
`SUBezierTag`가 항상 단일 라인으로 truncate되도록 수정합니다. (태그는 무조건 한 줄 스펙)

## 배경
`SUBezierTag`는 내부적으로 `Text.fixedSize(horizontal: true)`로 폭을 강제하기 때문에, 부모가 폭을 제약해도 라벨이 truncate되지 않고 컨테이너를 넘칩니다. 리스트 셀 등 폭이 제한된 컨텍스트에서 긴 태그가 넘치는 문제(cht-desk-ios MOB-6226)가 여기서 비롯됩니다.

## 변경 사항
- `Text`의 `.fixedSize(horizontal: true, vertical: false)`를 `.lineLimit(1).truncationMode(.tail)`로 교체.
  - 폭이 넉넉한 컨텍스트: 기존과 동일하게 전체 라벨을 표시 (회귀 없음).
  - 폭이 제약된 컨텍스트: tail 말줄임(…).
- 별도 파라미터 없이 컴포넌트 스펙(단일 라인)으로 내부 고정.

## 검증
- 라이브러리 빌드 통과.
- BezierExamples → Tag catalog에서 확인:
  - 짧은 라벨 + 전체 variant grid 정상 렌더 (회귀 없음).
  - 무제약 preview(HStack + Spacer)에서 긴 라벨은 전체 폭 표시 = 기존 `.fixedSize` 동작과 동일.
  - 폭 제약(`.frame(maxWidth:)`) 컨텍스트에서 `lineLimit(1) + truncationMode(.tail)`로 tail 말줄임 동작 확인.

## 참고
- 리니어: https://linear.app/channel/issue/MOB-6226
