### PR TITLE
[MOB-6343] BezierModal 컨테이너 + Modal 프레젠테이션 API (present + dim)

### DIFF
--- a/Examples/BezierExamples/BezierExamples/App/CatalogRegistry.swift
+++ b/Examples/BezierExamples/BezierExamples/App/CatalogRegistry.swift
@@ -70,6 +70,12 @@ enum CatalogRegistry {
       section: .v3Components,
       destination: AnyView(SpinnerCatalog())
     ),
+    CatalogItem(
+      id: "modal",
+      title: "Modal",
+      section: .v3Components,
+      destination: AnyView(ModalCatalog())
+    ),
     // MARK: - Legacy Components
     CatalogItem(
       id: "legacy-button",

--- a/Examples/BezierExamples/BezierExamples/Components/ModalCatalog.swift
+++ b/Examples/BezierExamples/BezierExamples/Components/ModalCatalog.swift
@@ -3,6 +3,8 @@ import UIKit
 import BezierSwift
 
 struct ModalCatalog: View {
+  @State private var isModalPresented = false
+
   var body: some View {
     CatalogScreen(title: "Modal") {
       CatalogSection(.swiftUI) { self.swiftUIPreview }
@@ -11,46 +13,59 @@ struct ModalCatalog: View {
   }
 
   private var swiftUIPreview: some View {
-    HStack {
-      Spacer()
-      SUBezierModal {
-        VStack(spacing: 8) {
-          Text("Custom Content")
+    VStack(spacing: 24) {
+      HStack {
+        Spacer()
+        SUBezierModal {
+          VStack(spacing: 8) {
+            Text("Custom Content")
+              .font(.system(size: 16, weight: .semibold))
+            Text("Modal은 customContent 슬롯 하나를 가진 순수 컨테이너입니다.")
+              .font(.system(size: 14))
+              .foregroundStyle(.secondary)
+              .multilineTextAlignment(.center)
+          }
+        }
+        Spacer()
+      }
+
+      SUBezierButton(
+        size: .medium,
+        variant: .filled,
+        semantic: .primary,
+        title: "Present"
+      ) {
+        self.isModalPresented = true
+      }
+      .bezierModal(isPresented: self.$isModalPresented) {
+        VStack(spacing: 16) {
+          Text("Presented Modal")
             .font(.system(size: 16, weight: .semibold))
-          Text("Modal은 customContent 슬롯 하나를 가진 순수 컨테이너입니다.")
+          Text("배경 dim 위에 별도 화면으로 표시됩니다.")
             .font(.system(size: 14))
             .foregroundStyle(.secondary)
             .multilineTextAlignment(.center)
+          SUBezierButton(
+            size: .medium,
+            variant: .filled,
+            semantic: .secondary,
+            title: "Close"
+          ) {
+            self.isModalPresented = false
+          }
         }
       }
-      Spacer()
     }
+    .frame(maxWidth: .infinity)
     .padding(.vertical, 24)
   }
 
   private var uiKitPreview: some View {
-    HStack {
-      Spacer()
+    VStack(spacing: 24) {
       UIKitWrap {
         let modal = BezierModal()
 
-        let titleLabel = UILabel()
-        titleLabel.text = "Custom Content"
-        titleLabel.font = .systemFont(ofSize: 16, weight: .semibold)
-        titleLabel.textAlignment = .center
-
-        let descriptionLabel = UILabel()
-        descriptionLabel.text = "Modal은 customContent 슬롯 하나를 가진 순수 컨테이너입니다."
-        descriptionLabel.font = .systemFont(ofSize: 14)
-        descriptionLabel.textColor = .secondaryLabel
-        descriptionLabel.textAlignment = .center
-        descriptionLabel.numberOfLines = 0
-
-        let stackView = UIStackView(arrangedSubviews: [titleLabel, descriptionLabel])
-        stackView.axis = .vertical
-        stackView.spacing = 8
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-
+        let stackView = Self.makeSampleContentStackView()
         modal.contentView.addSubview(stackView)
         NSLayoutConstraint.activate([
           stackView.topAnchor.constraint(equalTo: modal.contentView.topAnchor),
@@ -61,8 +76,56 @@ struct ModalCatalog: View {
         return modal
       }
       .fixedSize()
-      Spacer()
+
+      UIKitWrap {
+        let button = BezierButton(size: .medium, variant: .filled, semantic: .primary)
+        button.title = "Present (UIKit)"
+        button.addAction(
+          UIAction { [weak button] _ in
+            guard let presenter = button?.topPresentingViewController else { return }
+            let contentView = Self.makeSampleContentStackView()
+            let modalController = BezierModalViewController(contentView: contentView)
+
+            let closeButton = BezierButton(size: .medium, variant: .filled, semantic: .secondary)
+            closeButton.title = "Close"
+            closeButton.addAction(
+              UIAction { [weak modalController] _ in
+                modalController?.dismiss(animated: true)
+              },
+              for: .touchUpInside
+            )
+            contentView.setCustomSpacing(16, after: contentView.arrangedSubviews[1])
+            contentView.addArrangedSubview(closeButton)
+
+            presenter.present(modalController, animated: true)
+          },
+          for: .touchUpInside
+        )
+        return button
+      }
+      .fixedSize()
     }
+    .frame(maxWidth: .infinity)
     .padding(.vertical, 24)
+  }
+
+  private static func makeSampleContentStackView() -> UIStackView {
+    let titleLabel = UILabel()
+    titleLabel.text = "Custom Content"
+    titleLabel.font = .systemFont(ofSize: 16, weight: .semibold)
+    titleLabel.textAlignment = .center
+
+    let descriptionLabel = UILabel()
+    descriptionLabel.text = "Modal은 customContent 슬롯 하나를 가진 순수 컨테이너입니다."
+    descriptionLabel.font = .systemFont(ofSize: 14)
+    descriptionLabel.textColor = .secondaryLabel
+    descriptionLabel.textAlignment = .center
+    descriptionLabel.numberOfLines = 0
+
+    let stackView = UIStackView(arrangedSubviews: [titleLabel, descriptionLabel])
+    stackView.axis = .vertical
+    stackView.spacing = 8
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    return stackView
   }
 }

--- a/Examples/BezierExamples/BezierExamples/Components/ModalCatalog.swift
+++ b/Examples/BezierExamples/BezierExamples/Components/ModalCatalog.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+import UIKit
+import BezierSwift
+
+struct ModalCatalog: View {
+  var body: some View {
+    CatalogScreen(title: "Modal") {
+      CatalogSection(.swiftUI) { self.swiftUIPreview }
+      CatalogSection(.uiKit) { self.uiKitPreview }
+    }
+  }
+
+  private var swiftUIPreview: some View {
+    HStack {
+      Spacer()
+      SUBezierModal {
+        VStack(spacing: 8) {
+          Text("Custom Content")
+            .font(.system(size: 16, weight: .semibold))
+          Text("Modal은 customContent 슬롯 하나를 가진 순수 컨테이너입니다.")
+            .font(.system(size: 14))
+            .foregroundStyle(.secondary)
+            .multilineTextAlignment(.center)
+        }
+      }
+      Spacer()
+    }
+    .padding(.vertical, 24)
+  }
+
+  private var uiKitPreview: some View {
+    HStack {
+      Spacer()
+      UIKitWrap {
+        let modal = BezierModal()
+
+        let titleLabel = UILabel()
+        titleLabel.text = "Custom Content"
+        titleLabel.font = .systemFont(ofSize: 16, weight: .semibold)
+        titleLabel.textAlignment = .center
+
+        let descriptionLabel = UILabel()
+        descriptionLabel.text = "Modal은 customContent 슬롯 하나를 가진 순수 컨테이너입니다."
+        descriptionLabel.font = .systemFont(ofSize: 14)
+        descriptionLabel.textColor = .secondaryLabel
+        descriptionLabel.textAlignment = .center
+        descriptionLabel.numberOfLines = 0
+
+        let stackView = UIStackView(arrangedSubviews: [titleLabel, descriptionLabel])
+        stackView.axis = .vertical
+        stackView.spacing = 8
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+
+        modal.contentView.addSubview(stackView)
+        NSLayoutConstraint.activate([
+          stackView.topAnchor.constraint(equalTo: modal.contentView.topAnchor),
+          stackView.bottomAnchor.constraint(equalTo: modal.contentView.bottomAnchor),
+          stackView.leadingAnchor.constraint(equalTo: modal.contentView.leadingAnchor),
+          stackView.trailingAnchor.constraint(equalTo: modal.contentView.trailingAnchor),
+        ])
+        return modal
+      }
+      .fixedSize()
+      Spacer()
+    }
+    .padding(.vertical, 24)
+  }
+}

--- a/Examples/BezierExamples/BezierExamples/Shared/UIView+TopPresenting.swift
+++ b/Examples/BezierExamples/BezierExamples/Shared/UIView+TopPresenting.swift
@@ -1,0 +1,11 @@
+import UIKit
+
+extension UIView {
+  var topPresentingViewController: UIViewController? {
+    guard var controller = self.window?.rootViewController else { return nil }
+    while let presented = controller.presentedViewController {
+      controller = presented
+    }
+    return controller
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierButton/SUBezierButton.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierButton/SUBezierButton.swift
@@ -13,6 +13,7 @@ public struct SUBezierButton: View, Themeable {
   private let leadingIcon: Image?
   private let trailingIcon: Image?
   private let isLoading: Bool
+  private let isFillWidth: Bool
   private let action: () -> Void
 
   @Environment(\.isEnabled) private var isEnabled
@@ -28,6 +29,31 @@ public struct SUBezierButton: View, Themeable {
     isLoading: Bool = false,
     action: @escaping () -> Void
   ) {
+    self.init(
+      size: size,
+      variant: variant,
+      semantic: semantic,
+      title: title,
+      leadingIcon: leadingIcon,
+      trailingIcon: trailingIcon,
+      isLoading: isLoading,
+      isFillWidth: false,
+      action: action
+    )
+  }
+
+  // 배치는 컨테이너 책임이라 public으로 노출하지 않는다 — 모듈 내 컨테이너(SUBezierConfirmModal 등) 전용
+  init(
+    size: BezierButtonSize,
+    variant: BezierButtonVariant,
+    semantic: BezierButtonSemantic,
+    title: String? = nil,
+    leadingIcon: Image? = nil,
+    trailingIcon: Image? = nil,
+    isLoading: Bool = false,
+    isFillWidth: Bool,
+    action: @escaping () -> Void
+  ) {
     self.size = size
     self.variant = variant
     self.semantic = semantic
@@ -35,6 +61,7 @@ public struct SUBezierButton: View, Themeable {
     self.leadingIcon = leadingIcon
     self.trailingIcon = trailingIcon
     self.isLoading = isLoading
+    self.isFillWidth = isFillWidth
     self.action = action
   }
 
@@ -51,10 +78,11 @@ public struct SUBezierButton: View, Themeable {
       .padding(.horizontal, self.size.horizontalPadding)
       .frame(
         minWidth: self.size.minWidth,
+        maxWidth: self.isFillWidth ? .infinity : nil,
         minHeight: self.size.height,
         maxHeight: self.size.height
       )
-      .fixedSize(horizontal: true, vertical: false)
+      .fixedSize(horizontal: !self.isFillWidth, vertical: false)
     }
     .buttonStyle(
       SUBezierButtonStyle(

--- a/Sources/BezierSwift/MasterComponent/BezierModal/BezierModal.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierModal/BezierModal.swift
@@ -1,0 +1,114 @@
+//
+//  BezierModal.swift
+//  BezierSwift
+//
+
+import UIKit
+
+public final class BezierModal: UIView, BezierComponentable {
+  // MARK: - BezierComponentable
+
+  public var colorTheme: BezierColorTheme { .systemBezierColorTheme() }
+  public var componentTheme: BezierComponentTheme = .normal {
+    didSet { self.refreshAppearance() }
+  }
+
+  // MARK: - Public Properties
+
+  public let contentView = UIView()
+
+  // MARK: - Subviews
+
+  private let containerView = UIView()
+
+  // MARK: - Init
+
+  public init() {
+    super.init(frame: .zero)
+    self.setUp()
+  }
+
+  public required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    self.setUp()
+  }
+
+  // MARK: - Setup
+
+  private func setUp() {
+    self.translatesAutoresizingMaskIntoConstraints = false
+
+    // 그림자는 클리핑되지 않는 바깥 layer에, 콘텐츠 클리핑은 containerView에 분리 적용
+    self.layer.masksToBounds = false
+    self.layer.shadowOpacity = 1
+
+    self.containerView.translatesAutoresizingMaskIntoConstraints = false
+    self.containerView.layer.cornerRadius = BezierModalSpec.cornerRadius.rawValue
+    self.containerView.layer.cornerCurve = .continuous
+    self.containerView.layer.masksToBounds = true
+
+    self.contentView.translatesAutoresizingMaskIntoConstraints = false
+
+    self.addSubview(self.containerView)
+    self.containerView.addSubview(self.contentView)
+
+    let widthConstraint = self.widthAnchor.constraint(equalToConstant: BezierModalSpec.width)
+    widthConstraint.priority = .defaultHigh
+
+    NSLayoutConstraint.activate([
+      widthConstraint,
+      self.widthAnchor.constraint(lessThanOrEqualToConstant: BezierModalSpec.maxWidth),
+      self.containerView.topAnchor.constraint(equalTo: self.topAnchor),
+      self.containerView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+      self.containerView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+      self.containerView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+      self.contentView.topAnchor.constraint(
+        equalTo: self.containerView.topAnchor,
+        constant: BezierModalSpec.topPadding
+      ),
+      self.contentView.bottomAnchor.constraint(
+        equalTo: self.containerView.bottomAnchor,
+        constant: -BezierModalSpec.bottomPadding
+      ),
+      self.contentView.leadingAnchor.constraint(
+        equalTo: self.containerView.leadingAnchor,
+        constant: BezierModalSpec.horizontalPadding
+      ),
+      self.contentView.trailingAnchor.constraint(
+        equalTo: self.containerView.trailingAnchor,
+        constant: -BezierModalSpec.horizontalPadding
+      ),
+      self.contentView.heightAnchor.constraint(
+        greaterThanOrEqualToConstant: BezierModalSpec.contentMinHeight
+      ),
+    ])
+
+    self.refreshAppearance()
+  }
+
+  // MARK: - Layout Update
+
+  public override func layoutSubviews() {
+    super.layoutSubviews()
+    self.layer.shadowPath = UIBezierPath(
+      roundedRect: self.bounds,
+      cornerRadius: BezierModalSpec.cornerRadius.rawValue
+    ).cgPath
+  }
+
+  public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    self.refreshAppearance()
+  }
+
+  // MARK: - Refresh
+
+  private func refreshAppearance() {
+    self.containerView.backgroundColor = BezierModalSpec.backgroundToken.palette(self)
+
+    let elevation = BezierModalSpec.elevation.rawValue
+    self.layer.shadowColor = elevation.semanticColor.palette(self).cgColor
+    self.layer.shadowOffset = CGSize(width: elevation.x, height: elevation.y)
+    self.layer.shadowRadius = elevation.blur
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierModal/BezierModal.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierModal/BezierModal.swift
@@ -6,6 +6,9 @@
 import UIKit
 
 public final class BezierModal: UIView, BezierComponentable {
+  // 프레젠테이션 확장 제약(BezierModalPresentationConstant)이 이 값을 기준으로 +1 우선순위를 계산한다
+  static let widthConstraintPriority: UILayoutPriority = .defaultHigh
+
   // MARK: - BezierComponentable
 
   public var colorTheme: BezierColorTheme { .systemBezierColorTheme() }
@@ -53,7 +56,7 @@ public final class BezierModal: UIView, BezierComponentable {
     self.containerView.addSubview(self.contentView)
 
     let widthConstraint = self.widthAnchor.constraint(equalToConstant: BezierModalSpec.width)
-    widthConstraint.priority = .defaultHigh
+    widthConstraint.priority = Self.widthConstraintPriority
 
     NSLayoutConstraint.activate([
       widthConstraint,

--- a/Sources/BezierSwift/MasterComponent/BezierModal/BezierModalSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierModal/BezierModalSpec.swift
@@ -1,0 +1,18 @@
+//
+//  BezierModalSpec.swift
+//  BezierSwift
+//
+
+import CoreGraphics
+
+public enum BezierModalSpec {
+  public static let width: CGFloat = 320
+  public static let maxWidth: CGFloat = 480
+  public static let topPadding: CGFloat = 20
+  public static let bottomPadding: CGFloat = 16
+  public static let horizontalPadding: CGFloat = 16
+  public static let contentMinHeight: CGFloat = 1
+  public static let cornerRadius: BezierCornerRadius = .round32
+  public static let elevation: BezierElevation = .mEv3
+  public static let backgroundToken: BCSemanticToken = .surfaceHigher
+}

--- a/Sources/BezierSwift/MasterComponent/BezierModal/BezierModalViewController.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierModal/BezierModalViewController.swift
@@ -1,0 +1,119 @@
+//
+//  BezierModalViewController.swift
+//  BezierSwift
+//
+
+import UIKit
+
+// Figma에 dim/프레젠테이션 스펙이 없어 BezierModalSpec(SPEC.md 매핑)과 분리한 협의 상수
+enum BezierModalPresentationConstant {
+  static let dimToken: BCSemanticToken = .dimAbsoluteBlack
+  static let horizontalMargin: CGFloat = 40
+  static let expandedWidth: CGFloat = BezierModalSpec.maxWidth
+  // BezierModal 내장 width 320(.defaultHigh) 제약을 1만큼 이겨서 카드를 최대로 확장하고,
+  // required인 좌우 마진이 좁은 화면에서 이를 깎아 폭 = min(화면너비 − 80, 480)이 되게 한다
+  static let widthExpansionPriority = UILayoutPriority(UILayoutPriority.defaultHigh.rawValue + 1)
+}
+
+public final class BezierModalViewController: UIViewController, BezierComponentable {
+  // MARK: - BezierComponentable
+
+  public var colorTheme: BezierColorTheme { .systemBezierColorTheme() }
+  public var componentTheme: BezierComponentTheme = .normal {
+    didSet { self.refreshAppearance() }
+  }
+
+  // MARK: - Public Properties
+
+  public let modalView: UIView
+
+  // MARK: - Subviews
+
+  private let dimView = UIView()
+
+  // MARK: - Init
+
+  public init(modalView: UIView) {
+    self.modalView = modalView
+    super.init(nibName: nil, bundle: nil)
+    self.modalPresentationStyle = .overFullScreen
+    self.modalTransitionStyle = .crossDissolve
+  }
+
+  public convenience init(contentView: UIView) {
+    let modal = BezierModal()
+    contentView.translatesAutoresizingMaskIntoConstraints = false
+    modal.contentView.addSubview(contentView)
+    NSLayoutConstraint.activate([
+      contentView.topAnchor.constraint(equalTo: modal.contentView.topAnchor),
+      contentView.bottomAnchor.constraint(equalTo: modal.contentView.bottomAnchor),
+      contentView.leadingAnchor.constraint(equalTo: modal.contentView.leadingAnchor),
+      contentView.trailingAnchor.constraint(equalTo: modal.contentView.trailingAnchor),
+    ])
+    self.init(modalView: modal)
+  }
+
+  public required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: - View Cycles
+
+  public override func viewDidLoad() {
+    super.viewDidLoad()
+    self.setUp()
+  }
+
+  public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    self.refreshAppearance()
+  }
+
+  // MARK: - Setup
+
+  private func setUp() {
+    self.view.backgroundColor = .clear
+
+    self.dimView.translatesAutoresizingMaskIntoConstraints = false
+    self.modalView.translatesAutoresizingMaskIntoConstraints = false
+
+    self.view.addSubview(self.dimView)
+    self.dimView.addSubview(self.modalView)
+
+    let centerYConstraint = self.modalView.centerYAnchor.constraint(equalTo: self.view.centerYAnchor)
+    centerYConstraint.priority = .defaultHigh
+
+    let widthExpansionConstraint = self.modalView.widthAnchor.constraint(
+      equalToConstant: BezierModalPresentationConstant.expandedWidth
+    )
+    widthExpansionConstraint.priority = BezierModalPresentationConstant.widthExpansionPriority
+
+    NSLayoutConstraint.activate([
+      self.dimView.topAnchor.constraint(equalTo: self.view.topAnchor),
+      self.dimView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
+      self.dimView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+      self.dimView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+      self.modalView.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+      centerYConstraint,
+      widthExpansionConstraint,
+      self.modalView.leadingAnchor.constraint(
+        greaterThanOrEqualTo: self.view.leadingAnchor,
+        constant: BezierModalPresentationConstant.horizontalMargin
+      ),
+      self.modalView.trailingAnchor.constraint(
+        lessThanOrEqualTo: self.view.trailingAnchor,
+        constant: -BezierModalPresentationConstant.horizontalMargin
+      ),
+      self.modalView.topAnchor.constraint(greaterThanOrEqualTo: self.view.safeAreaLayoutGuide.topAnchor),
+      self.modalView.bottomAnchor.constraint(lessThanOrEqualTo: self.view.safeAreaLayoutGuide.bottomAnchor),
+    ])
+
+    self.refreshAppearance()
+  }
+
+  // MARK: - Refresh
+
+  private func refreshAppearance() {
+    self.dimView.backgroundColor = BezierModalPresentationConstant.dimToken.palette(self)
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierModal/BezierModalViewController.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierModal/BezierModalViewController.swift
@@ -10,9 +10,9 @@ enum BezierModalPresentationConstant {
   static let dimToken: BCSemanticToken = .dimAbsoluteBlack
   static let horizontalMargin: CGFloat = 40
   static let expandedWidth: CGFloat = BezierModalSpec.maxWidth
-  // BezierModal 내장 width 320(.defaultHigh) 제약을 1만큼 이겨서 카드를 최대로 확장하고,
+  // BezierModal 내장 width 320 제약을 1만큼 이겨서 카드를 최대로 확장하고,
   // required인 좌우 마진이 좁은 화면에서 이를 깎아 폭 = min(화면너비 − 80, 480)이 되게 한다
-  static let widthExpansionPriority = UILayoutPriority(UILayoutPriority.defaultHigh.rawValue + 1)
+  static let widthExpansionPriority = UILayoutPriority(BezierModal.widthConstraintPriority.rawValue + 1)
 }
 
 public final class BezierModalViewController: UIViewController, BezierComponentable {
@@ -73,6 +73,8 @@ public final class BezierModalViewController: UIViewController, BezierComponenta
 
   private func setUp() {
     self.view.backgroundColor = .clear
+    // overFullScreen은 배경 계층이 유지되어 VoiceOver가 뒤 화면에 포커스할 수 있다
+    self.view.accessibilityViewIsModal = true
 
     self.dimView.translatesAutoresizingMaskIntoConstraints = false
     self.modalView.translatesAutoresizingMaskIntoConstraints = false

--- a/Sources/BezierSwift/MasterComponent/BezierModal/SPEC.md
+++ b/Sources/BezierSwift/MasterComponent/BezierModal/SPEC.md
@@ -1,0 +1,113 @@
+# BezierModal Spec
+
+> Figma: [🚧 Mobile Components — Modal](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=5325-11895&m=dev)
+> Linear: [MOB-6343](https://linear.app/channel/issue/MOB-6343/bezierswift-v3-modal-confirmmodal-컴포넌트-구현)
+
+화면 중앙에 떠서 뒤 배경을 차단하는 surface 컨테이너. 내부는 `customContent` 슬롯 하나로, 임의 콘텐츠를 담는다.
+
+- **모양**: 라운드 사각형 (radius/32 = 32pt), 하방 drop shadow (§3 Effect 참조)
+- **역할**: 순수 컨테이너 — 자체 텍스트/버튼/아이콘 없음 (Figma 인스턴스 주석 `modal (그냥 순수한 컨테이너)`, node 4803:1042)
+- **Modal vs Overlay** (Figma Modal 페이지 노트, node 5325:11901): 모달은 뒤가 차단되고 센터에 뜸 / 오버레이는 뒤가 차단되지 않고 트리거 근처에 뜸
+
+---
+
+## 1. Component Properties
+
+Figma 컴포넌트가 정의하는 property와 옵션은 다음이 전부다.
+
+| Property | 값 | 비고 |
+|---|---|---|
+| **customContent** | slot (children) | 컨테이너 내부를 채우는 유일한 슬롯. node 5325:11867 |
+
+- Variant property 없음 (단일 컴포넌트, component set 아님)
+- State property 없음 (default/pressed/active/disabled/loading 분기 없음)
+- 텍스트 node 없음, asset(아이콘/이미지) node 없음
+
+총 instance: **1개** (단일 컴포넌트)
+
+---
+
+## 2. Layout Spec
+
+| 항목 | 값 |
+|---|---|
+| Width | 320pt |
+| Max Width | 480pt |
+| Height (Figma master) | 220pt — `customContent` 슬롯이 패딩 제외 잔여 영역(288×184)을 채움 |
+| Padding Top | 20pt |
+| Padding Bottom | 16pt |
+| Padding Horizontal | 16pt |
+| Corner Radius | `radius/32` = 32pt |
+| Overflow | clip (라운드 경계로 콘텐츠 클리핑) |
+| 정렬 | 세로 스택, 가로 center |
+| customContent 슬롯 | 폭 full (패딩 제외), flex-grow 1, min-height 1pt |
+
+---
+
+## 3. 컬러 토큰
+
+### Background
+
+| 대상 | Figma Variable | Raw |
+|---|---|---|
+| 컨테이너 배경 | `color/surface/higher` | `#FFFFFF` |
+
+### Shadow (Effect)
+
+| 대상 | Figma Style | 구성 |
+|---|---|---|
+| 컨테이너 그림자 | `Elevation/Mobile/3` | DROP_SHADOW, color `color/elevation/large` (`#00000038`), offset (0, `elevation/4` = 4), blur `elevation/20` = 20, spread 0 |
+
+Border 없음. 텍스트/아이콘 컬러 없음 (콘텐츠는 슬롯 주입).
+
+---
+
+## 4. Typography
+
+이 컴포넌트에 텍스트 없음.
+
+---
+
+## 5. State 별 시각 동작
+
+해당 없음. Modal 컨테이너 자체는 인터랙션 state property가 없다.
+
+---
+
+## 6. Loading Indicator
+
+해당 없음.
+
+---
+
+## 7. 디자이너 가이드라인 (Figma 캔버스 노트 인용)
+
+- "모달: 뒤가 차단되고 센터에 뜸 / 오버레이: 뒤가 차단되지 않고 트리거 근처에 뜸" (Modal 페이지, node 5325:11901)
+- "modal (그냥 순수한 컨테이너)" (ConfirmModal 페이지의 Modal 인스턴스 주석, node 4803:1042)
+- "컨펌모달이 모달을 레퍼런싱하게 고쳐놔야댐" (Modal 페이지, node 5325:11903) — ConfirmModal이 Modal 컨테이너를 재사용하는 구조를 뒷받침
+
+---
+
+## 8. 매핑되는 코드 심볼
+
+| 정의 | 파일 |
+|---|---|
+| UIKit 구현 | `BezierModal.swift` *(MOB-6343에서 신설)* |
+| SwiftUI 구현 | `SUBezierModal.swift` *(MOB-6343에서 신설)* |
+| Layout 상수 정의 | `BezierModalSpec.swift` *(MOB-6343에서 신설)* |
+| 배경 토큰 | `BCSemanticToken.surfaceHigher` (`Sources/BezierSwift/Foundation/Color/V3/BCSemanticToken.swift`) |
+| 그림자 | `BezierElevation.mEv3` (`Sources/BezierSwift/Foundation/Boxing/BezierElevation.swift`) — (.elevationLarge, x 0, y 4, blur 20) |
+| Corner radius | `BezierCornerRadius.round32` (`Sources/BezierSwift/Foundation/Boxing/BezierCornerRadius.swift`) |
+
+> **협의 사항 (MOB-6343)**: "Modal을 컨테이너 개념으로 만들고 ConfirmModal이 Modal을 상속하거나 그 안에 컨텐츠를 채우거나 하자" — 구현체의 높이는 Figma master의 고정 220pt가 아니라 주입된 콘텐츠 크기를 따른다(hug). ConfirmModal(별도 spec)이 이 컨테이너를 재사용한다.
+
+---
+
+## 9. Variant 매트릭스
+
+총 instance: **1개**
+
+```text
+Modal = 5325:11895
+└─ customContent (slot) = 5325:11867
+```

--- a/Sources/BezierSwift/MasterComponent/BezierModal/SUBezierModal+Presentation.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierModal/SUBezierModal+Presentation.swift
@@ -1,0 +1,90 @@
+//
+//  SUBezierModal+Presentation.swift
+//  BezierSwift
+//
+
+import SwiftUI
+import UIKit
+
+extension View {
+  public func bezierModal<ModalContent: View>(
+    isPresented: Binding<Bool>,
+    onDismiss: (() -> Void)? = nil,
+    @ViewBuilder content: @escaping () -> ModalContent
+  ) -> some View {
+    self.background(
+      SUBezierModalPresenter(
+        isPresented: isPresented,
+        onDismiss: onDismiss,
+        modalContent: content
+      )
+    )
+  }
+}
+
+struct SUBezierModalPresenter<ModalContent: View>: UIViewControllerRepresentable {
+  @Binding var isPresented: Bool
+  let onDismiss: (() -> Void)?
+  let modalContent: () -> ModalContent
+
+  final class Coordinator {
+    var modalController: BezierModalViewController?
+    var hostingController: UIHostingController<ModalContent>?
+  }
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator()
+  }
+
+  func makeUIViewController(context: Context) -> UIViewController {
+    UIViewController()
+  }
+
+  func updateUIViewController(_ anchor: UIViewController, context: Context) {
+    let coordinator = context.coordinator
+
+    if self.isPresented {
+      if let hostingController = coordinator.hostingController {
+        hostingController.rootView = self.modalContent()
+      } else {
+        self.present(from: anchor, coordinator: coordinator)
+      }
+    } else if let modalController = coordinator.modalController {
+      coordinator.modalController = nil
+      coordinator.hostingController = nil
+      modalController.dismiss(animated: true) {
+        self.onDismiss?()
+      }
+    }
+  }
+
+  static func dismantleUIViewController(_ uiViewController: UIViewController, coordinator: Coordinator) {
+    coordinator.modalController?.dismiss(animated: false)
+    coordinator.modalController = nil
+    coordinator.hostingController = nil
+  }
+
+  private func present(from anchor: UIViewController, coordinator: Coordinator) {
+    // 최초 렌더 직후에는 anchor가 아직 window에 붙지 않았을 수 있어 다음 runloop에 재시도
+    guard anchor.view.window != nil else {
+      DispatchQueue.main.async {
+        guard self.isPresented, coordinator.modalController == nil else { return }
+        self.present(from: anchor, coordinator: coordinator)
+      }
+      return
+    }
+
+    let hostingController = UIHostingController(rootView: self.modalContent())
+    hostingController.view.backgroundColor = .clear
+    hostingController.sizingOptions = .intrinsicContentSize
+
+    let modalController = BezierModalViewController(contentView: hostingController.view)
+    modalController.addChild(hostingController)
+    hostingController.didMove(toParent: modalController)
+
+    coordinator.modalController = modalController
+    coordinator.hostingController = hostingController
+
+    anchor.present(modalController, animated: true)
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierModal/SUBezierModal+Presentation.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierModal/SUBezierModal+Presentation.swift
@@ -30,6 +30,7 @@ struct SUBezierModalPresenter<ModalContent: View>: UIViewControllerRepresentable
   final class Coordinator {
     var modalController: BezierModalViewController?
     var hostingController: UIHostingController<ModalContent>?
+    var isDismissing = false
   }
 
   func makeCoordinator() -> Coordinator {
@@ -46,14 +47,20 @@ struct SUBezierModalPresenter<ModalContent: View>: UIViewControllerRepresentable
     if self.isPresented {
       if let hostingController = coordinator.hostingController {
         hostingController.rootView = self.modalContent()
-      } else {
+      } else if coordinator.modalController == nil, !coordinator.isDismissing {
         self.present(from: anchor, coordinator: coordinator)
       }
-    } else if let modalController = coordinator.modalController {
-      coordinator.modalController = nil
-      coordinator.hostingController = nil
+    } else if let modalController = coordinator.modalController, !coordinator.isDismissing {
+      coordinator.isDismissing = true
       modalController.dismiss(animated: true) {
+        coordinator.modalController = nil
+        coordinator.hostingController = nil
+        coordinator.isDismissing = false
         self.onDismiss?()
+        // dismiss 진행 중 binding이 다시 true가 된 경우 여기서 재-present (update가 다시 불리지 않음)
+        if self.isPresented {
+          self.present(from: anchor, coordinator: coordinator)
+        }
       }
     }
   }
@@ -62,13 +69,14 @@ struct SUBezierModalPresenter<ModalContent: View>: UIViewControllerRepresentable
     coordinator.modalController?.dismiss(animated: false)
     coordinator.modalController = nil
     coordinator.hostingController = nil
+    coordinator.isDismissing = false
   }
 
   private func present(from anchor: UIViewController, coordinator: Coordinator) {
     // 최초 렌더 직후에는 anchor가 아직 window에 붙지 않았을 수 있어 다음 runloop에 재시도
     guard anchor.view.window != nil else {
       DispatchQueue.main.async {
-        guard self.isPresented, coordinator.modalController == nil else { return }
+        guard self.isPresented, coordinator.modalController == nil, !coordinator.isDismissing else { return }
         self.present(from: anchor, coordinator: coordinator)
       }
       return

--- a/Sources/BezierSwift/MasterComponent/BezierModal/SUBezierModal.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierModal/SUBezierModal.swift
@@ -1,0 +1,42 @@
+//
+//  SUBezierModal.swift
+//  BezierSwift
+//
+
+import SwiftUI
+
+public struct SUBezierModal<Content: View>: View, Themeable {
+  @Environment(\.colorScheme) public var colorScheme
+
+  private let content: Content
+
+  public init(@ViewBuilder content: () -> Content) {
+    self.content = content()
+  }
+
+  public var body: some View {
+    VStack(spacing: 0) {
+      self.content
+        .frame(maxWidth: .infinity, minHeight: BezierModalSpec.contentMinHeight)
+    }
+    .padding(.top, BezierModalSpec.topPadding)
+    .padding(.bottom, BezierModalSpec.bottomPadding)
+    .padding(.horizontal, BezierModalSpec.horizontalPadding)
+    .frame(width: BezierModalSpec.width)
+    .background(self.palette(BezierModalSpec.backgroundToken))
+    .applyBezierCornerRadius(type: BezierModalSpec.cornerRadius)
+    .applyBezierElevation(BezierModalSpec.elevation)
+  }
+}
+
+struct SUBezierModal_Previews: PreviewProvider {
+  static var previews: some View {
+    ZStack {
+      Color(uiColor: .systemGroupedBackground).ignoresSafeArea()
+      SUBezierModal {
+        Text("Custom Content")
+          .frame(height: 184)
+      }
+    }
+  }
+}


### PR DESCRIPTION
## 배경

[MOB-6343](https://linear.app/channel/issue/MOB-6343) — V3 Modal/ConfirmModal 구현의 1차 PR. BezierModal 컨테이너(뷰)와, ch-desk-ios Legacy `BezierDialog`처럼 **별도 화면으로 present + 배경 dim** 사용 패턴을 Modal 레벨 API로 제공한다. ConfirmModal(2차 PR)은 이 API에 얹힌다.

Figma에는 dim/프레젠테이션 스펙이 없어(Overlay 노트는 "backdrop 없음" 명시) 이 영역은 협의 구현이며, 컨테이너 뷰 자체는 Figma Modal(`5325:11895`) SSOT를 따른다 — `BezierModal/SPEC.md` 참조.

## 변경 내용

### 1. BezierModal 컨테이너 (UIKit + SwiftUI)

- `BezierModal` / `SUBezierModal` / `BezierModalSpec` — 순수 컨테이너 (w320·maxW480 / padding 20·16·16 / radius32 / mEv3 / surfaceHigher), `customContent` 슬롯 하나
- Figma ↔ SPEC.md 7-validator 검증 통과

### 2. Modal 프레젠테이션 API (협의 구현)

- **UIKit `BezierModalViewController`**: `.overFullScreen` + `.crossDissolve` present (Legacy BezierDialog 패턴). dim = `BCSemanticToken.dimAbsoluteBlack` (GitHub Modal-spec의 `--color-dim-absolute-black`과 동일 토큰). dim 탭 닫기 미지원 (협의)
- **너비 정책** `min(화면너비 − 80, 480)` (Modal-spec §11 [Mobile] · Figma description): 좌우 마진 40 required + `width == 480 @751` 확장 제약이 BezierModal 내장 `320 @750`을 1만큼 이겨서, 회전/사이즈 변화에도 재계산 없이 자동 유지
- **SwiftUI `.bezierModal(isPresented:)`**: `UIViewControllerRepresentable`로 UIKit presenter 재사용 — dim/너비/전환 단일 구현, nav/tab bar 위를 실제로 덮음 (iOS 16.0 타깃이라 `presentationBackground(.clear)` 16.4+ 불가)
- 다크모드: `traitCollectionDidChange`에서 dim 색 재주입

### 3. SUBezierButton internal fill-width 오버로드

- SwiftUI는 컨테이너 주도 stretch가 불가능(캡슐 배경이 ButtonStyle 내부 label 기준)해서 **internal init 오버로드**로만 fill 동작 제공 — public API 무변화. 배치 결정권은 컨테이너 책임 (ch-desk-ios `ChatStreamInputBlockView`의 UIKit 스택 배치 관례와 정합). 2차 PR의 SUBezierConfirmModal이 사용

### 4. Examples

- `ModalCatalog`: 정적 프리뷰 + SwiftUI/UIKit present 데모 (`UIView.topPresentingViewController` 헬퍼 Shared로 추가)

## 검증

- BezierSwift clean build / BezierExamples 빌드 (이 브랜치 단독) ✅
- 시뮬레이터(iPhone 16): present/dismiss crossDissolve + dim, dim 탭 무반응, 폭 393pt 화면 → ~310pt(정책 일치), 다크모드 전환 시 dim 재적응 ✅

## 참고

- 리니어: https://linear.app/channel/issue/MOB-6343
- 후속: ConfirmModal 컴포넌트 PR (이 브랜치 기반 stacked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * SwiftUI와 UIKit에서 사용할 수 있는 새로운 모달 컴포넌트를 추가했습니다.
  * 모달 표시/해제를 SwiftUI 바인딩으로 제어하고, 해제 시 콜백을 지원합니다.
  * 모달 테마 기반 배경과 그림자 스타일을 적용했습니다.
  * 예제 카탈로그에 Modal 데모와 SwiftUI/ UIKit 미리보기를 추가했습니다.
  * 버튼의 가로 확장 레이아웃 동작을 개선했습니다.

* **문서**
  * 모달 컴포넌트 사양(레이아웃/스타일)을 문서화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->