### PR TITLE
[MOB-6349] BezierBanner + BezierFloatingBanner 컴포넌트 구현 (UIKit + SwiftUI)

### DIFF
--- a/Examples/BezierExamples/BezierExamples/App/CatalogRegistry.swift
+++ b/Examples/BezierExamples/BezierExamples/App/CatalogRegistry.swift
@@ -94,6 +94,18 @@ enum CatalogRegistry {
       section: .v3Components,
       destination: AnyView(ConfirmModalCatalog())
     ),
+    CatalogItem(
+      id: "banner",
+      title: "Banner",
+      section: .v3Components,
+      destination: AnyView(BannerCatalog())
+    ),
+    CatalogItem(
+      id: "floating-banner",
+      title: "FloatingBanner",
+      section: .v3Components,
+      destination: AnyView(FloatingBannerCatalog())
+    ),
     // MARK: - Legacy Components
     CatalogItem(
       id: "legacy-button",

--- a/Examples/BezierExamples/BezierExamples/Components/BannerCatalog.swift
+++ b/Examples/BezierExamples/BezierExamples/Components/BannerCatalog.swift
@@ -90,25 +90,38 @@ private struct BannerUIKitRepresentable: UIViewRepresentable {
   let description: String
   let clickAreaKind: BannerCatalog.ClickAreaKind
 
-  func makeUIView(context: Context) -> BezierBanner {
-    BezierBanner(
+  // BezierBanner는 intrinsic width(content hug)를 노출하므로 Representable에 직접 반환하면
+  // full-width로 늘어나지 않는다. wrapper에 leading/trailing을 pin해 컨테이너 폭을 채운다.
+  func makeUIView(context: Context) -> UIView {
+    let wrapper = UIView()
+    let banner = BezierBanner(
       variant: self.variant,
       leadingIcon: self.leadingIcon,
       title: self.title,
       description: self.description,
       clickArea: self.clickArea
     )
+    banner.translatesAutoresizingMaskIntoConstraints = false
+    wrapper.addSubview(banner)
+    NSLayoutConstraint.activate([
+      banner.leadingAnchor.constraint(equalTo: wrapper.leadingAnchor),
+      banner.trailingAnchor.constraint(equalTo: wrapper.trailingAnchor),
+      banner.topAnchor.constraint(equalTo: wrapper.topAnchor),
+      banner.bottomAnchor.constraint(equalTo: wrapper.bottomAnchor),
+    ])
+    return wrapper
   }
 
-  func updateUIView(_ uiView: BezierBanner, context: Context) {
-    uiView.variant = self.variant
-    uiView.leadingIcon = self.leadingIcon
-    uiView.title = self.title
-    uiView.bannerDescription = self.description
-    uiView.clickArea = self.clickArea
+  func updateUIView(_ wrapper: UIView, context: Context) {
+    guard let banner = wrapper.subviews.compactMap({ $0 as? BezierBanner }).first else { return }
+    banner.variant = self.variant
+    banner.leadingIcon = self.leadingIcon
+    banner.title = self.title
+    banner.bannerDescription = self.description
+    banner.clickArea = self.clickArea
   }
 
-  func sizeThatFits(_ proposal: ProposedViewSize, uiView: BezierBanner, context: Context) -> CGSize? {
+  func sizeThatFits(_ proposal: ProposedViewSize, uiView: UIView, context: Context) -> CGSize? {
     let width = proposal.width ?? 320
     let fitting = uiView.systemLayoutSizeFitting(
       CGSize(width: width, height: UIView.layoutFittingCompressedSize.height),

--- a/Examples/BezierExamples/BezierExamples/Components/BannerCatalog.swift
+++ b/Examples/BezierExamples/BezierExamples/Components/BannerCatalog.swift
@@ -1,0 +1,128 @@
+import SwiftUI
+import UIKit
+import BezierSwift
+
+struct BannerCatalog: View {
+  enum ClickAreaKind: String, CaseIterable, Identifiable {
+    case none, full, actionIcon
+    var id: String { self.rawValue }
+  }
+
+  @State private var variant: BezierBannerVariant = .default
+  @State private var clickAreaKind: ClickAreaKind = .actionIcon
+  @State private var showLeadingIcon = true
+  @State private var showTitle = true
+
+  var body: some View {
+    CatalogScreen(title: "Banner") {
+      self.controls
+      CatalogSection(.swiftUI) { self.swiftUIPreview }
+      CatalogSection(.uiKit) { self.uiKitPreview }
+    }
+  }
+
+  private var controls: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Picker("variant", selection: self.$variant) {
+        ForEach(BezierBannerVariant.allCases, id: \.self) { variant in
+          Text(self.variantLabel(variant)).tag(variant)
+        }
+      }
+      .pickerStyle(.menu)
+
+      Picker("clickArea", selection: self.$clickAreaKind) {
+        ForEach(ClickAreaKind.allCases) { kind in
+          Text(kind.rawValue).tag(kind)
+        }
+      }
+      .pickerStyle(.segmented)
+
+      Toggle("leadingIcon", isOn: self.$showLeadingIcon)
+      Toggle("hasTitle", isOn: self.$showTitle)
+    }
+    .font(.caption)
+  }
+
+  private var swiftUIPreview: some View {
+    SUBezierBanner(
+      variant: self.variant,
+      leadingIcon: self.showLeadingIcon ? .info : nil,
+      title: self.showTitle ? "Banner Title" : nil,
+      description: "Banner description text goes here.",
+      clickArea: self.bannerClickArea
+    )
+  }
+
+  private var uiKitPreview: some View {
+    BannerUIKitRepresentable(
+      variant: self.variant,
+      leadingIcon: self.showLeadingIcon ? .info : nil,
+      title: self.showTitle ? "Banner Title" : nil,
+      description: "Banner description text goes here.",
+      clickAreaKind: self.clickAreaKind
+    )
+  }
+
+  private var bannerClickArea: BezierBannerClickArea {
+    switch self.clickAreaKind {
+    case .none: return .none
+    case .full: return .full(onClick: {})
+    case .actionIcon: return .actionIcon(onClick: {})
+    }
+  }
+
+  private func variantLabel(_ variant: BezierBannerVariant) -> String {
+    switch variant {
+    case .default: return "default"
+    case .blue: return "blue"
+    case .cobalt: return "cobalt"
+    case .green: return "green"
+    case .orange: return "orange"
+    case .red: return "red"
+    }
+  }
+}
+
+private struct BannerUIKitRepresentable: UIViewRepresentable {
+  let variant: BezierBannerVariant
+  let leadingIcon: BezierIcon?
+  let title: String?
+  let description: String
+  let clickAreaKind: BannerCatalog.ClickAreaKind
+
+  func makeUIView(context: Context) -> BezierBanner {
+    BezierBanner(
+      variant: self.variant,
+      leadingIcon: self.leadingIcon,
+      title: self.title,
+      description: self.description,
+      clickArea: self.clickArea
+    )
+  }
+
+  func updateUIView(_ uiView: BezierBanner, context: Context) {
+    uiView.variant = self.variant
+    uiView.leadingIcon = self.leadingIcon
+    uiView.title = self.title
+    uiView.bannerDescription = self.description
+    uiView.clickArea = self.clickArea
+  }
+
+  func sizeThatFits(_ proposal: ProposedViewSize, uiView: BezierBanner, context: Context) -> CGSize? {
+    let width = proposal.width ?? 320
+    let fitting = uiView.systemLayoutSizeFitting(
+      CGSize(width: width, height: UIView.layoutFittingCompressedSize.height),
+      withHorizontalFittingPriority: .required,
+      verticalFittingPriority: .fittingSizeLevel
+    )
+    return CGSize(width: width, height: fitting.height)
+  }
+
+  private var clickArea: BezierBannerClickArea {
+    switch self.clickAreaKind {
+    case .none: return .none
+    case .full: return .full(onClick: {})
+    case .actionIcon: return .actionIcon(onClick: {})
+    }
+  }
+}

--- a/Examples/BezierExamples/BezierExamples/Components/FloatingBannerCatalog.swift
+++ b/Examples/BezierExamples/BezierExamples/Components/FloatingBannerCatalog.swift
@@ -83,25 +83,38 @@ private struct FloatingBannerUIKitRepresentable: UIViewRepresentable {
   let description: String
   let clickAreaKind: FloatingBannerCatalog.ClickAreaKind
 
-  func makeUIView(context: Context) -> BezierFloatingBanner {
-    BezierFloatingBanner(
+  // BezierFloatingBanner는 intrinsic width(content hug)를 노출하므로 Representable에 직접 반환하면
+  // full-width로 늘어나지 않는다. wrapper에 leading/trailing을 pin해 컨테이너 폭을 채운다.
+  func makeUIView(context: Context) -> UIView {
+    let wrapper = UIView()
+    let banner = BezierFloatingBanner(
       leadingIcon: self.leadingIcon,
       leadingIconColor: self.leadingIconColor,
       title: self.title,
       description: self.description,
       clickArea: self.clickArea
     )
+    banner.translatesAutoresizingMaskIntoConstraints = false
+    wrapper.addSubview(banner)
+    NSLayoutConstraint.activate([
+      banner.leadingAnchor.constraint(equalTo: wrapper.leadingAnchor),
+      banner.trailingAnchor.constraint(equalTo: wrapper.trailingAnchor),
+      banner.topAnchor.constraint(equalTo: wrapper.topAnchor),
+      banner.bottomAnchor.constraint(equalTo: wrapper.bottomAnchor),
+    ])
+    return wrapper
   }
 
-  func updateUIView(_ uiView: BezierFloatingBanner, context: Context) {
-    uiView.leadingIcon = self.leadingIcon
-    uiView.leadingIconColor = self.leadingIconColor
-    uiView.title = self.title
-    uiView.bannerDescription = self.description
-    uiView.clickArea = self.clickArea
+  func updateUIView(_ wrapper: UIView, context: Context) {
+    guard let banner = wrapper.subviews.compactMap({ $0 as? BezierFloatingBanner }).first else { return }
+    banner.leadingIcon = self.leadingIcon
+    banner.leadingIconColor = self.leadingIconColor
+    banner.title = self.title
+    banner.bannerDescription = self.description
+    banner.clickArea = self.clickArea
   }
 
-  func sizeThatFits(_ proposal: ProposedViewSize, uiView: BezierFloatingBanner, context: Context) -> CGSize? {
+  func sizeThatFits(_ proposal: ProposedViewSize, uiView: UIView, context: Context) -> CGSize? {
     let width = proposal.width ?? 320
     let fitting = uiView.systemLayoutSizeFitting(
       CGSize(width: width, height: UIView.layoutFittingCompressedSize.height),

--- a/Examples/BezierExamples/BezierExamples/Components/FloatingBannerCatalog.swift
+++ b/Examples/BezierExamples/BezierExamples/Components/FloatingBannerCatalog.swift
@@ -1,0 +1,121 @@
+import SwiftUI
+import UIKit
+import BezierSwift
+
+struct FloatingBannerCatalog: View {
+  enum ClickAreaKind: String, CaseIterable, Identifiable {
+    case none, full, actionIcon
+    var id: String { self.rawValue }
+  }
+
+  @State private var clickAreaKind: ClickAreaKind = .actionIcon
+  @State private var showLeadingIcon = true
+  @State private var tintLeadingIcon = false
+  @State private var showTitle = true
+
+  var body: some View {
+    CatalogScreen(title: "FloatingBanner") {
+      self.controls
+      CatalogSection(.swiftUI) { self.swiftUIPreview }
+      CatalogSection(.uiKit) { self.uiKitPreview }
+    }
+  }
+
+  private var controls: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Picker("clickArea", selection: self.$clickAreaKind) {
+        ForEach(ClickAreaKind.allCases) { kind in
+          Text(kind.rawValue).tag(kind)
+        }
+      }
+      .pickerStyle(.segmented)
+
+      Toggle("leadingIcon", isOn: self.$showLeadingIcon)
+      Toggle("leadingIcon tint (green)", isOn: self.$tintLeadingIcon)
+      Toggle("hasTitle", isOn: self.$showTitle)
+    }
+    .font(.caption)
+  }
+
+  private var swiftUIPreview: some View {
+    SUBezierFloatingBanner(
+      leadingIcon: self.showLeadingIcon ? .plus : nil,
+      leadingIconColor: self.leadingIconColor,
+      title: self.showTitle ? "Banner Title" : nil,
+      description: "Banner description text goes here.",
+      clickArea: self.floatingClickArea
+    )
+    .padding(12)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(Color(uiColor: .secondarySystemBackground))
+  }
+
+  private var uiKitPreview: some View {
+    FloatingBannerUIKitRepresentable(
+      leadingIcon: self.showLeadingIcon ? .plus : nil,
+      leadingIconColor: self.leadingIconColor,
+      title: self.showTitle ? "Banner Title" : nil,
+      description: "Banner description text goes here.",
+      clickAreaKind: self.clickAreaKind
+    )
+    .padding(12)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(Color(uiColor: .secondarySystemBackground))
+  }
+
+  private var leadingIconColor: BCSemanticToken {
+    self.tintLeadingIcon ? .iconAccentGreen : .iconNeutral
+  }
+
+  private var floatingClickArea: BezierFloatingBannerClickArea {
+    switch self.clickAreaKind {
+    case .none: return .none
+    case .full: return .full(onClick: {})
+    case .actionIcon: return .actionIcon(onClick: {})
+    }
+  }
+}
+
+private struct FloatingBannerUIKitRepresentable: UIViewRepresentable {
+  let leadingIcon: BezierIcon?
+  let leadingIconColor: BCSemanticToken
+  let title: String?
+  let description: String
+  let clickAreaKind: FloatingBannerCatalog.ClickAreaKind
+
+  func makeUIView(context: Context) -> BezierFloatingBanner {
+    BezierFloatingBanner(
+      leadingIcon: self.leadingIcon,
+      leadingIconColor: self.leadingIconColor,
+      title: self.title,
+      description: self.description,
+      clickArea: self.clickArea
+    )
+  }
+
+  func updateUIView(_ uiView: BezierFloatingBanner, context: Context) {
+    uiView.leadingIcon = self.leadingIcon
+    uiView.leadingIconColor = self.leadingIconColor
+    uiView.title = self.title
+    uiView.bannerDescription = self.description
+    uiView.clickArea = self.clickArea
+  }
+
+  func sizeThatFits(_ proposal: ProposedViewSize, uiView: BezierFloatingBanner, context: Context) -> CGSize? {
+    let width = proposal.width ?? 320
+    let fitting = uiView.systemLayoutSizeFitting(
+      CGSize(width: width, height: UIView.layoutFittingCompressedSize.height),
+      withHorizontalFittingPriority: .required,
+      verticalFittingPriority: .fittingSizeLevel
+    )
+    return CGSize(width: width, height: fitting.height)
+  }
+
+  private var clickArea: BezierFloatingBannerClickArea {
+    switch self.clickAreaKind {
+    case .none: return .none
+    case .full: return .full(onClick: {})
+    case .actionIcon: return .actionIcon(onClick: {})
+    }
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierBanner/BezierBanner.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBanner/BezierBanner.swift
@@ -183,8 +183,13 @@ public final class BezierBanner: UIView, BezierComponentable {
     self.contentStackView.addArrangedSubview(self.titleLabel)
     self.contentStackView.addArrangedSubview(self.descriptionLabel)
     self.contentContainer.addSubview(self.contentStackView)
-    self.contentContainer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+    // content가 남은 가로 공간을 채워 actionIcon을 오른쪽 끝으로 밀도록 hugging을 최저로 낮춘다.
+    let expandingPriority = UILayoutPriority(1)
+    self.contentContainer.setContentHuggingPriority(expandingPriority, for: .horizontal)
     self.contentContainer.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+    self.contentStackView.setContentHuggingPriority(expandingPriority, for: .horizontal)
+    self.titleLabel.setContentHuggingPriority(expandingPriority, for: .horizontal)
+    self.descriptionLabel.setContentHuggingPriority(expandingPriority, for: .horizontal)
     NSLayoutConstraint.activate([
       self.contentStackView.topAnchor.constraint(
         equalTo: self.contentContainer.topAnchor,

--- a/Sources/BezierSwift/MasterComponent/BezierBanner/BezierBanner.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBanner/BezierBanner.swift
@@ -1,0 +1,306 @@
+//
+//  BezierBanner.swift
+//  BezierSwift
+//
+
+import UIKit
+
+public final class BezierBanner: UIView, BezierComponentable {
+  // MARK: - BezierComponentable
+
+  public var colorTheme: BezierColorTheme { .systemBezierColorTheme() }
+  public var componentTheme: BezierComponentTheme = .normal {
+    didSet { self.refreshAppearance() }
+  }
+
+  // MARK: - Public Properties
+
+  public var variant: BezierBannerVariant = .default {
+    didSet { if oldValue != self.variant { self.refreshAppearance() } }
+  }
+
+  public var leadingIcon: BezierIcon? {
+    didSet { if oldValue != self.leadingIcon { self.refreshContent() } }
+  }
+
+  public var title: String? {
+    didSet { if oldValue != self.title { self.refreshContent() } }
+  }
+
+  public var bannerDescription: String = "" {
+    didSet { if oldValue != self.bannerDescription { self.refreshContent() } }
+  }
+
+  public var clickArea: BezierBannerClickArea = .none {
+    didSet { self.refreshClickArea() }
+  }
+
+  // MARK: - Subviews
+
+  private let rootStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .horizontal
+    stackView.alignment = .top
+    stackView.distribution = .fill
+    stackView.spacing = 0
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    return stackView
+  }()
+
+  private let leadingIconContainer = UIView()
+  private let leadingImageView: UIImageView = {
+    let imageView = UIImageView()
+    imageView.contentMode = .scaleAspectFit
+    return imageView
+  }()
+
+  private let contentContainer = UIView()
+  private let contentStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    stackView.alignment = .fill
+    stackView.distribution = .fill
+    stackView.spacing = BezierBannerConstant.contentSpacing
+    return stackView
+  }()
+  private let titleLabel: UILabel = {
+    let label = UILabel()
+    label.numberOfLines = 0
+    return label
+  }()
+  private let descriptionLabel: UILabel = {
+    let label = UILabel()
+    label.numberOfLines = 0
+    return label
+  }()
+
+  private let actionIconContainer = UIView()
+  private let actionImageView: UIImageView = {
+    let imageView = UIImageView()
+    imageView.contentMode = .scaleAspectFit
+    return imageView
+  }()
+
+  private lazy var fullTapGesture = UITapGestureRecognizer(
+    target: self,
+    action: #selector(self.handleFullTap)
+  )
+  private lazy var actionIconTapGesture = UITapGestureRecognizer(
+    target: self,
+    action: #selector(self.handleActionIconTap)
+  )
+
+  // MARK: - Init
+
+  public init(
+    variant: BezierBannerVariant = .default,
+    leadingIcon: BezierIcon? = nil,
+    title: String? = nil,
+    description: String,
+    clickArea: BezierBannerClickArea = .none
+  ) {
+    self.variant = variant
+    self.leadingIcon = leadingIcon
+    self.title = title
+    self.bannerDescription = description
+    self.clickArea = clickArea
+    super.init(frame: .zero)
+    self.setUp()
+  }
+
+  public required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    self.setUp()
+  }
+
+  // MARK: - Setup
+
+  private func setUp() {
+    self.translatesAutoresizingMaskIntoConstraints = false
+    self.layer.cornerRadius = BezierBannerConstant.cornerRadius
+    self.layer.masksToBounds = true
+
+    self.setUpLeadingIcon()
+    self.setUpContent()
+    self.setUpActionIcon()
+
+    self.rootStackView.addArrangedSubview(self.leadingIconContainer)
+    self.rootStackView.addArrangedSubview(self.contentContainer)
+    self.rootStackView.addArrangedSubview(self.actionIconContainer)
+    self.addSubview(self.rootStackView)
+
+    self.directionalLayoutMargins = NSDirectionalEdgeInsets(
+      top: BezierBannerConstant.verticalPadding,
+      leading: BezierBannerConstant.horizontalPadding,
+      bottom: BezierBannerConstant.verticalPadding,
+      trailing: BezierBannerConstant.horizontalPadding
+    )
+    let margins = self.layoutMarginsGuide
+    NSLayoutConstraint.activate([
+      self.rootStackView.topAnchor.constraint(equalTo: margins.topAnchor),
+      self.rootStackView.leadingAnchor.constraint(equalTo: margins.leadingAnchor),
+      self.rootStackView.trailingAnchor.constraint(equalTo: margins.trailingAnchor),
+      self.rootStackView.bottomAnchor.constraint(equalTo: margins.bottomAnchor),
+    ])
+
+    self.addGestureRecognizer(self.fullTapGesture)
+    self.actionIconContainer.addGestureRecognizer(self.actionIconTapGesture)
+
+    self.refreshContent()
+    self.refreshClickArea()
+    self.refreshAppearance()
+  }
+
+  private func setUpLeadingIcon() {
+    self.leadingImageView.translatesAutoresizingMaskIntoConstraints = false
+    self.leadingIconContainer.addSubview(self.leadingImageView)
+    self.leadingIconContainer.setContentHuggingPriority(.required, for: .horizontal)
+    self.leadingIconContainer.setContentCompressionResistancePriority(.required, for: .horizontal)
+    NSLayoutConstraint.activate([
+      self.leadingImageView.widthAnchor.constraint(equalToConstant: BezierBannerConstant.iconLength),
+      self.leadingImageView.heightAnchor.constraint(equalToConstant: BezierBannerConstant.iconLength),
+      self.leadingImageView.leadingAnchor.constraint(
+        equalTo: self.leadingIconContainer.leadingAnchor,
+        constant: BezierBannerConstant.leadingIconLeadingPadding
+      ),
+      self.leadingImageView.trailingAnchor.constraint(
+        equalTo: self.leadingIconContainer.trailingAnchor,
+        constant: -BezierBannerConstant.leadingIconTrailingPadding
+      ),
+      self.leadingImageView.topAnchor.constraint(
+        equalTo: self.leadingIconContainer.topAnchor,
+        constant: BezierBannerConstant.leadingIconVerticalPadding
+      ),
+      self.leadingImageView.bottomAnchor.constraint(
+        equalTo: self.leadingIconContainer.bottomAnchor,
+        constant: -BezierBannerConstant.leadingIconVerticalPadding
+      ),
+    ])
+  }
+
+  private func setUpContent() {
+    self.contentStackView.translatesAutoresizingMaskIntoConstraints = false
+    self.contentStackView.addArrangedSubview(self.titleLabel)
+    self.contentStackView.addArrangedSubview(self.descriptionLabel)
+    self.contentContainer.addSubview(self.contentStackView)
+    self.contentContainer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+    self.contentContainer.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+    NSLayoutConstraint.activate([
+      self.contentStackView.topAnchor.constraint(
+        equalTo: self.contentContainer.topAnchor,
+        constant: BezierBannerConstant.contentPadding
+      ),
+      self.contentStackView.leadingAnchor.constraint(
+        equalTo: self.contentContainer.leadingAnchor,
+        constant: BezierBannerConstant.contentPadding
+      ),
+      self.contentStackView.trailingAnchor.constraint(
+        equalTo: self.contentContainer.trailingAnchor,
+        constant: -BezierBannerConstant.contentPadding
+      ),
+      self.contentStackView.bottomAnchor.constraint(
+        equalTo: self.contentContainer.bottomAnchor,
+        constant: -BezierBannerConstant.contentPadding
+      ),
+    ])
+  }
+
+  private func setUpActionIcon() {
+    self.actionImageView.translatesAutoresizingMaskIntoConstraints = false
+    self.actionIconContainer.addSubview(self.actionImageView)
+    self.actionIconContainer.setContentHuggingPriority(.required, for: .horizontal)
+    self.actionIconContainer.setContentCompressionResistancePriority(.required, for: .horizontal)
+    NSLayoutConstraint.activate([
+      self.actionIconContainer.widthAnchor.constraint(
+        equalToConstant: BezierBannerConstant.actionIconContainerLength
+      ),
+      self.actionIconContainer.heightAnchor.constraint(
+        equalToConstant: BezierBannerConstant.actionIconContainerLength
+      ),
+      self.actionImageView.widthAnchor.constraint(equalToConstant: BezierBannerConstant.iconLength),
+      self.actionImageView.heightAnchor.constraint(equalToConstant: BezierBannerConstant.iconLength),
+      self.actionImageView.centerXAnchor.constraint(equalTo: self.actionIconContainer.centerXAnchor),
+      self.actionImageView.centerYAnchor.constraint(equalTo: self.actionIconContainer.centerYAnchor),
+    ])
+  }
+
+  // MARK: - Trait
+
+  public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    self.refreshAppearance()
+  }
+
+  // MARK: - Refresh
+
+  private func refreshContent() {
+    if let leadingIcon = self.leadingIcon {
+      self.leadingImageView.image = leadingIcon.uiImage?.withRenderingMode(.alwaysTemplate)
+      self.leadingIconContainer.isHidden = false
+    } else {
+      self.leadingImageView.image = nil
+      self.leadingIconContainer.isHidden = true
+    }
+
+    if let title = self.title, !title.isEmpty {
+      self.titleLabel.attributedText = BezierBannerConstant.titleTypography.attributedString(
+        self,
+        text: title,
+        semanticColorToken: self.variant.textColor,
+        alignment: .left
+      )
+      self.titleLabel.isHidden = false
+    } else {
+      self.titleLabel.attributedText = nil
+      self.titleLabel.isHidden = true
+    }
+
+    self.descriptionLabel.attributedText = BezierBannerConstant.descriptionTypography.attributedString(
+      self,
+      text: self.bannerDescription,
+      semanticColorToken: self.variant.textColor,
+      alignment: .left
+    )
+  }
+
+  private func refreshClickArea() {
+    let trailingIcon = self.clickArea.trailingIcon
+    if let trailingIcon = trailingIcon {
+      self.actionImageView.image = trailingIcon.uiImage?.withRenderingMode(.alwaysTemplate)
+      self.actionImageView.tintColor = self.variant.iconColor.palette(self)
+      self.actionIconContainer.isHidden = false
+    } else {
+      self.actionImageView.image = nil
+      self.actionIconContainer.isHidden = true
+    }
+
+    switch self.clickArea {
+    case .none:
+      self.fullTapGesture.isEnabled = false
+      self.actionIconContainer.isUserInteractionEnabled = false
+    case .full:
+      self.fullTapGesture.isEnabled = true
+      self.actionIconContainer.isUserInteractionEnabled = false
+    case .actionIcon:
+      self.fullTapGesture.isEnabled = false
+      self.actionIconContainer.isUserInteractionEnabled = true
+    }
+  }
+
+  private func refreshAppearance() {
+    self.backgroundColor = self.variant.backgroundColor.palette(self)
+    self.leadingImageView.tintColor = self.variant.iconColor.palette(self)
+    self.actionImageView.tintColor = self.variant.iconColor.palette(self)
+    self.refreshContent()
+  }
+
+  // MARK: - Actions
+
+  @objc private func handleFullTap() {
+    if case .full(let onClick) = self.clickArea { onClick() }
+  }
+
+  @objc private func handleActionIconTap() {
+    if case .actionIcon(let onClick) = self.clickArea { onClick() }
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierBanner/BezierBannerSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBanner/BezierBannerSpec.swift
@@ -1,0 +1,88 @@
+//
+//  BezierBannerSpec.swift
+//  BezierSwift
+//
+
+import CoreGraphics
+
+// MARK: - Variant
+
+public enum BezierBannerVariant: CaseIterable {
+  case `default`
+  case blue
+  case cobalt
+  case green
+  case orange
+  case red
+
+  var backgroundColor: BCSemanticToken {
+    switch self {
+    case .default: return .fillNeutralLighter
+    case .blue: return .fillAccentBlue
+    case .cobalt: return .fillAccentCobalt
+    case .green: return .fillAccentGreen
+    case .orange: return .fillAccentOrange
+    case .red: return .fillAccentRed
+    }
+  }
+
+  var iconColor: BCSemanticToken {
+    switch self {
+    case .default: return .iconNeutral
+    case .blue: return .iconAccentBlue
+    case .cobalt: return .iconAccentCobalt
+    case .green: return .iconAccentGreen
+    case .orange: return .iconAccentOrange
+    case .red: return .iconAccentRed
+    }
+  }
+
+  var textColor: BCSemanticToken {
+    switch self {
+    case .default: return .textNeutralLight
+    case .blue: return .textAccentBlue
+    case .cobalt: return .textAccentCobalt
+    case .green: return .textAccentGreen
+    case .orange: return .textAccentOrange
+    case .red: return .textAccentRed
+    }
+  }
+}
+
+// MARK: - ClickArea
+
+public enum BezierBannerClickArea {
+  case none
+  case full(onClick: () -> Void)
+  case actionIcon(onClick: () -> Void)
+
+  var trailingIcon: BezierIcon? {
+    switch self {
+    case .none: return nil
+    case .full: return .chevronSmallRight
+    case .actionIcon: return .cancelSmall
+    }
+  }
+}
+
+// MARK: - Constant
+
+public enum BezierBannerConstant {
+  public static let horizontalPadding: CGFloat = 8
+  public static let verticalPadding: CGFloat = 10
+  public static let cornerRadius: CGFloat = 16
+
+  public static let leadingIconLeadingPadding: CGFloat = 4
+  public static let leadingIconTrailingPadding: CGFloat = 2
+  public static let leadingIconVerticalPadding: CGFloat = 5
+  public static let iconLength: CGFloat = 20
+
+  public static let contentPadding: CGFloat = 6
+  public static let contentSpacing: CGFloat = 4
+
+  public static let actionIconContainerLength: CGFloat = 30
+  public static let actionIconPadding: CGFloat = 5
+
+  static let titleTypography: BTSemanticToken = .textMedium(weight: .bold)
+  static let descriptionTypography: BTSemanticToken = .textMedium(weight: .regular)
+}

--- a/Sources/BezierSwift/MasterComponent/BezierBanner/SUBezierBanner.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBanner/SUBezierBanner.swift
@@ -1,0 +1,140 @@
+//
+//  SUBezierBanner.swift
+//  BezierSwift
+//
+
+import SwiftUI
+
+public struct SUBezierBanner: View, Themeable {
+  @Environment(\.colorScheme) public var colorScheme
+
+  private let variant: BezierBannerVariant
+  private let leadingIcon: BezierIcon?
+  private let title: String?
+  private let description: String
+  private let clickArea: BezierBannerClickArea
+
+  public init(
+    variant: BezierBannerVariant = .default,
+    leadingIcon: BezierIcon? = nil,
+    title: String? = nil,
+    description: String,
+    clickArea: BezierBannerClickArea = .none
+  ) {
+    self.variant = variant
+    self.leadingIcon = leadingIcon
+    self.title = title
+    self.description = description
+    self.clickArea = clickArea
+  }
+
+  @ViewBuilder
+  public var body: some View {
+    if case .full(let onClick) = self.clickArea {
+      Button(action: onClick) { self.container }
+        .buttonStyle(.plain)
+    } else {
+      self.container
+    }
+  }
+
+  private var container: some View {
+    HStack(alignment: .top, spacing: 0) {
+      self.leadingIconView
+      self.contentView
+      self.actionIconView
+    }
+    .padding(.horizontal, BezierBannerConstant.horizontalPadding)
+    .padding(.vertical, BezierBannerConstant.verticalPadding)
+    .frame(maxWidth: .infinity)
+    .background(
+      RoundedRectangle(cornerRadius: BezierBannerConstant.cornerRadius)
+        .fill(self.palette(self.variant.backgroundColor))
+    )
+  }
+
+  @ViewBuilder
+  private var leadingIconView: some View {
+    if let leadingIcon = self.leadingIcon {
+      leadingIcon.image
+        .renderingMode(.template)
+        .resizable()
+        .scaledToFit()
+        .frame(width: BezierBannerConstant.iconLength, height: BezierBannerConstant.iconLength)
+        .foregroundColor(self.palette(self.variant.iconColor))
+        .padding(.leading, BezierBannerConstant.leadingIconLeadingPadding)
+        .padding(.trailing, BezierBannerConstant.leadingIconTrailingPadding)
+        .padding(.vertical, BezierBannerConstant.leadingIconVerticalPadding)
+    }
+  }
+
+  private var contentView: some View {
+    VStack(alignment: .leading, spacing: BezierBannerConstant.contentSpacing) {
+      if let title = self.title {
+        Text(title)
+          .applyBezierFontStyle(
+            BezierBannerConstant.titleTypography,
+            semanticColorToken: self.variant.textColor
+          )
+          .fixedSize(horizontal: false, vertical: true)
+          .frame(maxWidth: .infinity, alignment: .leading)
+      }
+
+      Text(self.description)
+        .applyBezierFontStyle(
+          BezierBannerConstant.descriptionTypography,
+          semanticColorToken: self.variant.textColor
+        )
+        .fixedSize(horizontal: false, vertical: true)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+    .padding(BezierBannerConstant.contentPadding)
+    .frame(maxWidth: .infinity, alignment: .leading)
+  }
+
+  @ViewBuilder
+  private var actionIconView: some View {
+    if let trailingIcon = self.clickArea.trailingIcon {
+      let iconView = trailingIcon.image
+        .renderingMode(.template)
+        .resizable()
+        .scaledToFit()
+        .frame(width: BezierBannerConstant.iconLength, height: BezierBannerConstant.iconLength)
+        .foregroundColor(self.palette(self.variant.iconColor))
+        .padding(BezierBannerConstant.actionIconPadding)
+
+      if case .actionIcon(let onClick) = self.clickArea {
+        Button(action: onClick) { iconView }
+          .buttonStyle(.plain)
+      } else {
+        iconView
+      }
+    }
+  }
+}
+
+struct SUBezierBanner_Previews: PreviewProvider {
+  static var previews: some View {
+    VStack(spacing: 16) {
+      SUBezierBanner(
+        leadingIcon: .info,
+        title: "Banner Title",
+        description: "Banner description text goes here.",
+        clickArea: .actionIcon(onClick: {})
+      )
+      SUBezierBanner(
+        variant: .red,
+        leadingIcon: .errorTriangleFilled,
+        description: "Something went wrong.",
+        clickArea: .full(onClick: {})
+      )
+      SUBezierBanner(
+        variant: .green,
+        leadingIcon: .checkCircleFilled,
+        title: "Success",
+        description: "Saved successfully."
+      )
+    }
+    .padding()
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierFloatingBanner/BezierFloatingBanner.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierFloatingBanner/BezierFloatingBanner.swift
@@ -1,0 +1,314 @@
+//
+//  BezierFloatingBanner.swift
+//  BezierSwift
+//
+
+import UIKit
+
+public final class BezierFloatingBanner: UIView, BezierComponentable {
+  // MARK: - BezierComponentable
+
+  public var colorTheme: BezierColorTheme { .systemBezierColorTheme() }
+  public var componentTheme: BezierComponentTheme = .normal {
+    didSet { self.refreshAppearance() }
+  }
+
+  // MARK: - Public Properties
+
+  public var leadingIcon: BezierIcon? {
+    didSet { if oldValue != self.leadingIcon { self.refreshContent() } }
+  }
+
+  public var leadingIconColor: BCSemanticToken = BezierFloatingBannerConstant.defaultLeadingIconColor {
+    didSet { if oldValue != self.leadingIconColor { self.refreshAppearance() } }
+  }
+
+  public var title: String? {
+    didSet { if oldValue != self.title { self.refreshContent() } }
+  }
+
+  public var bannerDescription: String = "" {
+    didSet { if oldValue != self.bannerDescription { self.refreshContent() } }
+  }
+
+  public var clickArea: BezierFloatingBannerClickArea = .none {
+    didSet { self.refreshClickArea() }
+  }
+
+  // MARK: - Subviews
+
+  private let rootStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .horizontal
+    stackView.alignment = .top
+    stackView.distribution = .fill
+    stackView.spacing = 0
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    return stackView
+  }()
+
+  private let leadingIconContainer = UIView()
+  private let leadingImageView: UIImageView = {
+    let imageView = UIImageView()
+    imageView.contentMode = .scaleAspectFit
+    return imageView
+  }()
+
+  private let contentContainer = UIView()
+  private let contentStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    stackView.alignment = .fill
+    stackView.distribution = .fill
+    stackView.spacing = BezierFloatingBannerConstant.contentSpacing
+    return stackView
+  }()
+  private let titleLabel: UILabel = {
+    let label = UILabel()
+    label.numberOfLines = 0
+    return label
+  }()
+  private let descriptionLabel: UILabel = {
+    let label = UILabel()
+    label.numberOfLines = 0
+    return label
+  }()
+
+  private let actionIconContainer = UIView()
+  private let actionImageView: UIImageView = {
+    let imageView = UIImageView()
+    imageView.contentMode = .scaleAspectFit
+    return imageView
+  }()
+
+  private lazy var fullTapGesture = UITapGestureRecognizer(
+    target: self,
+    action: #selector(self.handleFullTap)
+  )
+  private lazy var actionIconTapGesture = UITapGestureRecognizer(
+    target: self,
+    action: #selector(self.handleActionIconTap)
+  )
+
+  // MARK: - Init
+
+  public init(
+    leadingIcon: BezierIcon? = nil,
+    leadingIconColor: BCSemanticToken = BezierFloatingBannerConstant.defaultLeadingIconColor,
+    title: String? = nil,
+    description: String,
+    clickArea: BezierFloatingBannerClickArea = .none
+  ) {
+    self.leadingIcon = leadingIcon
+    self.leadingIconColor = leadingIconColor
+    self.title = title
+    self.bannerDescription = description
+    self.clickArea = clickArea
+    super.init(frame: .zero)
+    self.setUp()
+  }
+
+  public required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    self.setUp()
+  }
+
+  // MARK: - Setup
+
+  private func setUp() {
+    self.translatesAutoresizingMaskIntoConstraints = false
+    self.layer.cornerRadius = BezierFloatingBannerConstant.cornerRadius
+    // elevation 그림자를 렌더하려면 masksToBounds = false. 배경은 layer.cornerRadius로 둥글게 유지된다.
+    self.layer.masksToBounds = false
+
+    self.setUpLeadingIcon()
+    self.setUpContent()
+    self.setUpActionIcon()
+
+    self.rootStackView.addArrangedSubview(self.leadingIconContainer)
+    self.rootStackView.addArrangedSubview(self.contentContainer)
+    self.rootStackView.addArrangedSubview(self.actionIconContainer)
+    self.addSubview(self.rootStackView)
+
+    self.directionalLayoutMargins = NSDirectionalEdgeInsets(
+      top: BezierFloatingBannerConstant.verticalPadding,
+      leading: BezierFloatingBannerConstant.leadingPadding,
+      bottom: BezierFloatingBannerConstant.verticalPadding,
+      trailing: BezierFloatingBannerConstant.trailingPadding
+    )
+    let margins = self.layoutMarginsGuide
+    NSLayoutConstraint.activate([
+      self.rootStackView.topAnchor.constraint(equalTo: margins.topAnchor),
+      self.rootStackView.leadingAnchor.constraint(equalTo: margins.leadingAnchor),
+      self.rootStackView.trailingAnchor.constraint(equalTo: margins.trailingAnchor),
+      self.rootStackView.bottomAnchor.constraint(equalTo: margins.bottomAnchor),
+      self.heightAnchor.constraint(greaterThanOrEqualToConstant: BezierFloatingBannerConstant.minHeight),
+    ])
+
+    self.addGestureRecognizer(self.fullTapGesture)
+    self.actionIconContainer.addGestureRecognizer(self.actionIconTapGesture)
+
+    self.refreshContent()
+    self.refreshClickArea()
+    self.refreshAppearance()
+  }
+
+  private func setUpLeadingIcon() {
+    self.leadingImageView.translatesAutoresizingMaskIntoConstraints = false
+    self.leadingIconContainer.addSubview(self.leadingImageView)
+    self.leadingIconContainer.setContentHuggingPriority(.required, for: .horizontal)
+    self.leadingIconContainer.setContentCompressionResistancePriority(.required, for: .horizontal)
+    NSLayoutConstraint.activate([
+      self.leadingImageView.widthAnchor.constraint(equalToConstant: BezierFloatingBannerConstant.iconLength),
+      self.leadingImageView.heightAnchor.constraint(equalToConstant: BezierFloatingBannerConstant.iconLength),
+      self.leadingImageView.leadingAnchor.constraint(
+        equalTo: self.leadingIconContainer.leadingAnchor,
+        constant: BezierFloatingBannerConstant.leadingIconLeadingPadding
+      ),
+      self.leadingImageView.trailingAnchor.constraint(equalTo: self.leadingIconContainer.trailingAnchor),
+      self.leadingImageView.topAnchor.constraint(
+        equalTo: self.leadingIconContainer.topAnchor,
+        constant: BezierFloatingBannerConstant.leadingIconVerticalPadding
+      ),
+      self.leadingImageView.bottomAnchor.constraint(
+        equalTo: self.leadingIconContainer.bottomAnchor,
+        constant: -BezierFloatingBannerConstant.leadingIconVerticalPadding
+      ),
+    ])
+  }
+
+  private func setUpContent() {
+    self.contentStackView.translatesAutoresizingMaskIntoConstraints = false
+    self.contentStackView.addArrangedSubview(self.titleLabel)
+    self.contentStackView.addArrangedSubview(self.descriptionLabel)
+    self.contentContainer.addSubview(self.contentStackView)
+    self.contentContainer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+    self.contentContainer.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+    NSLayoutConstraint.activate([
+      self.contentStackView.topAnchor.constraint(
+        equalTo: self.contentContainer.topAnchor,
+        constant: BezierFloatingBannerConstant.contentPadding
+      ),
+      self.contentStackView.leadingAnchor.constraint(
+        equalTo: self.contentContainer.leadingAnchor,
+        constant: BezierFloatingBannerConstant.contentPadding
+      ),
+      self.contentStackView.trailingAnchor.constraint(
+        equalTo: self.contentContainer.trailingAnchor,
+        constant: -BezierFloatingBannerConstant.contentPadding
+      ),
+      self.contentStackView.bottomAnchor.constraint(
+        equalTo: self.contentContainer.bottomAnchor,
+        constant: -BezierFloatingBannerConstant.contentPadding
+      ),
+    ])
+  }
+
+  private func setUpActionIcon() {
+    self.actionImageView.translatesAutoresizingMaskIntoConstraints = false
+    self.actionIconContainer.addSubview(self.actionImageView)
+    self.actionIconContainer.setContentHuggingPriority(.required, for: .horizontal)
+    self.actionIconContainer.setContentCompressionResistancePriority(.required, for: .horizontal)
+    NSLayoutConstraint.activate([
+      self.actionIconContainer.widthAnchor.constraint(
+        equalToConstant: BezierFloatingBannerConstant.actionIconContainerLength
+      ),
+      self.actionIconContainer.heightAnchor.constraint(
+        equalToConstant: BezierFloatingBannerConstant.actionIconContainerLength
+      ),
+      self.actionImageView.widthAnchor.constraint(equalToConstant: BezierFloatingBannerConstant.iconLength),
+      self.actionImageView.heightAnchor.constraint(equalToConstant: BezierFloatingBannerConstant.iconLength),
+      self.actionImageView.centerXAnchor.constraint(equalTo: self.actionIconContainer.centerXAnchor),
+      self.actionImageView.centerYAnchor.constraint(equalTo: self.actionIconContainer.centerYAnchor),
+    ])
+  }
+
+  // MARK: - Trait
+
+  public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    self.refreshAppearance()
+  }
+
+  // MARK: - Refresh
+
+  private func refreshContent() {
+    if let leadingIcon = self.leadingIcon {
+      self.leadingImageView.image = leadingIcon.uiImage?.withRenderingMode(.alwaysTemplate)
+      self.leadingIconContainer.isHidden = false
+    } else {
+      self.leadingImageView.image = nil
+      self.leadingIconContainer.isHidden = true
+    }
+
+    if let title = self.title, !title.isEmpty {
+      self.titleLabel.attributedText = BezierFloatingBannerConstant.titleTypography.attributedString(
+        self,
+        text: title,
+        semanticColorToken: BezierFloatingBannerConstant.textColor,
+        alignment: .left
+      )
+      self.titleLabel.isHidden = false
+    } else {
+      self.titleLabel.attributedText = nil
+      self.titleLabel.isHidden = true
+    }
+
+    self.descriptionLabel.attributedText = BezierFloatingBannerConstant.descriptionTypography.attributedString(
+      self,
+      text: self.bannerDescription,
+      semanticColorToken: BezierFloatingBannerConstant.textColor,
+      alignment: .left
+    )
+  }
+
+  private func refreshClickArea() {
+    let trailingIcon = self.clickArea.trailingIcon
+    if let trailingIcon = trailingIcon {
+      self.actionImageView.image = trailingIcon.uiImage?.withRenderingMode(.alwaysTemplate)
+      self.actionImageView.tintColor = BezierFloatingBannerConstant.actionIconColor.palette(self)
+      self.actionIconContainer.isHidden = false
+    } else {
+      self.actionImageView.image = nil
+      self.actionIconContainer.isHidden = true
+    }
+
+    switch self.clickArea {
+    case .none:
+      self.fullTapGesture.isEnabled = false
+      self.actionIconContainer.isUserInteractionEnabled = false
+    case .full:
+      self.fullTapGesture.isEnabled = true
+      self.actionIconContainer.isUserInteractionEnabled = false
+    case .actionIcon:
+      self.fullTapGesture.isEnabled = false
+      self.actionIconContainer.isUserInteractionEnabled = true
+    }
+  }
+
+  private func refreshAppearance() {
+    self.backgroundColor = BezierFloatingBannerConstant.backgroundColor.palette(self)
+    self.leadingImageView.tintColor = self.leadingIconColor.palette(self)
+    self.actionImageView.tintColor = BezierFloatingBannerConstant.actionIconColor.palette(self)
+    self.refreshElevation()
+    self.refreshContent()
+  }
+
+  private func refreshElevation() {
+    let elevation = BezierFloatingBannerConstant.elevation.rawValue
+    self.layer.shadowColor = elevation.semanticColor.palette(self).cgColor
+    self.layer.shadowOffset = CGSize(width: elevation.x, height: elevation.y)
+    self.layer.shadowRadius = elevation.blur
+    self.layer.shadowOpacity = 1
+  }
+
+  // MARK: - Actions
+
+  @objc private func handleFullTap() {
+    if case .full(let onClick) = self.clickArea { onClick() }
+  }
+
+  @objc private func handleActionIconTap() {
+    if case .actionIcon(let onClick) = self.clickArea { onClick() }
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierFloatingBanner/BezierFloatingBanner.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierFloatingBanner/BezierFloatingBanner.swift
@@ -223,6 +223,16 @@ public final class BezierFloatingBanner: UIView, BezierComponentable {
     ])
   }
 
+  // MARK: - Layout
+
+  public override func layoutSubviews() {
+    super.layoutSubviews()
+    self.layer.shadowPath = UIBezierPath(
+      roundedRect: self.bounds,
+      cornerRadius: BezierFloatingBannerConstant.cornerRadius
+    ).cgPath
+  }
+
   // MARK: - Trait
 
   public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/Sources/BezierSwift/MasterComponent/BezierFloatingBanner/BezierFloatingBanner.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierFloatingBanner/BezierFloatingBanner.swift
@@ -182,8 +182,13 @@ public final class BezierFloatingBanner: UIView, BezierComponentable {
     self.contentStackView.addArrangedSubview(self.titleLabel)
     self.contentStackView.addArrangedSubview(self.descriptionLabel)
     self.contentContainer.addSubview(self.contentStackView)
-    self.contentContainer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+    // content가 남은 가로 공간을 채워 actionIcon을 오른쪽 끝으로 밀도록 hugging을 최저로 낮춘다.
+    let expandingPriority = UILayoutPriority(1)
+    self.contentContainer.setContentHuggingPriority(expandingPriority, for: .horizontal)
     self.contentContainer.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+    self.contentStackView.setContentHuggingPriority(expandingPriority, for: .horizontal)
+    self.titleLabel.setContentHuggingPriority(expandingPriority, for: .horizontal)
+    self.descriptionLabel.setContentHuggingPriority(expandingPriority, for: .horizontal)
     NSLayoutConstraint.activate([
       self.contentStackView.topAnchor.constraint(
         equalTo: self.contentContainer.topAnchor,

--- a/Sources/BezierSwift/MasterComponent/BezierFloatingBanner/BezierFloatingBannerSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierFloatingBanner/BezierFloatingBannerSpec.swift
@@ -1,0 +1,52 @@
+//
+//  BezierFloatingBannerSpec.swift
+//  BezierSwift
+//
+
+import CoreGraphics
+
+// MARK: - ClickArea
+
+public enum BezierFloatingBannerClickArea {
+  case none
+  case full(onClick: () -> Void)
+  case actionIcon(onClick: () -> Void)
+
+  var trailingIcon: BezierIcon? {
+    switch self {
+    case .none: return nil
+    case .full: return .chevronSmallRight
+    case .actionIcon: return .cancelSmall
+    }
+  }
+}
+
+// MARK: - Constant
+
+public enum BezierFloatingBannerConstant {
+  public static let leadingPadding: CGFloat = 10
+  public static let trailingPadding: CGFloat = 8
+  public static let verticalPadding: CGFloat = 10
+  public static let cornerRadius: CGFloat = 16
+  public static let minHeight: CGFloat = 30
+
+  public static let leadingIconLeadingPadding: CGFloat = 2
+  public static let leadingIconVerticalPadding: CGFloat = 5
+  public static let iconLength: CGFloat = 20
+
+  public static let contentPadding: CGFloat = 6
+  public static let contentSpacing: CGFloat = 4
+
+  public static let actionIconContainerLength: CGFloat = 30
+  public static let actionIconPadding: CGFloat = 5
+
+  public static let elevation: BezierElevation = .mEv3
+
+  static let backgroundColor: BCSemanticToken = .surfaceHighest
+  static let textColor: BCSemanticToken = .textNeutralLight
+  static let actionIconColor: BCSemanticToken = .iconNeutral
+  public static let defaultLeadingIconColor: BCSemanticToken = .iconNeutral
+
+  static let titleTypography: BTSemanticToken = .textMedium(weight: .bold)
+  static let descriptionTypography: BTSemanticToken = .textMedium(weight: .regular)
+}

--- a/Sources/BezierSwift/MasterComponent/BezierFloatingBanner/SUBezierFloatingBanner.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierFloatingBanner/SUBezierFloatingBanner.swift
@@ -1,0 +1,141 @@
+//
+//  SUBezierFloatingBanner.swift
+//  BezierSwift
+//
+
+import SwiftUI
+
+public struct SUBezierFloatingBanner: View, Themeable {
+  @Environment(\.colorScheme) public var colorScheme
+
+  private let leadingIcon: BezierIcon?
+  private let leadingIconColor: BCSemanticToken
+  private let title: String?
+  private let description: String
+  private let clickArea: BezierFloatingBannerClickArea
+
+  public init(
+    leadingIcon: BezierIcon? = nil,
+    leadingIconColor: BCSemanticToken = BezierFloatingBannerConstant.defaultLeadingIconColor,
+    title: String? = nil,
+    description: String,
+    clickArea: BezierFloatingBannerClickArea = .none
+  ) {
+    self.leadingIcon = leadingIcon
+    self.leadingIconColor = leadingIconColor
+    self.title = title
+    self.description = description
+    self.clickArea = clickArea
+  }
+
+  @ViewBuilder
+  public var body: some View {
+    if case .full(let onClick) = self.clickArea {
+      Button(action: onClick) { self.container }
+        .buttonStyle(.plain)
+    } else {
+      self.container
+    }
+  }
+
+  private var container: some View {
+    HStack(alignment: .top, spacing: 0) {
+      self.leadingIconView
+      self.contentView
+      self.actionIconView
+    }
+    .padding(.leading, BezierFloatingBannerConstant.leadingPadding)
+    .padding(.trailing, BezierFloatingBannerConstant.trailingPadding)
+    .padding(.vertical, BezierFloatingBannerConstant.verticalPadding)
+    .frame(minHeight: BezierFloatingBannerConstant.minHeight)
+    .frame(maxWidth: .infinity)
+    .background(
+      RoundedRectangle(cornerRadius: BezierFloatingBannerConstant.cornerRadius)
+        .fill(self.palette(BezierFloatingBannerConstant.backgroundColor))
+    )
+    .applyBezierElevation(BezierFloatingBannerConstant.elevation)
+  }
+
+  @ViewBuilder
+  private var leadingIconView: some View {
+    if let leadingIcon = self.leadingIcon {
+      leadingIcon.image
+        .renderingMode(.template)
+        .resizable()
+        .scaledToFit()
+        .frame(width: BezierFloatingBannerConstant.iconLength, height: BezierFloatingBannerConstant.iconLength)
+        .foregroundColor(self.palette(self.leadingIconColor))
+        .padding(.leading, BezierFloatingBannerConstant.leadingIconLeadingPadding)
+        .padding(.vertical, BezierFloatingBannerConstant.leadingIconVerticalPadding)
+    }
+  }
+
+  private var contentView: some View {
+    VStack(alignment: .leading, spacing: BezierFloatingBannerConstant.contentSpacing) {
+      if let title = self.title {
+        Text(title)
+          .applyBezierFontStyle(
+            BezierFloatingBannerConstant.titleTypography,
+            semanticColorToken: BezierFloatingBannerConstant.textColor
+          )
+          .fixedSize(horizontal: false, vertical: true)
+          .frame(maxWidth: .infinity, alignment: .leading)
+      }
+
+      Text(self.description)
+        .applyBezierFontStyle(
+          BezierFloatingBannerConstant.descriptionTypography,
+          semanticColorToken: BezierFloatingBannerConstant.textColor
+        )
+        .fixedSize(horizontal: false, vertical: true)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+    .padding(BezierFloatingBannerConstant.contentPadding)
+    .frame(maxWidth: .infinity, alignment: .leading)
+  }
+
+  @ViewBuilder
+  private var actionIconView: some View {
+    if let trailingIcon = self.clickArea.trailingIcon {
+      let iconView = trailingIcon.image
+        .renderingMode(.template)
+        .resizable()
+        .scaledToFit()
+        .frame(width: BezierFloatingBannerConstant.iconLength, height: BezierFloatingBannerConstant.iconLength)
+        .foregroundColor(self.palette(BezierFloatingBannerConstant.actionIconColor))
+        .padding(BezierFloatingBannerConstant.actionIconPadding)
+
+      if case .actionIcon(let onClick) = self.clickArea {
+        Button(action: onClick) { iconView }
+          .buttonStyle(.plain)
+      } else {
+        iconView
+      }
+    }
+  }
+}
+
+struct SUBezierFloatingBanner_Previews: PreviewProvider {
+  static var previews: some View {
+    VStack(spacing: 16) {
+      SUBezierFloatingBanner(
+        leadingIcon: .plus,
+        title: "Banner Title",
+        description: "Banner description text goes here.",
+        clickArea: .actionIcon(onClick: {})
+      )
+      SUBezierFloatingBanner(
+        description: "Floating banner without leading icon.",
+        clickArea: .full(onClick: {})
+      )
+      SUBezierFloatingBanner(
+        leadingIcon: .checkCircleFilled,
+        leadingIconColor: .iconAccentGreen,
+        title: "Success",
+        description: "Saved successfully."
+      )
+    }
+    .padding()
+    .background(Color.gray.opacity(0.2))
+  }
+}

--- a/Tests/BezierSwiftTests/BezierBannerLayoutTests.swift
+++ b/Tests/BezierSwiftTests/BezierBannerLayoutTests.swift
@@ -1,0 +1,114 @@
+import Testing
+import UIKit
+@testable import BezierSwift
+
+// MARK: - BezierBanner 레이아웃 테스트
+//
+// 검증 대상: full-width 배너에서 content(제목/본문)가 남은 가로 공간을 채워
+// actionIcon(닫기/chevron)이 오른쪽 끝(trailing padding 안쪽)에 정렬되는지.
+// content가 확장하지 못하면 actionIcon이 텍스트 바로 뒤(왼쪽)로 치우친다.
+
+@Suite("BezierBanner Layout - actionIcon trailing 정렬", .serialized)
+@MainActor
+struct BezierBannerLayoutTests {
+  @Test("actionIcon이 배너 오른쪽 끝에 정렬된다 (content 가로 확장)")
+  func actionIconAlignsToTrailing() {
+    let banner = BezierBanner(
+      variant: .default,
+      leadingIcon: .info,
+      title: "Banner Title",
+      description: "Banner description text goes here.",
+      clickArea: .actionIcon(onClick: {})
+    )
+    banner.translatesAutoresizingMaskIntoConstraints = false
+
+    let width: CGFloat = 346
+    let container = UIView(frame: CGRect(x: 0, y: 0, width: width, height: 120))
+    let window = UIWindow(frame: container.bounds)
+    window.addSubview(container)
+    container.addSubview(banner)
+
+    NSLayoutConstraint.activate([
+      banner.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+      banner.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+      banner.topAnchor.constraint(equalTo: container.topAnchor),
+    ])
+
+    window.setNeedsLayout()
+    window.layoutIfNeeded()
+
+    let imageViews = Self.allImageViews(in: banner)
+    #expect(imageViews.count >= 2, "leading + action 아이콘 2개가 있어야 함 (실제 \(imageViews.count))")
+    guard let actionIV = imageViews.last, let leadingIV = imageViews.first else { return }
+
+    let actionCenter = banner.convert(actionIV.center, from: actionIV.superview)
+    let leadingCenter = banner.convert(leadingIV.center, from: leadingIV.superview)
+
+    // actionIcon 기대 center x: width - horizontalPadding(8) - actionIconContainer/2(15)
+    let expectedActionX = width
+      - BezierBannerConstant.horizontalPadding
+      - BezierBannerConstant.actionIconContainerLength / 2
+    // leadingIcon 기대 center x: horizontalPadding(8) + leadingIconLeadingPadding(4) + iconLength/2(10)
+    let expectedLeadingX = BezierBannerConstant.horizontalPadding
+      + BezierBannerConstant.leadingIconLeadingPadding
+      + BezierBannerConstant.iconLength / 2
+
+    #expect(
+      abs(actionCenter.x - expectedActionX) < 2,
+      "actionIcon center x=\(actionCenter.x)pt, 기대 \(expectedActionX)pt (배너 오른쪽 끝). content 미확장 시 왼쪽으로 치우침"
+    )
+    #expect(
+      abs(leadingCenter.x - expectedLeadingX) < 2,
+      "leadingIcon center x=\(leadingCenter.x)pt, 기대 \(expectedLeadingX)pt (왼쪽 padding 안쪽)"
+    )
+  }
+
+  @Test("FloatingBanner actionIcon이 배너 오른쪽 끝에 정렬된다 (content 가로 확장)")
+  func floatingActionIconAlignsToTrailing() {
+    let banner = BezierFloatingBanner(
+      leadingIcon: .plus,
+      title: "Banner Title",
+      description: "Banner description text goes here.",
+      clickArea: .actionIcon(onClick: {})
+    )
+    banner.translatesAutoresizingMaskIntoConstraints = false
+
+    let width: CGFloat = 346
+    let container = UIView(frame: CGRect(x: 0, y: 0, width: width, height: 120))
+    let window = UIWindow(frame: container.bounds)
+    window.addSubview(container)
+    container.addSubview(banner)
+
+    NSLayoutConstraint.activate([
+      banner.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+      banner.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+      banner.topAnchor.constraint(equalTo: container.topAnchor),
+    ])
+
+    window.setNeedsLayout()
+    window.layoutIfNeeded()
+
+    let imageViews = Self.allImageViews(in: banner)
+    #expect(imageViews.count >= 2, "leading + action 아이콘 2개가 있어야 함 (실제 \(imageViews.count))")
+    guard let actionIV = imageViews.last else { return }
+
+    let actionCenter = banner.convert(actionIV.center, from: actionIV.superview)
+    let expectedActionX = width
+      - BezierFloatingBannerConstant.trailingPadding
+      - BezierFloatingBannerConstant.actionIconContainerLength / 2
+
+    #expect(
+      abs(actionCenter.x - expectedActionX) < 2,
+      "FloatingBanner actionIcon center x=\(actionCenter.x)pt, 기대 \(expectedActionX)pt (오른쪽 끝). content 미확장 시 왼쪽으로 치우침"
+    )
+  }
+
+  private static func allImageViews(in view: UIView) -> [UIImageView] {
+    var result: [UIImageView] = []
+    for sub in view.subviews {
+      if let iv = sub as? UIImageView { result.append(iv) }
+      result += allImageViews(in: sub)
+    }
+    return result
+  }
+}


### PR DESCRIPTION
## 개요

Figma SSOT 기반 V3 신규 컴포넌트 **`BezierBanner`(Inner)** 와 **`BezierFloatingBanner`** 구현 (UIKit + SwiftUI). 시스템 상태·오류·경고를 지속 표시하는 메시지 컴포넌트로, Toast와 달리 자동 소멸하지 않습니다.

> **MOB-6350**(FloatingBanner)은 본 PR에 함께 포함되어 **MOB-6349에 duplicate 처리**되었습니다.

## Figma SSOT

- Banner: [🚧 Mobile Components — Banner](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=1092-2&m=dev)
- FloatingBanner: [🚧 Mobile Components — FloatingBanner](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=5019-13311&m=dev)
- Design spec: [Banner-spec.md](https://github.com/channel-io/team-design/blob/main/bezier-v3/components/Banner-spec.md) · [FloatingBanner-spec.md](https://github.com/channel-io/team-design/blob/main/bezier-v3/components/FloatingBanner-spec.md)

## 구현

### BezierBanner (Inner)
- **variant** 6색(default / blue / cobalt / green / orange / red) × **clickArea** 3(none / full / actionIcon)
- 아이콘·텍스트 색은 variant가 강제, `leadingIcon`은 `BezierIcon?` 주입 (아이콘 컬러 개별 변경 불가)

### BezierFloatingBanner
- variant 없는 단일 셋. 배경 `surfaceHighest` + **elevation `mEv3`** 그림자 (`layoutSubviews`에서 `shadowPath` 설정으로 렌더 비용 절감, CodeRabbit 리뷰 반영)
- `leadingIcon` + `leadingIconColor` 주입(아이콘 종류·컬러 교체 가능)

### 공통
- `clickArea`를 associated closure(`.none` / `.full(onClick:)` / `.actionIcon(onClick:)`)로 모델링 → 후행 아이콘(chevron/cancel)과 탭 영역을 타입 안전하게 결정
- Figma 캔버스 320 대신 **컨테이너 폭을 채우는 full-width**. content가 남은 가로 공간을 채워 actionIcon이 오른쪽 끝에 정렬됨(hugging 조정 + UIWindow 레이아웃 테스트로 검증)
- UIKit은 `traitCollectionDidChange`에서 토큰 재주입(다크모드 적응), SwiftUI는 자동
- 타이포 `textMedium(weight: .bold/.regular)`
- Examples: `BannerCatalog` / `FloatingBannerCatalog` 추가 (SwiftUI + UIKit 프리뷰, UIKit은 wrapper pin으로 full-width 표시)

## 파일

| 정의 | Banner | FloatingBanner |
|---|---|---|
| UIKit | `BezierBanner.swift` | `BezierFloatingBanner.swift` |
| SwiftUI | `SUBezierBanner.swift` | `SUBezierFloatingBanner.swift` |
| Spec/상수 | `BezierBannerSpec.swift` | `BezierFloatingBannerSpec.swift` |
| 레이아웃 테스트 | `BezierBannerLayoutTests.swift` (actionIcon trailing 정렬) | |

## 검증

- **Figma → Spec → 구현** 파이프라인: Spec 검증 7차원 + 구현 검증 4개(Banner·FloatingBanner × UIKit·SwiftUI) 전부 통과
- 시뮬레이터 렌더 검증(라이트/다크, SwiftUI=UIKit 일치)

## 시각 검증

시뮬레이터(iPhone 17) 렌더. 각 조합에서 **SwiftUI·UIKit이 일치**하며 라이트/다크 모두 컬러 토큰이 정확히 적응합니다.

### Banner

| default · actionIcon (light) | red · full (light) | red · full (dark) |
|:---:|:---:|:---:|
| <img src="https://github.com/user-attachments/assets/cf0d7387-c8d4-468b-b7a9-17a8e6dbc012" width="240" /> | <img src="https://github.com/user-attachments/assets/d6c9f780-de0b-437f-bb98-a199f9f1cd42" width="240" /> | <img src="https://github.com/user-attachments/assets/ba0b3f9e-8eb9-4537-95d9-9bf2ca4da726" width="240" /> |

### FloatingBanner (surfaceHighest + elevation shadow)

| plus · actionIcon (light) | full (light) | full (dark) |
|:---:|:---:|:---:|
| <img src="https://github.com/user-attachments/assets/5cfb9469-dafc-44ee-b776-b03b2d5896eb" width="240" /> | <img src="https://github.com/user-attachments/assets/e2585f72-829a-4581-b32c-14b7c226dc88" width="240" /> | <img src="https://github.com/user-attachments/assets/18a407d0-bf9e-4e13-9200-24b72edaccff" width="240" /> |

🤖 Generated with [Claude Code](https://claude.com/claude-code)