### PR TITLE
[MOB-6343] BezierConfirmModal 컴포넌트 구현 (UIKit + SwiftUI)

### DIFF
--- a/Examples/BezierExamples/BezierExamples/App/CatalogRegistry.swift
+++ b/Examples/BezierExamples/BezierExamples/App/CatalogRegistry.swift
@@ -76,6 +76,12 @@ enum CatalogRegistry {
       section: .v3Components,
       destination: AnyView(ModalCatalog())
     ),
+    CatalogItem(
+      id: "confirm-modal",
+      title: "ConfirmModal",
+      section: .v3Components,
+      destination: AnyView(ConfirmModalCatalog())
+    ),
     // MARK: - Legacy Components
     CatalogItem(
       id: "legacy-button",

--- a/Examples/BezierExamples/BezierExamples/Components/ConfirmModalCatalog.swift
+++ b/Examples/BezierExamples/BezierExamples/Components/ConfirmModalCatalog.swift
@@ -1,0 +1,196 @@
+import SwiftUI
+import UIKit
+import BezierSwift
+
+struct ConfirmModalCatalog: View {
+  @State private var isVerticalPresented = false
+  @State private var isHorizontalPresented = false
+
+  var body: some View {
+    CatalogScreen(title: "ConfirmModal") {
+      CatalogSection(.swiftUI) { self.swiftUIPreview }
+      CatalogSection(.uiKit) { self.uiKitPreview }
+    }
+  }
+
+  // MARK: - SwiftUI
+
+  private var swiftUIPreview: some View {
+    VStack(spacing: 24) {
+      SUBezierConfirmModal(
+        title: "Dialog Title",
+        description: "Description text goes here.",
+        confirmAction: BezierConfirmModalAction(title: "Confirm"),
+        cancelAction: BezierConfirmModalAction(title: "Cancel")
+      )
+
+      SUBezierConfirmModal(
+        title: "Dialog Title",
+        description: "Description text goes here.",
+        type: .destructive,
+        confirmAction: BezierConfirmModalAction(title: "Delete"),
+        cancelAction: BezierConfirmModalAction(title: "Cancel")
+      )
+
+      SUBezierConfirmModal(
+        title: "Dialog Title",
+        description: "Description text goes here.",
+        buttonLayout: .vertical(altAction: nil),
+        confirmAction: BezierConfirmModalAction(title: "Confirm"),
+        cancelAction: BezierConfirmModalAction(title: "Cancel")
+      )
+
+      SUBezierConfirmModal(
+        title: "Dialog Title",
+        description: "Description text goes here.",
+        type: .destructive,
+        buttonLayout: .vertical(altAction: nil),
+        confirmAction: BezierConfirmModalAction(title: "Delete"),
+        cancelAction: BezierConfirmModalAction(title: "Cancel")
+      )
+
+      SUBezierConfirmModal(
+        title: "Dialog Title",
+        description: "Description text goes here.",
+        buttonLayout: .vertical(altAction: BezierConfirmModalAction(title: "Alt Action")),
+        confirmAction: BezierConfirmModalAction(title: "Confirm"),
+        cancelAction: BezierConfirmModalAction(title: "Cancel")
+      )
+
+      SUBezierConfirmModal(
+        title: "Dialog Title",
+        description: "Description text goes here.",
+        confirmAction: BezierConfirmModalAction(title: "OK"),
+        cancelAction: nil
+      )
+
+      SUBezierConfirmModal(
+        title: "Dialog Title",
+        description: "Description text goes here.",
+        buttonLayout: .vertical(altAction: nil),
+        confirmAction: BezierConfirmModalAction(title: "Confirm"),
+        cancelAction: BezierConfirmModalAction(title: "Cancel")
+      ) {
+        RoundedRectangle(cornerRadius: 8)
+          .fill(Color.secondary.opacity(0.15))
+          .frame(height: 64)
+          .overlay(
+            Text("Custom Content")
+              .font(.system(size: 13))
+              .foregroundStyle(.secondary)
+          )
+      }
+
+      HStack(spacing: 12) {
+        SUBezierButton(
+          size: .medium,
+          variant: .filled,
+          semantic: .primary,
+          title: "Present (vertical)"
+        ) {
+          self.isVerticalPresented = true
+        }
+        .bezierConfirmModal(
+          isPresented: self.$isVerticalPresented,
+          title: "게시글을 삭제할까요?",
+          description: "삭제하면 되돌릴 수 없어요.",
+          type: .destructive,
+          buttonLayout: .vertical(altAction: nil),
+          confirmAction: BezierConfirmModalAction(title: "삭제"),
+          cancelAction: BezierConfirmModalAction(title: "취소")
+        )
+
+        SUBezierButton(
+          size: .medium,
+          variant: .filled,
+          semantic: .secondary,
+          title: "Present (horizontal)"
+        ) {
+          self.isHorizontalPresented = true
+        }
+        .bezierConfirmModal(
+          isPresented: self.$isHorizontalPresented,
+          title: "변경사항을 저장할까요?",
+          description: "저장하지 않으면 변경사항이 사라져요.",
+          confirmAction: BezierConfirmModalAction(title: "저장"),
+          cancelAction: BezierConfirmModalAction(title: "취소")
+        )
+      }
+    }
+    .frame(maxWidth: .infinity)
+    .padding(.vertical, 24)
+  }
+
+  // MARK: - UIKit
+
+  private var uiKitPreview: some View {
+    VStack(spacing: 24) {
+      UIKitWrap {
+        BezierConfirmModal(
+          title: "Dialog Title",
+          description: "Description text goes here.",
+          confirmAction: BezierConfirmModalAction(title: "Confirm"),
+          cancelAction: BezierConfirmModalAction(title: "Cancel")
+        )
+      }
+      .fixedSize()
+
+      UIKitWrap {
+        BezierConfirmModal(
+          title: "Dialog Title",
+          description: "Description text goes here.",
+          type: .destructive,
+          buttonLayout: .vertical(altAction: nil),
+          confirmAction: BezierConfirmModalAction(title: "Delete"),
+          cancelAction: BezierConfirmModalAction(title: "Cancel")
+        )
+      }
+      .fixedSize()
+
+      UIKitWrap {
+        BezierConfirmModal(
+          title: "Dialog Title",
+          description: "Description text goes here.",
+          buttonLayout: .vertical(altAction: BezierConfirmModalAction(title: "Alt Action")),
+          confirmAction: BezierConfirmModalAction(title: "Confirm"),
+          cancelAction: BezierConfirmModalAction(title: "Cancel")
+        )
+      }
+      .fixedSize()
+
+      UIKitWrap {
+        BezierConfirmModal(
+          title: "Dialog Title",
+          description: "Description text goes here.",
+          confirmAction: BezierConfirmModalAction(title: "OK"),
+          cancelAction: nil
+        )
+      }
+      .fixedSize()
+
+      UIKitWrap {
+        let button = BezierButton(size: .medium, variant: .filled, semantic: .primary)
+        button.title = "Present (UIKit)"
+        button.addAction(
+          UIAction { [weak button] _ in
+            guard let presenter = button?.topPresentingViewController else { return }
+            let modalController = BezierModalViewController.confirm(
+              title: "채팅에서 나갈까요?",
+              description: "나가면 대화 내용이 보이지 않아요.",
+              type: .destructive,
+              buttonLayout: .vertical(altAction: nil),
+              confirmAction: BezierConfirmModalAction(title: "나가기"),
+              cancelAction: BezierConfirmModalAction(title: "취소")
+            )
+            presenter.present(modalController, animated: true)
+          },
+          for: .touchUpInside
+        )
+        return button
+      }
+      .fixedSize()
+    }
+    .frame(maxWidth: .infinity)
+    .padding(.vertical, 24)
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierConfirmModal/BezierConfirmModal+Presentation.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierConfirmModal/BezierConfirmModal+Presentation.swift
@@ -1,0 +1,50 @@
+//
+//  BezierConfirmModal+Presentation.swift
+//  BezierSwift
+//
+
+import UIKit
+
+extension BezierModalViewController {
+  public static func confirm(
+    title: String,
+    description: String? = nil,
+    customContent: UIView? = nil,
+    type: BezierConfirmModalType = .default,
+    buttonLayout: BezierConfirmModalButtonLayout = .horizontal,
+    confirmAction: BezierConfirmModalAction,
+    cancelAction: BezierConfirmModalAction?
+  ) -> BezierModalViewController {
+    weak var weakController: BezierModalViewController?
+
+    func dismissingAction(_ action: BezierConfirmModalAction) -> BezierConfirmModalAction {
+      BezierConfirmModalAction(title: action.title) {
+        weakController?.dismiss(animated: true) {
+          action.handler()
+        }
+      }
+    }
+
+    let wrappedLayout: BezierConfirmModalButtonLayout
+    switch buttonLayout {
+    case .vertical(let altAction):
+      wrappedLayout = .vertical(altAction: altAction.map(dismissingAction))
+    case .horizontal:
+      wrappedLayout = .horizontal
+    }
+
+    let modalView = BezierConfirmModal(
+      title: title,
+      description: description,
+      customContent: customContent,
+      type: type,
+      buttonLayout: wrappedLayout,
+      confirmAction: dismissingAction(confirmAction),
+      cancelAction: cancelAction.map(dismissingAction)
+    )
+
+    let controller = BezierModalViewController(modalView: modalView)
+    weakController = controller
+    return controller
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierConfirmModal/BezierConfirmModal.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierConfirmModal/BezierConfirmModal.swift
@@ -1,0 +1,245 @@
+//
+//  BezierConfirmModal.swift
+//  BezierSwift
+//
+
+import UIKit
+
+public final class BezierConfirmModal: UIView, BezierComponentable {
+  // MARK: - BezierComponentable
+
+  public var colorTheme: BezierColorTheme { .systemBezierColorTheme() }
+  public var componentTheme: BezierComponentTheme = .normal {
+    didSet {
+      self.modalView.componentTheme = self.componentTheme
+      self.confirmButton.componentTheme = self.componentTheme
+      self.cancelButton?.componentTheme = self.componentTheme
+      self.altButton?.componentTheme = self.componentTheme
+      self.refreshAppearance()
+    }
+  }
+
+  // MARK: - Public Properties
+
+  public var title: String {
+    didSet { self.refreshAppearance() }
+  }
+
+  // UIView.description(NSObject)과의 충돌을 피하기 위한 명명
+  public var descriptionText: String? {
+    didSet { self.refreshAppearance() }
+  }
+
+  public let confirmButton: BezierButton
+  public let cancelButton: BezierButton?
+  public let altButton: BezierButton?
+
+  // MARK: - Subviews
+
+  private let modalView = BezierModal()
+  private let rootStackView = UIStackView()
+  private let contentStackView = UIStackView()
+  private let titleLabel = UILabel()
+  private let descriptionLabel = UILabel()
+  private let buttonStackView = UIStackView()
+
+  // MARK: - Init
+
+  public init(
+    title: String,
+    description: String? = nil,
+    customContent: UIView? = nil,
+    type: BezierConfirmModalType = .default,
+    buttonLayout: BezierConfirmModalButtonLayout = .horizontal,
+    confirmAction: BezierConfirmModalAction,
+    cancelAction: BezierConfirmModalAction?
+  ) {
+    self.title = title
+    self.descriptionText = description
+    self.confirmButton = BezierButton(
+      size: BezierConfirmModalSpec.buttonSize,
+      variant: BezierConfirmModalSpec.buttonVariant,
+      semantic: type.confirmButtonSemantic
+    )
+    self.cancelButton = cancelAction.map { _ in
+      BezierButton(
+        size: BezierConfirmModalSpec.buttonSize,
+        variant: BezierConfirmModalSpec.buttonVariant,
+        semantic: BezierConfirmModalSpec.cancelSemantic
+      )
+    }
+
+    var altAction: BezierConfirmModalAction?
+    if case .vertical(let action) = buttonLayout {
+      altAction = action
+    }
+    // 취소 없는 1버튼(acknowledge) 케이스는 altAction 조합이 무효 (Figma showCancel 유효 조합 규칙)
+    if cancelAction == nil, altAction != nil {
+      assertionFailure("cancelAction 없이 altAction을 사용할 수 없습니다")
+      altAction = nil
+    }
+    self.altButton = altAction.map { _ in
+      BezierButton(
+        size: BezierConfirmModalSpec.buttonSize,
+        variant: BezierConfirmModalSpec.buttonVariant,
+        semantic: BezierConfirmModalSpec.cancelSemantic
+      )
+    }
+
+    super.init(frame: .zero)
+    self.setUp(
+      customContent: customContent,
+      buttonLayout: buttonLayout,
+      confirmAction: confirmAction,
+      altAction: altAction,
+      cancelAction: cancelAction
+    )
+  }
+
+  public required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: - Setup
+
+  private func setUp(
+    customContent: UIView?,
+    buttonLayout: BezierConfirmModalButtonLayout,
+    confirmAction: BezierConfirmModalAction,
+    altAction: BezierConfirmModalAction?,
+    cancelAction: BezierConfirmModalAction?
+  ) {
+    self.translatesAutoresizingMaskIntoConstraints = false
+    self.rootStackView.translatesAutoresizingMaskIntoConstraints = false
+
+    self.rootStackView.axis = .vertical
+    self.rootStackView.alignment = .fill
+    self.rootStackView.spacing = 0
+
+    self.contentStackView.axis = .vertical
+    self.contentStackView.alignment = .fill
+    self.contentStackView.spacing = BezierConfirmModalSpec.contentSpacing
+
+    self.titleLabel.numberOfLines = 0
+    self.descriptionLabel.numberOfLines = 0
+
+    self.contentStackView.addArrangedSubview(self.titleLabel)
+    self.contentStackView.addArrangedSubview(self.descriptionLabel)
+
+    self.setUpButtons(
+      buttonLayout: buttonLayout,
+      confirmAction: confirmAction,
+      altAction: altAction,
+      cancelAction: cancelAction
+    )
+
+    self.rootStackView.addArrangedSubview(self.contentStackView)
+    if let customContent {
+      self.rootStackView.addArrangedSubview(customContent)
+      self.rootStackView.setCustomSpacing(
+        BezierConfirmModalSpec.contentBottomPadding,
+        after: self.contentStackView
+      )
+      self.rootStackView.setCustomSpacing(
+        BezierConfirmModalSpec.buttonsTopPadding,
+        after: customContent
+      )
+    } else {
+      self.rootStackView.setCustomSpacing(
+        BezierConfirmModalSpec.contentBottomPadding + BezierConfirmModalSpec.buttonsTopPadding,
+        after: self.contentStackView
+      )
+    }
+    self.rootStackView.addArrangedSubview(self.buttonStackView)
+
+    self.addSubview(self.modalView)
+    self.modalView.contentView.addSubview(self.rootStackView)
+
+    NSLayoutConstraint.activate([
+      self.modalView.topAnchor.constraint(equalTo: self.topAnchor),
+      self.modalView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+      self.modalView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+      self.modalView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+      self.rootStackView.topAnchor.constraint(equalTo: self.modalView.contentView.topAnchor),
+      self.rootStackView.bottomAnchor.constraint(equalTo: self.modalView.contentView.bottomAnchor),
+      self.rootStackView.leadingAnchor.constraint(equalTo: self.modalView.contentView.leadingAnchor),
+      self.rootStackView.trailingAnchor.constraint(equalTo: self.modalView.contentView.trailingAnchor),
+    ])
+
+    self.refreshAppearance()
+  }
+
+  private func setUpButtons(
+    buttonLayout: BezierConfirmModalButtonLayout,
+    confirmAction: BezierConfirmModalAction,
+    altAction: BezierConfirmModalAction?,
+    cancelAction: BezierConfirmModalAction?
+  ) {
+    switch buttonLayout {
+    case .vertical:
+      self.buttonStackView.axis = .vertical
+      self.buttonStackView.spacing = BezierConfirmModalSpec.verticalButtonSpacing
+      self.buttonStackView.distribution = .fill
+      self.buttonStackView.addArrangedSubview(self.confirmButton)
+      if let altButton = self.altButton {
+        self.buttonStackView.addArrangedSubview(altButton)
+      }
+      if let cancelButton = self.cancelButton {
+        self.buttonStackView.addArrangedSubview(cancelButton)
+      }
+
+    case .horizontal:
+      self.buttonStackView.axis = .horizontal
+      self.buttonStackView.spacing = BezierConfirmModalSpec.horizontalButtonSpacing
+      self.buttonStackView.distribution = .fillEqually
+      if let cancelButton = self.cancelButton {
+        self.buttonStackView.addArrangedSubview(cancelButton)
+      }
+      self.buttonStackView.addArrangedSubview(self.confirmButton)
+    }
+
+    self.confirmButton.title = confirmAction.title
+    self.confirmButton.addAction(UIAction { _ in confirmAction.handler() }, for: .touchUpInside)
+
+    if let cancelAction {
+      self.cancelButton?.title = cancelAction.title
+      self.cancelButton?.addAction(UIAction { _ in cancelAction.handler() }, for: .touchUpInside)
+    }
+
+    if let altAction {
+      self.altButton?.title = altAction.title
+      self.altButton?.addAction(UIAction { _ in altAction.handler() }, for: .touchUpInside)
+    }
+  }
+
+  // MARK: - Layout Update
+
+  public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    self.refreshAppearance()
+  }
+
+  // MARK: - Refresh
+
+  private func refreshAppearance() {
+    self.titleLabel.attributedText = BezierConfirmModalSpec.titleTypography.attributedString(
+      self,
+      text: self.title,
+      semanticColorToken: BezierConfirmModalSpec.textColorToken,
+      alignment: .center
+    )
+
+    if let descriptionText = self.descriptionText {
+      self.descriptionLabel.isHidden = false
+      self.descriptionLabel.attributedText = BezierConfirmModalSpec.descriptionTypography.attributedString(
+        self,
+        text: descriptionText,
+        semanticColorToken: BezierConfirmModalSpec.textColorToken,
+        alignment: .center
+      )
+    } else {
+      self.descriptionLabel.isHidden = true
+      self.descriptionLabel.attributedText = nil
+    }
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierConfirmModal/BezierConfirmModalSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierConfirmModal/BezierConfirmModalSpec.swift
@@ -1,0 +1,48 @@
+//
+//  BezierConfirmModalSpec.swift
+//  BezierSwift
+//
+
+import UIKit
+
+public struct BezierConfirmModalAction {
+  public let title: String
+  public let handler: () -> Void
+
+  public init(title: String, handler: @escaping () -> Void = {}) {
+    self.title = title
+    self.handler = handler
+  }
+}
+
+public enum BezierConfirmModalType {
+  case `default`
+  case destructive
+
+  public var confirmButtonSemantic: BezierButtonSemantic {
+    switch self {
+    case .default: return .primary
+    case .destructive: return .destructive
+    }
+  }
+}
+
+// horizontal + altAction 조합은 SPEC 금지 규칙이라 타입 구조로 배제한다
+public enum BezierConfirmModalButtonLayout {
+  case vertical(altAction: BezierConfirmModalAction?)
+  case horizontal
+}
+
+public enum BezierConfirmModalSpec {
+  public static let contentSpacing: CGFloat = 10
+  public static let contentBottomPadding: CGFloat = 8
+  public static let buttonsTopPadding: CGFloat = 12
+  public static let horizontalButtonSpacing: CGFloat = 8
+  public static let verticalButtonSpacing: CGFloat = 10
+  public static let buttonSize: BezierButtonSize = .large
+  public static let buttonVariant: BezierButtonVariant = .filled
+  public static let cancelSemantic: BezierButtonSemantic = .secondary
+  public static let titleTypography: BTSemanticToken = .headingXSmall
+  public static let descriptionTypography: BTSemanticToken = .textLarge(weight: .regular)
+  public static let textColorToken: BCSemanticToken = .textNeutral
+}

--- a/Sources/BezierSwift/MasterComponent/BezierConfirmModal/SPEC.md
+++ b/Sources/BezierSwift/MasterComponent/BezierConfirmModal/SPEC.md
@@ -164,9 +164,9 @@ ConfirmModal 자체는 state property가 없다. 버튼의 pressed/disabled/load
 
 | 정의 | 파일 / 심볼 |
 |---|---|
-| UIKit 구현 | `BezierConfirmModal.swift` *(신설 예정 — V3 컨벤션)* |
-| SwiftUI 구현 | `SUBezierConfirmModal.swift` *(신설 예정 — V3 컨벤션)* |
-| Layout 상수 정의 | `BezierConfirmModalSpec.swift` *(신설 예정 — V3 컨벤션)* |
+| UIKit 구현 | `BezierConfirmModal.swift` |
+| SwiftUI 구현 | `SUBezierConfirmModal.swift` |
+| Layout 상수 정의 | `BezierConfirmModalSpec.swift` |
 | 컨테이너 재사용 | `BezierModal` / `SUBezierModal` (`Sources/BezierSwift/MasterComponent/BezierModal/`) — 협의 사항: ConfirmModal이 Modal 컨테이너를 재사용 (BezierModal SPEC §8) |
 | 버튼 재사용 | `BezierButton` / `SUBezierButton` — `BezierButtonSize.large`, `BezierButtonVariant.filled`, `BezierButtonSemantic.primary` / `.secondary` / `.destructive` (`BezierButtonSpec.swift`, 버튼 spec: `Sources/BezierSwift/MasterComponent/BezierButton/SPEC.md`) |
 | Typography 토큰 | `BTSemanticToken.headingXSmall`, `BTSemanticToken.textLarge(weight: .regular)` (`Sources/BezierSwift/Foundation/Typography/V3/BTSemanticToken.swift`) |

--- a/Sources/BezierSwift/MasterComponent/BezierConfirmModal/SPEC.md
+++ b/Sources/BezierSwift/MasterComponent/BezierConfirmModal/SPEC.md
@@ -1,0 +1,188 @@
+# ConfirmModal Spec
+
+> Figma: [🚧 Mobile Components — ConfirmModal](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=2420-477&m=dev)
+> Design spec doc: [ConfirmModal-spec.md](https://github.com/channel-io/design-team/blob/main/specs/components/ConfirmModal-spec.md)
+> Linear: [MOB-6343](https://linear.app/channel/issue/MOB-6343/bezierswift-v3-modal-confirmmodal-컴포넌트-구현)
+
+모바일 다이얼로그. 확인·경고·파괴 액션에 사용한다 (Figma component description 1행).
+
+- **모양**: 라운드 사각형 (radius/32 = 32pt), 하방 drop shadow (§3 Effect 참조)
+- **구조**: 루트 프레임이 컨테이너 스타일(배경 / radius / shadow / padding)을 직접 보유하고, 내부에 title / description / customContent 슬롯 / 버튼 영역을 세로로 쌓은 구성
+- **너비 정책** (Figma description): 너비 = min(화면너비 − 80pt, 480pt). 양쪽 마진 40pt · 상한 480pt. Figma 기준 폭 320pt = 약 400pt 화면 기준 프리뷰
+
+---
+
+## 1. Component Properties
+
+Figma 컴포넌트가 정의하는 property와 옵션은 다음이 전부다.
+
+### Variant 축
+
+| Property | 값 | 비고 |
+|---|---|---|
+| **destructive** | `false` / `true` | 기본 `false`. 강조 버튼의 semantic (false → primary / true → destructive) |
+| **buttonLayout** | `vertical` / `horizontal` | 버튼 배치 방향. 기본 `horizontal` (2026-07-21 협의 확정 — description의 "vertical(기본)" 표기는 수정 예정) |
+
+### Boolean / Text / Slot property
+
+| Property | 타입 | 기본값 | 비고 |
+|---|---|---|---|
+| **title** | text | `"Dialog Title"` (placeholder) | 제목 |
+| **hasDescription** | boolean | `true` | description 표시 여부 |
+| **description** | text | `"Description text goes here."` (placeholder) | 본문 |
+| **hasCustomContent** | boolean | `false` | customContent 슬롯 표시 여부 |
+| **customContent** | slot (children) | — | title/description 아래·버튼 위에 임의 콘텐츠 삽입 (node 4750:3951) |
+| **hasAltAction** | boolean | `false` | vertical 전용 — 강조 버튼과 취소 버튼 사이 보조 액션 버튼 표시 |
+
+- State 축 없음 (ConfirmModal 자체는 default/pressed/disabled/loading 분기가 없다. 버튼 인터랙션은 내장 Button 인스턴스 소관)
+- ⚠️ `horizontal` + `hasAltAction=true` 조합 금지 — 3버튼은 항상 vertical (Figma description)
+
+총 instance: `destructive 2 × buttonLayout 2 = 4개`
+
+> **2026-07-21 디자이너 협의 확정 (Figma 반영 예정)** — ConfirmModal-spec.md(team-design)와 Figma 실물 대조에서 발견된 불일치를 디자이너와 협의해 확정한 사항:
+> - variant 축 `destructive`는 `type = default | destructive` enum 축으로 전환
+> - `showCancel` BOOLEAN(기본 `true`) 추가 — `false`는 취소 없는 1버튼(acknowledge) 케이스, `hasAltAction=false` 조합만 유효
+> - `hasCustomContent` / `customContent`는 현행 유지
+> - `buttonLayout` 기본값은 `horizontal`
+>
+> 코드는 이 결정을 선반영한다 (`BezierConfirmModalType`, `cancelAction` optional, 기본 `.horizontal`). Figma 반영 후 §1/§9를 실물 기준으로 재검증한다.
+
+---
+
+## 2. Layout Spec
+
+### 컨테이너 (ConfirmModal 루트 노드에 직접 존재)
+
+| 항목 | 값 |
+|---|---|
+| Width | 320pt |
+| Max Width | 480pt |
+| Padding Top | 20pt |
+| Padding Bottom | 16pt |
+| Padding Horizontal | 16pt |
+| Corner Radius | `radius/32` = 32pt |
+| Overflow | clip |
+| 정렬 | 세로 스택, 가로 center |
+
+### 내부 블록
+
+| 블록 | 값 |
+|---|---|
+| content (title+description) | 세로 스택, gap 10pt, padding-bottom 8pt, 폭 full, 텍스트 center 정렬, word-break |
+| customContent 슬롯 | 폭 full. Figma 마스터에서는 높이 16pt placeholder frame (node 4750:3951) |
+| buttons 영역 | padding-top 12pt, 폭 full |
+| buttons — `horizontal` | 가로 스택, gap 8pt, 각 버튼 균등 분할 (flex 1) |
+| buttons — `vertical` | 세로 스택, gap 10pt, 각 버튼 폭 full |
+| 버튼 | Button 컴포넌트 `Size=large` 인스턴스 — 높이 44pt, min-width 44pt |
+
+### 전체 높이 (Figma master, hasDescription=true · customContent/altAction 없음 기준)
+
+| buttonLayout | 높이 |
+|---|---|
+| `horizontal` | 154pt |
+| `vertical` | 208pt |
+
+---
+
+## 3. 컬러 토큰
+
+### 컨테이너
+
+| 대상 | Figma Variable | Raw |
+|---|---|---|
+| 배경 | `color/surface/higher` | `#FFFFFF` |
+
+### Shadow (Effect)
+
+| 대상 | Figma Style | 구성 |
+|---|---|---|
+| 컨테이너 그림자 | `Elevation/Mobile/3` | DROP_SHADOW, color `color/elevation/large` (`#00000038`), offset (0, `elevation/4` = 4), blur `elevation/20` = 20, spread 0 |
+
+### 텍스트
+
+| 대상 | Figma Variable | Raw |
+|---|---|---|
+| title / description | `color/text/neutral` | `#000000D9` |
+
+### 버튼 (내장 Button `Size=large, variant=filled` 인스턴스)
+
+| 역할 | Button semantic | Background | Raw | Foreground | Raw |
+|---|---|---|---|---|---|
+| 강조 (destructive=false) | `primary` | `color/fill/neutral/heaviest` | `#000000D9` | `color/text/inverse` | `#FFFFFF` |
+| 강조 (destructive=true) | `destructive` | `color/fill/accent/red/heavier` | `#E1535D` | `color/text/inverse` | `#FFFFFF` |
+| 취소 / Alt Action | `secondary` | `color/fill/neutral` | `#00000014` | `color/text/neutral` | `#000000D9` |
+
+Border 없음.
+
+---
+
+## 4. Typography
+
+### Case A — Typography Token 사용
+
+| 위치 | Token | Figma Style 이름 | 구성 |
+|---|---|---|---|
+| title | `headingXSmall` | `Typography/heading/xsmall` | Inter SemiBold, size 16, weight 700, line-height 24, letter-spacing -0.1 |
+| description | `textLarge` | `Typography/text/large` | Inter Regular, size 15, weight 400, line-height 20, letter-spacing -0.1 |
+
+### Case B — Custom Typography
+
+없음.
+
+> 버튼 라벨 typography는 내장 Button 인스턴스 내부 텍스트로, Button 컴포넌트 spec이 관할한다.
+
+---
+
+## 5. State 별 시각 동작
+
+ConfirmModal 자체는 state property가 없다. 버튼의 pressed/disabled/loading 시각은 내장 Button 인스턴스가 담당한다.
+
+### 버튼 배치 규칙 (Figma description)
+
+| buttonLayout | 배치 |
+|---|---|
+| `vertical` | 강조 위 · (Alt Action 중간) · 취소 아래 |
+| `horizontal` (기본 — 2026-07-21 협의) | 취소 좌 · 강조 우 (2버튼 전용) |
+
+- 버튼 방향은 라벨 길이 기준 디자이너 수동 선택 (플랫폼 자동 전환 없음)
+
+---
+
+## 6. Loading Indicator
+
+해당 없음 (ConfirmModal 레벨). 버튼 loading은 Button 컴포넌트 소관.
+
+---
+
+## 7. 디자이너 가이드라인 (Figma 컴포넌트 description 인용)
+
+> 모바일 다이얼로그 (BezierDialog). 확인·경고·파괴 액션에 사용한다. \[너비 정책\] 너비 = min(화면너비 − 80px, 480px). 양쪽 마진 40px · 상한 480px. 예) 360px 폰 → 280px / 390px iPhone → 310px / 480px+ → 480px. Figma 기준 폭 320px = 약 400px 화면 기준 프리뷰. \[buttonLayout\] vertical(기본): 강조 위·취소 아래. horizontal: 취소 좌·강조 우 (2버튼 전용). ⚠️ horizontal + hasAltAction=true 조합 금지 — 3버튼은 항상 vertical. 버튼 방향은 라벨 길이 기준 디자이너 수동 선택 (플랫폼 자동 전환 없음). 스펙: Modal-spec.md §11 \[Mobile\]
+
+---
+
+## 8. 매핑되는 코드 심볼
+
+| 정의 | 파일 / 심볼 |
+|---|---|
+| UIKit 구현 | `BezierConfirmModal.swift` *(신설 예정 — V3 컨벤션)* |
+| SwiftUI 구현 | `SUBezierConfirmModal.swift` *(신설 예정 — V3 컨벤션)* |
+| Layout 상수 정의 | `BezierConfirmModalSpec.swift` *(신설 예정 — V3 컨벤션)* |
+| 컨테이너 재사용 | `BezierModal` / `SUBezierModal` (`Sources/BezierSwift/MasterComponent/BezierModal/`) — 협의 사항: ConfirmModal이 Modal 컨테이너를 재사용 (BezierModal SPEC §8) |
+| 버튼 재사용 | `BezierButton` / `SUBezierButton` — `BezierButtonSize.large`, `BezierButtonVariant.filled`, `BezierButtonSemantic.primary` / `.secondary` / `.destructive` (`BezierButtonSpec.swift`, 버튼 spec: `Sources/BezierSwift/MasterComponent/BezierButton/SPEC.md`) |
+| Typography 토큰 | `BTSemanticToken.headingXSmall`, `BTSemanticToken.textLarge(weight: .regular)` (`Sources/BezierSwift/Foundation/Typography/V3/BTSemanticToken.swift`) |
+| 텍스트 컬러 토큰 | `BCSemanticToken.textNeutral` (`Sources/BezierSwift/Foundation/Color/V3/BCSemanticToken.swift`) |
+
+> 코드 측에 본 spec의 SSOT(Figma)와 어긋나는 정의가 존재한다면, 그것은 코드 측의 정리 대상이며 spec에 반영하지 않는다.
+
+---
+
+## 9. Variant 매트릭스
+
+총 instance: destructive 2 × buttonLayout 2 = **4개**
+
+```text
+destructive=false, buttonLayout=horizontal = 4858:114
+destructive=true,  buttonLayout=horizontal = 4858:123
+destructive=false, buttonLayout=vertical   = 4750:3947
+destructive=true,  buttonLayout=vertical   = 4750:3956
+```

--- a/Sources/BezierSwift/MasterComponent/BezierConfirmModal/SUBezierConfirmModal+Presentation.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierConfirmModal/SUBezierConfirmModal+Presentation.swift
@@ -1,0 +1,166 @@
+//
+//  SUBezierConfirmModal+Presentation.swift
+//  BezierSwift
+//
+
+import SwiftUI
+import UIKit
+
+extension View {
+  public func bezierConfirmModal(
+    isPresented: Binding<Bool>,
+    title: String,
+    description: String? = nil,
+    type: BezierConfirmModalType = .default,
+    buttonLayout: BezierConfirmModalButtonLayout = .horizontal,
+    confirmAction: BezierConfirmModalAction,
+    cancelAction: BezierConfirmModalAction?
+  ) -> some View {
+    self.background(
+      SUBezierConfirmModalPresenter<EmptyView>(
+        isPresented: isPresented,
+        title: title,
+        description: description,
+        type: type,
+        buttonLayout: buttonLayout,
+        confirmAction: confirmAction,
+        cancelAction: cancelAction,
+        customContent: nil
+      )
+    )
+  }
+
+  public func bezierConfirmModal<CustomContent: View>(
+    isPresented: Binding<Bool>,
+    title: String,
+    description: String? = nil,
+    type: BezierConfirmModalType = .default,
+    buttonLayout: BezierConfirmModalButtonLayout = .horizontal,
+    confirmAction: BezierConfirmModalAction,
+    cancelAction: BezierConfirmModalAction?,
+    @ViewBuilder customContent: @escaping () -> CustomContent
+  ) -> some View {
+    self.background(
+      SUBezierConfirmModalPresenter(
+        isPresented: isPresented,
+        title: title,
+        description: description,
+        type: type,
+        buttonLayout: buttonLayout,
+        confirmAction: confirmAction,
+        cancelAction: cancelAction,
+        customContent: customContent
+      )
+    )
+  }
+}
+
+// 프레젠테이션 시각 결과(dim/너비 정책/전환)를 UIKit 경로 하나로 수렴시키기 위해
+// SwiftUI에서도 UIKit BezierConfirmModal을 카드로 present한다
+private struct SUBezierConfirmModalPresenter<CustomContent: View>: UIViewControllerRepresentable {
+  @Binding var isPresented: Bool
+  let title: String
+  let description: String?
+  let type: BezierConfirmModalType
+  let buttonLayout: BezierConfirmModalButtonLayout
+  let confirmAction: BezierConfirmModalAction
+  let cancelAction: BezierConfirmModalAction?
+  let customContent: (() -> CustomContent)?
+
+  final class Coordinator {
+    var modalController: BezierModalViewController?
+    var hostingController: UIHostingController<CustomContent>?
+    var pendingHandler: (() -> Void)?
+  }
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator()
+  }
+
+  func makeUIViewController(context: Context) -> UIViewController {
+    UIViewController()
+  }
+
+  func updateUIViewController(_ anchor: UIViewController, context: Context) {
+    let coordinator = context.coordinator
+
+    if self.isPresented {
+      if let hostingController = coordinator.hostingController, let customContent = self.customContent {
+        hostingController.rootView = customContent()
+      } else if coordinator.modalController == nil {
+        self.present(from: anchor, coordinator: coordinator)
+      }
+    } else if let modalController = coordinator.modalController {
+      let pendingHandler = coordinator.pendingHandler
+      coordinator.modalController = nil
+      coordinator.hostingController = nil
+      coordinator.pendingHandler = nil
+      modalController.dismiss(animated: true) {
+        pendingHandler?()
+      }
+    }
+  }
+
+  static func dismantleUIViewController(_ uiViewController: UIViewController, coordinator: Coordinator) {
+    coordinator.modalController?.dismiss(animated: false)
+    coordinator.modalController = nil
+    coordinator.hostingController = nil
+    coordinator.pendingHandler = nil
+  }
+
+  private func present(from anchor: UIViewController, coordinator: Coordinator) {
+    // 최초 렌더 직후에는 anchor가 아직 window에 붙지 않았을 수 있어 다음 runloop에 재시도
+    guard anchor.view.window != nil else {
+      DispatchQueue.main.async {
+        guard self.isPresented, coordinator.modalController == nil else { return }
+        self.present(from: anchor, coordinator: coordinator)
+      }
+      return
+    }
+
+    // 버튼 액션은 binding을 단일 dismiss 경로로 사용하고,
+    // handler는 dismiss 완료 후 실행되도록 coordinator에 보관한다
+    func bindingAction(_ action: BezierConfirmModalAction) -> BezierConfirmModalAction {
+      BezierConfirmModalAction(title: action.title) {
+        coordinator.pendingHandler = action.handler
+        self.isPresented = false
+      }
+    }
+
+    let wrappedLayout: BezierConfirmModalButtonLayout
+    switch self.buttonLayout {
+    case .vertical(let altAction):
+      wrappedLayout = .vertical(altAction: altAction.map(bindingAction))
+    case .horizontal:
+      wrappedLayout = .horizontal
+    }
+
+    var customContentView: UIView?
+    if let customContent = self.customContent {
+      let hostingController = UIHostingController(rootView: customContent())
+      hostingController.view.backgroundColor = .clear
+      hostingController.sizingOptions = .intrinsicContentSize
+      coordinator.hostingController = hostingController
+      customContentView = hostingController.view
+    }
+
+    let modalView = BezierConfirmModal(
+      title: self.title,
+      description: self.description,
+      customContent: customContentView,
+      type: self.type,
+      buttonLayout: wrappedLayout,
+      confirmAction: bindingAction(self.confirmAction),
+      cancelAction: self.cancelAction.map(bindingAction)
+    )
+
+    let modalController = BezierModalViewController(modalView: modalView)
+    if let hostingController = coordinator.hostingController {
+      modalController.addChild(hostingController)
+      hostingController.didMove(toParent: modalController)
+    }
+
+    coordinator.modalController = modalController
+    anchor.present(modalController, animated: true)
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierConfirmModal/SUBezierConfirmModal+Presentation.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierConfirmModal/SUBezierConfirmModal+Presentation.swift
@@ -71,6 +71,7 @@ private struct SUBezierConfirmModalPresenter<CustomContent: View>: UIViewControl
     var modalController: BezierModalViewController?
     var hostingController: UIHostingController<CustomContent>?
     var pendingHandler: (() -> Void)?
+    var isDismissing = false
   }
 
   func makeCoordinator() -> Coordinator {
@@ -87,16 +88,22 @@ private struct SUBezierConfirmModalPresenter<CustomContent: View>: UIViewControl
     if self.isPresented {
       if let hostingController = coordinator.hostingController, let customContent = self.customContent {
         hostingController.rootView = customContent()
-      } else if coordinator.modalController == nil {
+      } else if coordinator.modalController == nil, !coordinator.isDismissing {
         self.present(from: anchor, coordinator: coordinator)
       }
-    } else if let modalController = coordinator.modalController {
+    } else if let modalController = coordinator.modalController, !coordinator.isDismissing {
+      coordinator.isDismissing = true
       let pendingHandler = coordinator.pendingHandler
-      coordinator.modalController = nil
-      coordinator.hostingController = nil
       coordinator.pendingHandler = nil
       modalController.dismiss(animated: true) {
+        coordinator.modalController = nil
+        coordinator.hostingController = nil
+        coordinator.isDismissing = false
         pendingHandler?()
+        // dismiss 진행 중 binding이 다시 true가 된 경우 여기서 재-present (update가 다시 불리지 않음)
+        if self.isPresented {
+          self.present(from: anchor, coordinator: coordinator)
+        }
       }
     }
   }
@@ -106,13 +113,14 @@ private struct SUBezierConfirmModalPresenter<CustomContent: View>: UIViewControl
     coordinator.modalController = nil
     coordinator.hostingController = nil
     coordinator.pendingHandler = nil
+    coordinator.isDismissing = false
   }
 
   private func present(from anchor: UIViewController, coordinator: Coordinator) {
     // 최초 렌더 직후에는 anchor가 아직 window에 붙지 않았을 수 있어 다음 runloop에 재시도
     guard anchor.view.window != nil else {
       DispatchQueue.main.async {
-        guard self.isPresented, coordinator.modalController == nil else { return }
+        guard self.isPresented, coordinator.modalController == nil, !coordinator.isDismissing else { return }
         self.present(from: anchor, coordinator: coordinator)
       }
       return

--- a/Sources/BezierSwift/MasterComponent/BezierConfirmModal/SUBezierConfirmModal.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierConfirmModal/SUBezierConfirmModal.swift
@@ -1,0 +1,196 @@
+//
+//  SUBezierConfirmModal.swift
+//  BezierSwift
+//
+
+import SwiftUI
+
+public struct SUBezierConfirmModal<CustomContent: View>: View {
+  private let title: String
+  private let description: String?
+  private let type: BezierConfirmModalType
+  private let buttonLayout: BezierConfirmModalButtonLayout
+  private let confirmAction: BezierConfirmModalAction
+  private let cancelAction: BezierConfirmModalAction?
+  private let customContent: CustomContent?
+
+  public init(
+    title: String,
+    description: String? = nil,
+    type: BezierConfirmModalType = .default,
+    buttonLayout: BezierConfirmModalButtonLayout = .horizontal,
+    confirmAction: BezierConfirmModalAction,
+    cancelAction: BezierConfirmModalAction?,
+    @ViewBuilder customContent: () -> CustomContent
+  ) {
+    self.init(
+      title: title,
+      description: description,
+      type: type,
+      buttonLayout: buttonLayout,
+      confirmAction: confirmAction,
+      cancelAction: cancelAction,
+      customContent: customContent()
+    )
+  }
+
+  private init(
+    title: String,
+    description: String?,
+    type: BezierConfirmModalType,
+    buttonLayout: BezierConfirmModalButtonLayout,
+    confirmAction: BezierConfirmModalAction,
+    cancelAction: BezierConfirmModalAction?,
+    customContent: CustomContent?
+  ) {
+    self.title = title
+    self.description = description
+    self.type = type
+
+    var sanitizedLayout = buttonLayout
+    // 취소 없는 1버튼(acknowledge) 케이스는 altAction 조합이 무효 (Figma showCancel 유효 조합 규칙)
+    if cancelAction == nil, case .vertical(let altAction) = buttonLayout, altAction != nil {
+      assertionFailure("cancelAction 없이 altAction을 사용할 수 없습니다")
+      sanitizedLayout = .vertical(altAction: nil)
+    }
+    self.buttonLayout = sanitizedLayout
+
+    self.confirmAction = confirmAction
+    self.cancelAction = cancelAction
+    self.customContent = customContent
+  }
+
+  public var body: some View {
+    SUBezierModal {
+      VStack(spacing: 0) {
+        VStack(spacing: BezierConfirmModalSpec.contentSpacing) {
+          Text(self.title)
+            .applyBezierFontStyle(
+              BezierConfirmModalSpec.titleTypography,
+              semanticColorToken: BezierConfirmModalSpec.textColorToken
+            )
+            .multilineTextAlignment(.center)
+            .frame(maxWidth: .infinity)
+
+          if let description = self.description {
+            Text(description)
+              .applyBezierFontStyle(
+                BezierConfirmModalSpec.descriptionTypography,
+                semanticColorToken: BezierConfirmModalSpec.textColorToken
+              )
+              .multilineTextAlignment(.center)
+              .frame(maxWidth: .infinity)
+          }
+        }
+        .padding(.bottom, BezierConfirmModalSpec.contentBottomPadding)
+
+        if let customContent = self.customContent {
+          customContent
+            .frame(maxWidth: .infinity)
+        }
+
+        self.buttons
+          .padding(.top, BezierConfirmModalSpec.buttonsTopPadding)
+      }
+    }
+  }
+
+  @ViewBuilder
+  private var buttons: some View {
+    switch self.buttonLayout {
+    case .vertical(let altAction):
+      VStack(spacing: BezierConfirmModalSpec.verticalButtonSpacing) {
+        self.button(for: self.confirmAction, semantic: self.type.confirmButtonSemantic)
+        if let altAction {
+          self.button(for: altAction, semantic: BezierConfirmModalSpec.cancelSemantic)
+        }
+        if let cancelAction = self.cancelAction {
+          self.button(for: cancelAction, semantic: BezierConfirmModalSpec.cancelSemantic)
+        }
+      }
+
+    case .horizontal:
+      HStack(spacing: BezierConfirmModalSpec.horizontalButtonSpacing) {
+        if let cancelAction = self.cancelAction {
+          self.button(for: cancelAction, semantic: BezierConfirmModalSpec.cancelSemantic)
+        }
+        self.button(for: self.confirmAction, semantic: self.type.confirmButtonSemantic)
+      }
+    }
+  }
+
+  private func button(
+    for action: BezierConfirmModalAction,
+    semantic: BezierButtonSemantic
+  ) -> some View {
+    SUBezierButton(
+      size: BezierConfirmModalSpec.buttonSize,
+      variant: BezierConfirmModalSpec.buttonVariant,
+      semantic: semantic,
+      title: action.title,
+      isFillWidth: true,
+      action: action.handler
+    )
+  }
+}
+
+extension SUBezierConfirmModal where CustomContent == EmptyView {
+  public init(
+    title: String,
+    description: String? = nil,
+    type: BezierConfirmModalType = .default,
+    buttonLayout: BezierConfirmModalButtonLayout = .horizontal,
+    confirmAction: BezierConfirmModalAction,
+    cancelAction: BezierConfirmModalAction?
+  ) {
+    self.init(
+      title: title,
+      description: description,
+      type: type,
+      buttonLayout: buttonLayout,
+      confirmAction: confirmAction,
+      cancelAction: cancelAction,
+      customContent: nil
+    )
+  }
+}
+
+struct SUBezierConfirmModal_Previews: PreviewProvider {
+  static var previews: some View {
+    ZStack {
+      Color(uiColor: .systemGroupedBackground).ignoresSafeArea()
+      ScrollView {
+        VStack(spacing: 24) {
+          SUBezierConfirmModal(
+            title: "Dialog Title",
+            description: "Description text goes here.",
+            confirmAction: BezierConfirmModalAction(title: "Confirm"),
+            cancelAction: BezierConfirmModalAction(title: "Cancel")
+          )
+          SUBezierConfirmModal(
+            title: "Dialog Title",
+            description: "Description text goes here.",
+            type: .destructive,
+            buttonLayout: .vertical(altAction: nil),
+            confirmAction: BezierConfirmModalAction(title: "Delete"),
+            cancelAction: BezierConfirmModalAction(title: "Cancel")
+          )
+          SUBezierConfirmModal(
+            title: "Dialog Title",
+            description: "Description text goes here.",
+            buttonLayout: .vertical(altAction: BezierConfirmModalAction(title: "Alt Action")),
+            confirmAction: BezierConfirmModalAction(title: "Confirm"),
+            cancelAction: BezierConfirmModalAction(title: "Cancel")
+          )
+          SUBezierConfirmModal(
+            title: "Dialog Title",
+            description: "Description text goes here.",
+            confirmAction: BezierConfirmModalAction(title: "OK"),
+            cancelAction: nil
+          )
+        }
+        .padding(.vertical, 24)
+      }
+    }
+  }
+}


### PR DESCRIPTION
> ✅ #145는 develop에 squash merge 완료 (a65e66b) — 이 브랜치는 develop 기반으로 재구성되어 ConfirmModal 변경분만 포함한다.

## 배경

[MOB-6343](https://linear.app/channel/issue/MOB-6343) — V3 ConfirmModal(모바일 다이얼로그) 구현. Figma ConfirmModal CS(`2420:477`)를 SSOT로 `SPEC.md`를 작성·검증(7-validator)한 뒤, UIKit/SwiftUI 컴포넌트와 프레젠테이션 결합을 구현했다. 구현 후 Figma↔SPEC↔구현 3자 전수 재검증(resolved 토큰 값 수준)까지 통과.

**2026-07-21 디자이너 협의 확정 사항을 선반영**했다 (team-design 문서 PR: channel-io/team-design#249):

- variant 축은 `type = default | destructive` enum (`BezierConfirmModalType`) — Figma의 `destructive` BOOLEAN은 enum 축으로 전환 예정
- `showCancel` 대응 — `cancelAction`이 optional, `nil`이면 취소 없는 1버튼(acknowledge). 취소 없이 `altAction` 조합은 무효(debug assert)
- `buttonLayout` 기본값 `horizontal` (Figma description "vertical(기본)" 표기는 수정 예정)

## 변경 내용

### 1. BezierConfirmModal (UIKit) / SUBezierConfirmModal (SwiftUI)

- **BezierModal 컨테이너 조합(wrapper)** — 컨테이너 수치·제약(320@750/≤480, radius32, mEv3, surfaceHigher)을 그대로 상속, 프레젠테이션 751 확장 제약도 edge-pin으로 관통
- 구조: content(title `headingXSmall` / description `textLarge(regular)`, `textNeutral`, gap 10·pb 8) → `customContent` 슬롯 → 버튼 영역(pt 12)
- 버튼: `BezierButton(large, filled)` 재사용 — 강조 = `type.confirmButtonSemantic`(primary/destructive), 취소·alt = secondary. vertical [강조→alt?→취소] gap 10 full-width / horizontal [취소 좌·강조 우] gap 8 균등분할
- `horizontal + altAction` 조합은 enum 구조로 컴파일 타임 배제 (SPEC 금지 규칙)
- `confirmButton`/`cancelButton`/`altButton` 노출 — `isLoading`/`isEnabled` 외부 제어
- UIKit 간격: `setCustomSpacing` — customContent 있으면 8/12 분리, 없으면 20 (hidden 뷰 뒤 custom spacing 무시 이슈 회피)
- 다크모드: attributed string 재생성 (`traitCollectionDidChange`)

### 2. 프레젠테이션 결합

- **UIKit**: `BezierModalViewController.confirm(...)` 팩토리 — 버튼 액션을 `weakController?.dismiss { handler() }`로 래핑 (자동 dismiss)
- **SwiftUI**: `.bezierConfirmModal(isPresented:...)` modifier — 내부에서 UIKit `BezierConfirmModal`을 present (플랫폼 간 시각 결과 통일). 액션은 binding 단일 경로 dismiss + handler는 dismiss 완료 후 실행. `customContent` 오버로드는 슬롯만 `UIHostingController`로 주입

### 3. SPEC.md

- Figma SSOT 문서 (`BezierConfirmModal/SPEC.md`) — Phase 2 7-validator 전수 검증 통과. §1에 2026-07-21 협의 확정 노트(Figma 반영 예정) 기재

### 4. Examples

- `ConfirmModalCatalog`: 4 variant + altAction 3버튼 + acknowledge 1버튼 + customContent 프리뷰, SwiftUI/UIKit present 데모

## 검증

- clean build + Examples 빌드 ✅
- figma-component-spec Phase 3: UIKit/SwiftUI Implementation Validator 전수 ✅ (critical 0)
- Figma↔구현 직접 대조(SPEC 미경유, resolved hex/수치 수준) ✅ — 높이 154/208 합산 재현 포함
- 시뮬레이터: 4 variant 렌더, present/dismiss, dim 탭 무반응, 다크모드 재적응, altAction/customContent ✅

## 범위 밖 (후속)

- Figma 측: `type` enum 축 전환·`showCancel` BOOLEAN 추가·description 기본값 표기 수정 (디자이너, team-design#249 참조) — 반영 후 SPEC §1/§9 재검증
- Button 라벨 weight 3자 불일치(Figma 500 / 코드 700 / 주석 600) 확인: [MOB-6394](https://linear.app/channel/issue/MOB-6394)

## 참고

- 리니어: https://linear.app/channel/issue/MOB-6343
- 문서 PR: https://github.com/channel-io/team-design/pull/249

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 확인 및 취소 액션을 지원하는 Confirm Modal 컴포넌트를 UIKit과 SwiftUI에서 제공합니다.
  * 기본·파괴적 스타일, 가로·세로 버튼 배치, 대체 액션 및 커스텀 콘텐츠를 지원합니다.
  * 모달 표시 후 액션 실행과 자동 닫힘 동작을 제공합니다.
  * SwiftUI에서 간편하게 모달을 표시할 수 있는 프레젠테이션 API를 추가했습니다.

* **문서 및 예제**
  * 컴포넌트 카탈로그에 ConfirmModal 예제를 추가했습니다.
  * 다양한 버튼 구성과 UIKit·SwiftUI 사용 사례를 확인할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
