### PR TITLE
[MOB-6444] BezierBaseItem 컴포넌트 구현 (UIKit + SwiftUI)

### DIFF
--- a/Examples/BezierExamples/BezierExamples/App/CatalogRegistry.swift
+++ b/Examples/BezierExamples/BezierExamples/App/CatalogRegistry.swift
@@ -29,6 +29,12 @@ enum CatalogRegistry {
     ),
     // MARK: - V3 Components
     CatalogItem(
+      id: "base-item",
+      title: "BaseItem",
+      section: .v3Components,
+      destination: AnyView(BaseItemCatalog())
+    ),
+    CatalogItem(
       id: "button",
       title: "Button",
       section: .v3Components,

--- a/Examples/BezierExamples/BezierExamples/Components/BaseItemCatalog.swift
+++ b/Examples/BezierExamples/BezierExamples/Components/BaseItemCatalog.swift
@@ -1,0 +1,200 @@
+import SwiftUI
+import UIKit
+import BezierSwift
+
+struct BaseItemCatalog: View {
+  @State private var size: BezierBaseItemSize = .medium
+  @State private var interactive = true
+  @State private var isEnabled = true
+
+  var body: some View {
+    CatalogScreen(title: "BaseItem") {
+      self.controls
+      CatalogSection(.swiftUI) { self.swiftUIPreview }
+      CatalogSection(.uiKit) { self.uiKitPreview }
+    }
+  }
+
+  private var controls: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Picker("size", selection: self.$size) {
+        ForEach(BezierBaseItemSize.allCases, id: \.self) { size in
+          Text(self.sizeLabel(size)).tag(size)
+        }
+      }
+      .pickerStyle(.segmented)
+
+      Toggle("interactive (onTap)", isOn: self.$interactive)
+      Toggle("isEnabled", isOn: self.$isEnabled)
+    }
+    .font(.caption)
+  }
+
+  private var onTap: (() -> Void)? {
+    self.interactive ? {} : nil
+  }
+
+  private var swiftUIPreview: some View {
+    VStack(spacing: 4) {
+      // leading + title
+      SUBezierBaseItem(
+        size: self.size,
+        title: "Leading + title",
+        onTap: self.onTap,
+        leading: { self.leadingIcon },
+        trailing: { EmptyView() }
+      )
+      // leading + title + description
+      SUBezierBaseItem(
+        size: self.size,
+        title: "Leading + description",
+        description: "Secondary description text that can wrap onto a second line.",
+        onTap: self.onTap,
+        leading: { self.leadingIcon },
+        trailing: { EmptyView() }
+      )
+      // leading + centerSlot + trailing
+      SUBezierBaseItem(
+        size: self.size,
+        title: "Center slot + trailing",
+        onTap: self.onTap,
+        leading: { self.leadingIcon },
+        centerSlot: { Circle().fill(Color.red).frame(width: 6, height: 6) },
+        trailing: { self.trailingIcon }
+      )
+      // no leading + trailing
+      SUBezierBaseItem(
+        size: self.size,
+        title: "No leading + trailing",
+        onTap: self.onTap,
+        leading: { EmptyView() },
+        trailing: { self.trailingIcon }
+      )
+    }
+    .disabled(!self.isEnabled)
+  }
+
+  private var leadingIcon: some View {
+    BezierIcon.personCircle.image
+      .renderingMode(.template)
+      .resizable()
+      .scaledToFit()
+      .foregroundColor(.secondary)
+  }
+
+  private var trailingIcon: some View {
+    BezierIcon.chevronSmallRight.image
+      .renderingMode(.template)
+      .resizable()
+      .scaledToFit()
+      .frame(width: 20, height: 20)
+      .foregroundColor(.secondary)
+  }
+
+  private var uiKitPreview: some View {
+    BaseItemUIKitRepresentable(
+      size: self.size,
+      interactive: self.interactive,
+      isEnabled: self.isEnabled
+    )
+  }
+
+  private func sizeLabel(_ size: BezierBaseItemSize) -> String {
+    switch size {
+    case .small: return "small"
+    case .medium: return "medium"
+    case .large: return "large"
+    }
+  }
+}
+
+private struct BaseItemUIKitRepresentable: UIViewRepresentable {
+  let size: BezierBaseItemSize
+  let interactive: Bool
+  let isEnabled: Bool
+
+  func makeUIView(context: Context) -> UIView {
+    let wrapper = UIView()
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    stackView.spacing = 4
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    wrapper.addSubview(stackView)
+    NSLayoutConstraint.activate([
+      stackView.leadingAnchor.constraint(equalTo: wrapper.leadingAnchor),
+      stackView.trailingAnchor.constraint(equalTo: wrapper.trailingAnchor),
+      stackView.topAnchor.constraint(equalTo: wrapper.topAnchor),
+      stackView.bottomAnchor.constraint(equalTo: wrapper.bottomAnchor),
+    ])
+
+    stackView.addArrangedSubview(self.makeItem(title: "Leading + title", hasLeading: true))
+    stackView.addArrangedSubview(self.makeItem(
+      title: "Leading + description",
+      description: "Secondary description text that can wrap onto a second line.",
+      hasLeading: true
+    ))
+    stackView.addArrangedSubview(self.makeItem(title: "Center slot + trailing", hasLeading: true, hasCenterSlot: true, hasTrailing: true))
+    stackView.addArrangedSubview(self.makeItem(title: "No leading + trailing", hasLeading: false, hasTrailing: true))
+    return wrapper
+  }
+
+  func updateUIView(_ wrapper: UIView, context: Context) {
+    guard let stackView = wrapper.subviews.first as? UIStackView else { return }
+    for case let item as BezierBaseItem in stackView.arrangedSubviews {
+      item.size = self.size
+      item.onTap = self.interactive ? {} : nil
+      item.isEnabled = self.isEnabled
+    }
+  }
+
+  func sizeThatFits(_ proposal: ProposedViewSize, uiView: UIView, context: Context) -> CGSize? {
+    let width = proposal.width ?? 320
+    let fitting = uiView.systemLayoutSizeFitting(
+      CGSize(width: width, height: UIView.layoutFittingCompressedSize.height),
+      withHorizontalFittingPriority: .required,
+      verticalFittingPriority: .fittingSizeLevel
+    )
+    return CGSize(width: width, height: fitting.height)
+  }
+
+  private func makeItem(
+    title: String,
+    description: String? = nil,
+    hasLeading: Bool = false,
+    hasCenterSlot: Bool = false,
+    hasTrailing: Bool = false
+  ) -> BezierBaseItem {
+    let item = BezierBaseItem(size: self.size, title: title, description: description)
+    item.onTap = self.interactive ? {} : nil
+    item.isEnabled = self.isEnabled
+    if hasLeading {
+      let imageView = UIImageView(image: BezierIcon.personCircle.uiImage?.withRenderingMode(.alwaysTemplate))
+      imageView.contentMode = .scaleAspectFit
+      imageView.tintColor = .secondaryLabel
+      item.leadingContent = imageView
+    }
+    if hasCenterSlot {
+      let dot = UIView()
+      dot.backgroundColor = .systemRed
+      dot.layer.cornerRadius = 3
+      dot.translatesAutoresizingMaskIntoConstraints = false
+      NSLayoutConstraint.activate([
+        dot.widthAnchor.constraint(equalToConstant: 6),
+        dot.heightAnchor.constraint(equalToConstant: 6),
+      ])
+      item.centerSlot = dot
+    }
+    if hasTrailing {
+      let imageView = UIImageView(image: BezierIcon.chevronSmallRight.uiImage?.withRenderingMode(.alwaysTemplate))
+      imageView.contentMode = .scaleAspectFit
+      imageView.tintColor = .secondaryLabel
+      imageView.translatesAutoresizingMaskIntoConstraints = false
+      NSLayoutConstraint.activate([
+        imageView.widthAnchor.constraint(equalToConstant: 20),
+        imageView.heightAnchor.constraint(equalToConstant: 20),
+      ])
+      item.trailingContent = imageView
+    }
+    return item
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierBaseItem/BezierBaseItem.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBaseItem/BezierBaseItem.swift
@@ -1,0 +1,360 @@
+//
+//  BezierBaseItem.swift
+//  BezierSwift
+//
+
+import UIKit
+
+public final class BezierBaseItem: UIControl, BezierComponentable {
+  // MARK: - BezierComponentable
+
+  public var colorTheme: BezierColorTheme { .systemBezierColorTheme() }
+  public var componentTheme: BezierComponentTheme = .normal {
+    didSet { self.refreshAppearance() }
+  }
+
+  // MARK: - Public Properties
+
+  public var size: BezierBaseItemSize = .medium {
+    didSet { if oldValue != self.size { self.refreshSize() } }
+  }
+
+  public var title: String? {
+    didSet { if oldValue != self.title { self.refreshText() } }
+  }
+
+  public var itemDescription: String? {
+    didSet { if oldValue != self.itemDescription { self.refreshText() } }
+  }
+
+  public var onTap: (() -> Void)? {
+    didSet { self.refreshInteraction() }
+  }
+
+  public var leadingContent: UIView? {
+    didSet { self.updateSlot(container: self.leadingContainer, old: oldValue, new: self.leadingContent, fill: true) }
+  }
+
+  public var centerSlot: UIView? {
+    didSet { self.updateSlot(container: self.centerSlotContainer, old: oldValue, new: self.centerSlot, fill: true) }
+  }
+
+  public var trailingContent: UIView? {
+    didSet { self.updateSlot(container: self.trailingContainer, old: oldValue, new: self.trailingContent, fill: true) }
+  }
+
+  // MARK: - State
+
+  public override var isHighlighted: Bool {
+    didSet {
+      if oldValue != self.isHighlighted {
+        self.refreshAppearance()
+        self.refreshPressScale()
+      }
+    }
+  }
+
+  public override var isEnabled: Bool {
+    didSet { if oldValue != self.isEnabled { self.refreshEnabled() } }
+  }
+
+  // MARK: - Subviews
+
+  private let rootStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .horizontal
+    stackView.alignment = .center
+    stackView.distribution = .fill
+    stackView.spacing = BezierBaseItemConstant.slotSpacing
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    stackView.isUserInteractionEnabled = false
+    return stackView
+  }()
+
+  private let leadingContainer = UIView()
+
+  private let centerStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    stackView.alignment = .fill
+    stackView.distribution = .fill
+    stackView.spacing = 0
+    stackView.isLayoutMarginsRelativeArrangement = true
+    stackView.directionalLayoutMargins = NSDirectionalEdgeInsets(
+      top: 0,
+      leading: BezierBaseItemConstant.centerLeadingInset,
+      bottom: 0,
+      trailing: 0
+    )
+    return stackView
+  }()
+
+  private let titleRowStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .horizontal
+    stackView.alignment = .center
+    stackView.distribution = .fill
+    stackView.spacing = BezierBaseItemConstant.titleRowSpacing
+    return stackView
+  }()
+
+  private let titleLabel: UILabel = {
+    let label = UILabel()
+    label.numberOfLines = 1
+    return label
+  }()
+
+  private let centerSlotContainer = UIView()
+  private let titleSpacer = UIView()
+
+  private let descriptionLabel: UILabel = {
+    let label = UILabel()
+    label.numberOfLines = 0
+    return label
+  }()
+
+  private let trailingContainer = UIView()
+
+  // MARK: - Constraints
+
+  private var leadingWidthConstraint: NSLayoutConstraint?
+  private var leadingHeightConstraint: NSLayoutConstraint?
+  private var minHeightConstraint: NSLayoutConstraint?
+
+  // MARK: - Init
+
+  public init(
+    size: BezierBaseItemSize = .medium,
+    title: String? = nil,
+    description: String? = nil,
+    onTap: (() -> Void)? = nil
+  ) {
+    self.size = size
+    self.title = title
+    self.itemDescription = description
+    self.onTap = onTap
+    super.init(frame: .zero)
+    self.setUp()
+  }
+
+  public required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    self.setUp()
+  }
+
+  // MARK: - Setup
+
+  private func setUp() {
+    self.translatesAutoresizingMaskIntoConstraints = false
+    self.layer.cornerRadius = BezierBaseItemConstant.cornerRadius
+    self.layer.masksToBounds = true
+
+    self.setUpLeading()
+    self.setUpCenter()
+    self.setUpTrailing()
+
+    self.rootStackView.addArrangedSubview(self.leadingContainer)
+    self.rootStackView.addArrangedSubview(self.centerStackView)
+    self.rootStackView.addArrangedSubview(self.trailingContainer)
+    self.addSubview(self.rootStackView)
+
+    let margins = self.layoutMarginsGuide
+    let minHeightConstraint = self.heightAnchor.constraint(
+      greaterThanOrEqualToConstant: self.size.minHeight
+    )
+    self.minHeightConstraint = minHeightConstraint
+    NSLayoutConstraint.activate([
+      self.rootStackView.topAnchor.constraint(equalTo: margins.topAnchor),
+      self.rootStackView.leadingAnchor.constraint(equalTo: margins.leadingAnchor),
+      self.rootStackView.trailingAnchor.constraint(equalTo: margins.trailingAnchor),
+      self.rootStackView.bottomAnchor.constraint(equalTo: margins.bottomAnchor),
+      minHeightConstraint,
+    ])
+
+    self.addTarget(self, action: #selector(self.handleTap), for: .touchUpInside)
+
+    self.refreshSize()
+    self.refreshText()
+    self.refreshInteraction()
+    self.refreshEnabled()
+    self.refreshAppearance()
+  }
+
+  private func setUpLeading() {
+    self.leadingContainer.setContentHuggingPriority(.required, for: .horizontal)
+    self.leadingContainer.setContentCompressionResistancePriority(.required, for: .horizontal)
+    let widthConstraint = self.leadingContainer.widthAnchor.constraint(
+      equalToConstant: self.size.leadingLength
+    )
+    let heightConstraint = self.leadingContainer.heightAnchor.constraint(
+      equalToConstant: self.size.leadingLength
+    )
+    self.leadingWidthConstraint = widthConstraint
+    self.leadingHeightConstraint = heightConstraint
+    NSLayoutConstraint.activate([widthConstraint, heightConstraint])
+    self.leadingContainer.isHidden = true
+  }
+
+  private func setUpCenter() {
+    // center가 남은 가로 공간을 채워 trailing을 오른쪽 끝으로 밀도록 hugging을 최저로 낮춘다.
+    let expandingPriority = UILayoutPriority(1)
+    self.centerStackView.setContentHuggingPriority(expandingPriority, for: .horizontal)
+    self.centerStackView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+    self.titleLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+    self.centerSlotContainer.setContentHuggingPriority(.required, for: .horizontal)
+    self.centerSlotContainer.setContentCompressionResistancePriority(.required, for: .horizontal)
+    // titleSpacer가 라벨 우측 여백을 흡수해 라벨을 HUG로 유지한다.
+    self.titleSpacer.setContentHuggingPriority(expandingPriority, for: .horizontal)
+    self.titleSpacer.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+    self.titleRowStackView.addArrangedSubview(self.titleLabel)
+    self.titleRowStackView.addArrangedSubview(self.centerSlotContainer)
+    self.titleRowStackView.addArrangedSubview(self.titleSpacer)
+
+    self.centerStackView.addArrangedSubview(self.titleRowStackView)
+    self.centerStackView.addArrangedSubview(self.descriptionLabel)
+
+    self.centerSlotContainer.isHidden = true
+    self.descriptionLabel.isHidden = true
+  }
+
+  private func setUpTrailing() {
+    self.trailingContainer.setContentHuggingPriority(.required, for: .horizontal)
+    self.trailingContainer.setContentCompressionResistancePriority(.required, for: .horizontal)
+    self.trailingContainer.isHidden = true
+  }
+
+  // MARK: - Slot
+
+  private func updateSlot(container: UIView, old: UIView?, new: UIView?, fill: Bool) {
+    old?.removeFromSuperview()
+    guard let new = new else {
+      container.isHidden = true
+      return
+    }
+    new.translatesAutoresizingMaskIntoConstraints = false
+    container.addSubview(new)
+    NSLayoutConstraint.activate([
+      new.topAnchor.constraint(equalTo: container.topAnchor),
+      new.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+      new.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+      new.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+    ])
+    container.isHidden = false
+  }
+
+  // MARK: - Trait
+
+  public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    self.refreshAppearance()
+  }
+
+  // MARK: - Refresh
+
+  private func refreshSize() {
+    self.leadingWidthConstraint?.constant = self.size.leadingLength
+    self.leadingHeightConstraint?.constant = self.size.leadingLength
+    self.minHeightConstraint?.constant = self.size.minHeight
+    self.directionalLayoutMargins = NSDirectionalEdgeInsets(
+      top: self.size.verticalPadding,
+      leading: BezierBaseItemConstant.horizontalPadding,
+      bottom: self.size.verticalPadding,
+      trailing: BezierBaseItemConstant.horizontalPadding
+    )
+    self.refreshText()
+    self.setNeedsLayout()
+  }
+
+  private func refreshText() {
+    if let title = self.title, !title.isEmpty {
+      self.titleLabel.attributedText = BezierBaseItemConstant.titleTypography.attributedString(
+        self,
+        text: title,
+        semanticColorToken: BezierBaseItemConstant.titleColor,
+        alignment: .left,
+        lineBreakMode: .byTruncatingTail
+      )
+      self.titleLabel.isHidden = false
+    } else {
+      self.titleLabel.attributedText = nil
+      self.titleLabel.isHidden = true
+    }
+
+    // SPEC §2: description은 medium·large만 지원 (small variant엔 description 노드 자체가 없음)
+    if self.size != .small, let itemDescription = self.itemDescription, !itemDescription.isEmpty {
+      self.descriptionLabel.attributedText = BezierBaseItemConstant.descriptionTypography.attributedString(
+        self,
+        text: itemDescription,
+        semanticColorToken: BezierBaseItemConstant.descriptionColor,
+        alignment: .left,
+        lineBreakMode: .byWordWrapping
+      )
+      self.descriptionLabel.isHidden = false
+    } else {
+      self.descriptionLabel.attributedText = nil
+      self.descriptionLabel.isHidden = true
+    }
+  }
+
+  private static let pressReleaseAnimationKey = "bezierBaseItemPressRelease"
+
+  private func refreshInteraction() {
+    self.isUserInteractionEnabled = self.onTap != nil
+    if self.onTap == nil {
+      self.rootStackView.layer.removeAnimation(forKey: Self.pressReleaseAnimationKey)
+      self.rootStackView.transform = .identity
+    }
+  }
+
+  // 콘텐츠(rootStackView)만 press scale — 배경(self)은 full-size 유지.
+  // ch-desk-ios ListItemPressFeedback와 동일: press-in 축소 → release 시 오버슈트 복귀.
+  private func refreshPressScale() {
+    guard self.onTap != nil, !UIAccessibility.isReduceMotionEnabled else {
+      self.rootStackView.layer.removeAnimation(forKey: Self.pressReleaseAnimationKey)
+      self.rootStackView.transform = .identity
+      return
+    }
+
+    if self.isHighlighted {
+      self.rootStackView.layer.removeAnimation(forKey: Self.pressReleaseAnimationKey)
+      UIView.animate(
+        withDuration: BezierBaseItemConstant.pressInDuration,
+        delay: 0,
+        options: [.curveEaseInOut, .beginFromCurrentState]
+      ) {
+        self.rootStackView.transform = CGAffineTransform(
+          scaleX: BezierBaseItemConstant.pressScale,
+          y: BezierBaseItemConstant.pressScale
+        )
+      }
+    } else {
+      self.rootStackView.transform = .identity
+      let keyframe = CAKeyframeAnimation(keyPath: "transform.scale")
+      keyframe.values = BezierBaseItemConstant.releaseScaleValues
+      keyframe.keyTimes = BezierBaseItemConstant.releaseScaleKeyTimes
+      keyframe.duration = BezierBaseItemConstant.releaseDuration
+      keyframe.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+      keyframe.isRemovedOnCompletion = true
+      self.rootStackView.layer.add(keyframe, forKey: Self.pressReleaseAnimationKey)
+    }
+  }
+
+  private func refreshEnabled() {
+    self.alpha = self.isEnabled ? 1 : BezierBaseItemConstant.disabledOpacity
+  }
+
+  private func refreshAppearance() {
+    self.backgroundColor = self.isHighlighted
+      ? BezierBaseItemConstant.pressedBackgroundColor.palette(self)
+      : .clear
+    self.refreshText()
+  }
+
+  // MARK: - Action
+
+  @objc private func handleTap() {
+    self.onTap?()
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierBaseItem/BezierBaseItem.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBaseItem/BezierBaseItem.swift
@@ -19,7 +19,7 @@ public final class BezierBaseItem: UIControl, BezierComponentable {
     didSet { if oldValue != self.size { self.refreshSize() } }
   }
 
-  public var title: String? {
+  public var title: String = "" {
     didSet { if oldValue != self.title { self.refreshText() } }
   }
 
@@ -125,7 +125,7 @@ public final class BezierBaseItem: UIControl, BezierComponentable {
 
   public init(
     size: BezierBaseItemSize = .medium,
-    title: String? = nil,
+    title: String,
     description: String? = nil,
     onTap: (() -> Void)? = nil
   ) {
@@ -268,10 +268,10 @@ public final class BezierBaseItem: UIControl, BezierComponentable {
   }
 
   private func refreshText() {
-    if let title = self.title, !title.isEmpty {
+    if !self.title.isEmpty {
       self.titleLabel.attributedText = BezierBaseItemConstant.titleTypography.attributedString(
         self,
-        text: title,
+        text: self.title,
         semanticColorToken: BezierBaseItemConstant.titleColor,
         alignment: .left,
         lineBreakMode: .byTruncatingTail

--- a/Sources/BezierSwift/MasterComponent/BezierBaseItem/BezierBaseItemSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBaseItem/BezierBaseItemSpec.swift
@@ -1,0 +1,63 @@
+//
+//  BezierBaseItemSpec.swift
+//  BezierSwift
+//
+
+import Foundation
+
+// MARK: - Size
+
+public enum BezierBaseItemSize: CaseIterable {
+  case small
+  case medium
+  case large
+
+  var minHeight: CGFloat {
+    switch self {
+    case .small: return 40
+    case .medium: return 48
+    case .large: return 52
+    }
+  }
+
+  var verticalPadding: CGFloat {
+    switch self {
+    case .small, .medium: return 6
+    case .large: return 8
+    }
+  }
+
+  var leadingLength: CGFloat {
+    switch self {
+    case .small, .medium: return 24
+    case .large: return 36
+    }
+  }
+}
+
+// MARK: - Constant
+
+public enum BezierBaseItemConstant {
+  public static let horizontalPadding: CGFloat = 6
+  public static let cornerRadius: CGFloat = 8
+  public static let slotSpacing: CGFloat = 10
+  public static let titleRowSpacing: CGFloat = 4
+  public static let centerLeadingInset: CGFloat = 2
+
+  static let disabledOpacity: CGFloat = BOGlobalToken.disabled
+
+  static let titleTypography: BTSemanticToken = .textXLarge(weight: .regular)
+  static let descriptionTypography: BTSemanticToken = .captionMedium(weight: .regular)
+
+  static let titleColor: BCSemanticToken = .textNeutral
+  static let descriptionColor: BCSemanticToken = .textNeutralLighter
+  static let pressedBackgroundColor: BCSemanticToken = .fillNeutralLighter
+
+  // Press scale 피드백 (Figma 외 · 협의 — ch-desk-ios ListItemPressFeedback 참조)
+  // 콘텐츠가 눌림 시 0.97로 축소되고, 뗄 때 살짝 오버슈트하며 복귀한다.
+  static let pressScale: CGFloat = 0.97
+  static let pressInDuration: TimeInterval = 0.10
+  static let releaseDuration: TimeInterval = 0.40
+  static let releaseScaleValues: [NSNumber] = [0.97, 1.004, 1.0]
+  static let releaseScaleKeyTimes: [NSNumber] = [0, 0.55, 1.0]
+}

--- a/Sources/BezierSwift/MasterComponent/BezierBaseItem/SPEC.md
+++ b/Sources/BezierSwift/MasterComponent/BezierBaseItem/SPEC.md
@@ -1,0 +1,129 @@
+# BezierBaseItem SPEC
+
+> **SSOT**: [Figma · Mobile-Components / Base — `_BaseItem` (4404:11875)](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=4400-213)
+> **Design spec doc**: [team-design / bezier-v3 / components / BaseItem.md](https://github.com/channel-io/team-design/blob/main/bezier-v3/components/BaseItem.md) (보조 참조 — 값 충돌 시 Figma 파일 우선)
+>
+> 모든 수치/토큰은 Figma `_BaseItem` 노드에 실재한다. §7 인터랙션은 Figma `_BaseItem`에 state variant가 없어 별도 협의 결정으로 분리 표기한다.
+
+## 1. Component Overview
+
+- **이름**: BaseItem (`_BaseItem`)
+- **설명**: 리스트/메뉴 계열 `*Item` 서브컴포넌트가 공유하는 공통 레이아웃 base. `leading` / `center`(title·description) / `trailing` 3영역 anatomy.
+- **가이드라인** (Figma component description 인용):
+  - 단독 배치 금지 — `*Item` 계열(NavigationItem, SelectItem 등) 내부 base 레퍼런스 전용.
+  - `showLeadingContent`: 대표 UI 슬롯 (정방형 — small/medium 24×24 / large 36×36, **단일**).
+  - `showTrailingContent`: 부가 메타 슬롯 (1~2개 요소, 꼭 필요할 때만).
+  - `showDescription`: label 하단 보조 텍스트 (**size=small 미지원**).
+  - `showCenterSlot`: label 우측 인라인 보조 슬롯.
+  - label은 Figma에서 HUG이나, 구현에서는 공간 부족 시 ellipsis truncate.
+
+## 2. Component Properties
+
+Figma `_BaseItem`(4404:11875) property 정의 전수. 기계 property key(`has*` / SLOT / TEXT)를 기준으로 하고, component description의 서술 표기(`show*`)는 별도 주석.
+
+| Figma property key | Type | Default | 옵션 / 값 | 구현 매핑 |
+|---|---|---|---|---|
+| `size` | VARIANT | small | small / medium / large | `BezierBaseItemSize` |
+| `hasLeadingContent` | BOOLEAN | true | on / off | leading 슬롯 유무 |
+| `hasCenterSlot` | BOOLEAN | true | on / off | centerSlot 유무 |
+| `hasDescription` | BOOLEAN | false | on / off (medium·large만) | description 유무 |
+| `hasTrailingContent` | BOOLEAN | true | on / off | trailing 슬롯 유무 |
+| `label` | TEXT | "Label" | 문자열 | title |
+| `description` | TEXT | "Description text" | 문자열 | description |
+| `leadingContent` | SLOT | — | 임의 콘텐츠 | leading 슬롯 |
+| `centerSlot` | SLOT | — | 임의 콘텐츠 | centerSlot |
+| `trailingContent` | SLOT | — | 임의 콘텐츠 | trailing 슬롯 |
+
+> VARIANT 축은 `size` 하나뿐 — **state(hover/pressed/disabled) variant는 없다** (순수 레이아웃 심볼). 인터랙션은 §7 참조.
+> component description은 위 boolean을 `showLeadingContent`/`showCenterSlot`/`showDescription`/`showTrailingContent`로 서술하나, 기계 property key는 `has*` (Figma 내 표기 혼용).
+> **small의 description 미지원**: small variant(`4404:2`)엔 `descriptionWrapper`·`description` 노드가 **아예 없다**(medium·large만 `visible:false`로 보유).
+
+## 3. Layout (size별) — Figma 실측
+
+단위 iOS `pt`. Figma 인스턴스 `4448:277`(small) / `4448:278`(medium) / `4448:279`(large) / `4448:780`(large+desc) 실측.
+
+| size | minHeight | padding (상하/좌우) | leading (정방형) | 근거 노드 |
+|---|---|---|---|---|
+| small | 40 | 6 / 6 (`p-6`) | 24×24 | `4448:277` |
+| medium | 48 | 6 / 6 (`p-6`) | 24×24 | `4448:278` |
+| large | 52 | 8 / 6 (`px-6 py-8`) | 36×36 | `4448:279` |
+
+- **corner radius**: 전 size **8** (`rounded-[8px]`), `overflow-clip`(masksToBounds).
+- **root gap**: 10 (leading ↔ center ↔ trailing), root `items-center`(세로 중앙 정렬).
+- **centerContent**: `flex-1`, `min-w-px`, `pl-2`(좌측 인셋 2).
+- **titleRow gap**: 4 (label ↔ centerSlot).
+- **leading**: 고정 정방형(위 표). **trailing**: 내용 HUG(고정 크기 없음).
+- **description 있을 때 높이(content-driven)**: large+desc = 8+24+16+8 = 56 (인스턴스 `4448:780` 실측). medium+desc = 6+24+16+6 = 52 (**파생 계산** — Figma에 medium+desc 인스턴스 부재, medium padding·description 높이로 산출). minHeight 초과 시 콘텐츠가 높이 결정.
+
+### Anatomy (전 size 공통 — nest 구조)
+
+```
+_BaseItem (H, items-center, gap 10, radius 8, overflow-clip, padding[size])
+  ├─ leadingContent (고정 정방형 24/24/36)            [optional]
+  ├─ centerContent (V, flex-1, min-w-px, pl 2)
+  │    ├─ titleRow (H, gap 4, items-center)
+  │    │    ├─ label (text/xlarge, 1줄 ellipsis·nowrap)
+  │    │    └─ centerSlot                              [optional]
+  │    └─ descriptionWrapper (H, items-start)          [optional; small 미지원]
+  │         └─ description (caption/medium, wrap)
+  └─ trailingContent (HUG, 중앙)                       [optional]
+```
+
+> description은 전 size 모두 `centerContent` **내부**에 위치(nest). 루트 `items-center`라 leading/trailing은 항목 전체 높이 기준 세로 중앙.
+
+## 4. Color 토큰 (Figma 사용처 기준)
+
+| 위치 | Token (`BCSemanticToken`) | Figma Variable | Raw |
+|---|---|---|---|
+| label 텍스트 | `.textNeutral` | `color/text/neutral` | `rgba(0,0,0,0.85)` |
+| description 텍스트 | `.textNeutralLighter` | `color/text/neutral/lighter` | `rgba(0,0,0,0.4)` |
+
+> `_BaseItem` 기본 상태는 배경 fill 없음(투명). leadingContent/trailingContent는 슬롯이라 색을 강제하지 않는다(소비 측 책임). Figma 플레이스홀더의 accent 색(red/blue/green)은 슬롯 예시일 뿐 SSOT 아님.
+
+## 5. Typography
+
+### Case A — Typography Token 사용 (전부 토큰)
+
+| 위치 | Token (`BTSemanticToken`) | Figma Style |
+|---|---|---|
+| label | `.textXLarge(weight: .regular)` | `Typography/text/xlarge` (Inter Regular, size 16, lineHeight 24, letterSpacing `text/letter-spacing/tight` −0.1) |
+| description | `.captionMedium(weight: .regular)` | `Typography/caption/medium` (Inter Regular, size 12, lineHeight 16, letterSpacing `caption/letter-spacing` 0) |
+
+> 전 size 라벨 단일 타이포(`text/xlarge`) — size별 분기 없음. letter-spacing은 semantic 토큰에 내장.
+
+### Case B — Custom Typography
+
+없음 (모든 텍스트가 토큰 사용).
+
+## 6. State 별 시각 동작 (Figma)
+
+`_BaseItem` 노드에 state variant 없음 — Figma는 **default 레이아웃 1종만** 정의. 시각 상태 정의는 §7(협의) 참조.
+
+## 7. 인터랙션 (Figma `_BaseItem` 외 · 협의 결정)
+
+> ⚠️ 아래는 Figma `_BaseItem` 노드에 **없다**. 출처: design-team `BaseItem.md` §상태 정의(웹 states) + 구현 협의(MOB-6444). SSOT(Figma `_BaseItem`)의 일부가 아니므로 Color/Noise Validator가 "Figma 외"로 보고하는 것이 정상.
+
+| 상태 | 시각/거동 | 값 |
+|---|---|---|
+| default | 배경 없음(투명) | — |
+| pressed | 배경 오버레이 + 콘텐츠 축소 | 배경 `.fillNeutralLighter` / 콘텐츠 scale `0.97` (release 시 `[0.97, 1.004, 1.0]` 오버슈트 복귀) |
+| disabled | 본체 opacity | `BOGlobalToken.disabled` = 0.4 |
+
+- `onTap` 제공 시에만 인터랙티브(pressed 피드백 + 탭). 미제공 시 순수 레이아웃.
+- pressed 배경 매핑 근거: 웹 hover/active 배경 = `fill-neutral-lighter`(design-team spec). 모바일엔 hover 없어 pressed로 매핑.
+- **press scale 피드백**: 콘텐츠(배경 제외)가 눌림 시 `0.97`로 축소, 뗄 때 살짝 오버슈트하며 복귀 (출처: ch-desk-ios `ListItemPressFeedback`). UIKit은 press-in `UIView.animate`(0.10s) + release `CAKeyframeAnimation`(0.40s, `[0.97,1.004,1.0]`), SwiftUI는 `scaleEffect` + spring. **Reduce Motion 시 비활성**.
+
+## 8. 매핑되는 코드 심볼
+
+| 정의 | 파일 |
+|---|---|
+| UIKit 구현 | `BezierBaseItem.swift` (`UIControl`, `BezierComponentable`) |
+| SwiftUI 구현 | `SUBezierBaseItem.swift` (제네릭 슬롯 `<Leading, CenterAccessory, Trailing>`) |
+| size / 상수 / 토큰 매핑 | `BezierBaseItemSpec.swift` (`BezierBaseItemSize`, `BezierBaseItemConstant`) |
+
+> 사용 토큰 실재 확인: `.textNeutral` / `.textNeutralLighter` / `.fillNeutralLighter`(`BCSemanticToken`), `.textXLarge` / `.captionMedium`(`BTSemanticToken`), `BOGlobalToken.disabled`=0.4.
+
+## 9. Figma 참조 노드
+
+- 심볼 세트: `_BaseItem` `4404:11875` (`size=small` 4404:2 / `size=medium` 4404:3 / `size=large` 4404:4)
+- 실측 인스턴스: small `4448:277` / medium `4448:278` / large `4448:279` / large+description `4448:780`

--- a/Sources/BezierSwift/MasterComponent/BezierBaseItem/SUBezierBaseItem.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBaseItem/SUBezierBaseItem.swift
@@ -1,0 +1,212 @@
+//
+//  SUBezierBaseItem.swift
+//  BezierSwift
+//
+
+import SwiftUI
+
+public struct SUBezierBaseItem<Leading: View, CenterSlot: View, Trailing: View>: View, Themeable {
+  @Environment(\.colorScheme) public var colorScheme
+  @Environment(\.isEnabled) private var isEnabled
+
+  private let size: BezierBaseItemSize
+  private let title: String
+  private let itemDescription: String?
+  private let onTap: (() -> Void)?
+  private let leading: Leading
+  private let centerSlot: CenterSlot
+  private let trailing: Trailing
+
+  public init(
+    size: BezierBaseItemSize = .medium,
+    title: String,
+    description: String? = nil,
+    onTap: (() -> Void)? = nil,
+    @ViewBuilder leading: () -> Leading,
+    @ViewBuilder centerSlot: () -> CenterSlot,
+    @ViewBuilder trailing: () -> Trailing
+  ) {
+    self.size = size
+    self.title = title
+    self.itemDescription = description
+    self.onTap = onTap
+    self.leading = leading()
+    self.centerSlot = centerSlot()
+    self.trailing = trailing()
+  }
+
+  public var body: some View {
+    Group {
+      if let onTap = self.onTap {
+        Button(action: onTap) { self.row }
+          .buttonStyle(SUBezierBaseItemStyle(size: self.size))
+      } else {
+        self.row.modifier(SUBezierBaseItemContainer(size: self.size, isPressed: false))
+      }
+    }
+    .opacity(self.isEnabled ? 1 : BezierBaseItemConstant.disabledOpacity)
+    .allowsHitTesting(self.isEnabled)
+  }
+
+  private var row: some View {
+    HStack(spacing: BezierBaseItemConstant.slotSpacing) {
+      self.leadingView
+      self.centerView
+      self.trailingView
+    }
+  }
+
+  @ViewBuilder
+  private var leadingView: some View {
+    if Leading.self != EmptyView.self {
+      self.leading
+        .frame(width: self.size.leadingLength, height: self.size.leadingLength)
+    }
+  }
+
+  private var centerView: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      HStack(spacing: BezierBaseItemConstant.titleRowSpacing) {
+        Text(self.title)
+          .applyBezierFontStyle(
+            BezierBaseItemConstant.titleTypography,
+            semanticColorToken: BezierBaseItemConstant.titleColor
+          )
+          .lineLimit(1)
+          .truncationMode(.tail)
+        self.centerSlotView
+        Spacer(minLength: 0)
+      }
+
+      if self.size != .small, let itemDescription = self.itemDescription {
+        Text(itemDescription)
+          .applyBezierFontStyle(
+            BezierBaseItemConstant.descriptionTypography,
+            semanticColorToken: BezierBaseItemConstant.descriptionColor
+          )
+          .fixedSize(horizontal: false, vertical: true)
+          .frame(maxWidth: .infinity, alignment: .leading)
+      }
+    }
+    .padding(.leading, BezierBaseItemConstant.centerLeadingInset)
+    .frame(maxWidth: .infinity, alignment: .leading)
+  }
+
+  @ViewBuilder
+  private var centerSlotView: some View {
+    if CenterSlot.self != EmptyView.self {
+      self.centerSlot
+    }
+  }
+
+  @ViewBuilder
+  private var trailingView: some View {
+    if Trailing.self != EmptyView.self {
+      self.trailing
+    }
+  }
+}
+
+// MARK: - Convenience init (centerSlot 생략)
+
+extension SUBezierBaseItem where CenterSlot == EmptyView {
+  public init(
+    size: BezierBaseItemSize = .medium,
+    title: String,
+    description: String? = nil,
+    onTap: (() -> Void)? = nil,
+    @ViewBuilder leading: () -> Leading,
+    @ViewBuilder trailing: () -> Trailing
+  ) {
+    self.init(
+      size: size,
+      title: title,
+      description: description,
+      onTap: onTap,
+      leading: leading,
+      centerSlot: { EmptyView() },
+      trailing: trailing
+    )
+  }
+}
+
+// MARK: - Container
+
+private struct SUBezierBaseItemContainer: ViewModifier, Themeable {
+  @Environment(\.colorScheme) var colorScheme
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+  let size: BezierBaseItemSize
+  let isPressed: Bool
+
+  private var contentScale: CGFloat {
+    (self.isPressed && !self.reduceMotion) ? BezierBaseItemConstant.pressScale : 1
+  }
+
+  func body(content: Content) -> some View {
+    content
+      // 콘텐츠만 축소 — 배경은 full-size 유지 (press scale 피드백)
+      .scaleEffect(self.contentScale)
+      .padding(.horizontal, BezierBaseItemConstant.horizontalPadding)
+      .padding(.vertical, self.size.verticalPadding)
+      .frame(minHeight: self.size.minHeight)
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .background(
+        self.isPressed
+          ? self.palette(BezierBaseItemConstant.pressedBackgroundColor)
+          : Color.clear
+      )
+      .clipShape(RoundedRectangle(cornerRadius: BezierBaseItemConstant.cornerRadius))
+      .contentShape(Rectangle())
+      .animation(.spring(response: 0.34, dampingFraction: 0.62), value: self.isPressed)
+  }
+}
+
+// MARK: - ButtonStyle (pressed 배경)
+
+private struct SUBezierBaseItemStyle: ButtonStyle {
+  let size: BezierBaseItemSize
+
+  func makeBody(configuration: Configuration) -> some View {
+    configuration.label
+      .modifier(SUBezierBaseItemContainer(size: self.size, isPressed: configuration.isPressed))
+  }
+}
+
+struct SUBezierBaseItem_Previews: PreviewProvider {
+  static var previews: some View {
+    VStack(spacing: 0) {
+      SUBezierBaseItem(
+        size: .small,
+        title: "Small item",
+        onTap: {},
+        leading: { Circle().fill(Color.gray) },
+        trailing: { EmptyView() }
+      )
+      SUBezierBaseItem(
+        size: .medium,
+        title: "Medium item with description",
+        description: "Secondary description text",
+        onTap: {},
+        leading: { Circle().fill(Color.gray) },
+        trailing: { Image(systemName: "chevron.right") }
+      )
+      SUBezierBaseItem(
+        size: .large,
+        title: "Large item",
+        description: "Two-line description sitting next to a 36pt leading square.",
+        leading: { RoundedRectangle(cornerRadius: 8).fill(Color.gray) },
+        trailing: { EmptyView() }
+      )
+      SUBezierBaseItem(
+        size: .medium,
+        title: "Disabled item",
+        onTap: {},
+        leading: { Circle().fill(Color.gray) },
+        trailing: { EmptyView() }
+      )
+      .disabled(true)
+    }
+    .padding()
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierBaseItem/SUBezierBaseItem.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBaseItem/SUBezierBaseItem.swift
@@ -67,18 +67,20 @@ public struct SUBezierBaseItem<Leading: View, CenterSlot: View, Trailing: View>:
   private var centerView: some View {
     VStack(alignment: .leading, spacing: 0) {
       HStack(spacing: BezierBaseItemConstant.titleRowSpacing) {
-        Text(self.title)
-          .applyBezierFontStyle(
-            BezierBaseItemConstant.titleTypography,
-            semanticColorToken: BezierBaseItemConstant.titleColor
-          )
-          .lineLimit(1)
-          .truncationMode(.tail)
+        if !self.title.isEmpty {
+          Text(self.title)
+            .applyBezierFontStyle(
+              BezierBaseItemConstant.titleTypography,
+              semanticColorToken: BezierBaseItemConstant.titleColor
+            )
+            .lineLimit(1)
+            .truncationMode(.tail)
+        }
         self.centerSlotView
         Spacer(minLength: 0)
       }
 
-      if self.size != .small, let itemDescription = self.itemDescription {
+      if self.size != .small, let itemDescription = self.itemDescription, !itemDescription.isEmpty {
         Text(itemDescription)
           .applyBezierFontStyle(
             BezierBaseItemConstant.descriptionTypography,


### PR DESCRIPTION
## 개요

리스트/메뉴 계열 `*Item`/`*Option` 컴포넌트(SelectOption, DropdownMenuItem, SectionItem 등)가 공유하는 **레이아웃 base 컴포넌트** `BezierBaseItem`을 구현합니다. Web(bezier-react)·Android(bezier-compose)엔 있으나 iOS는 미구현이던 base로, 후속 `*Item` 컴포넌트의 선행 작업입니다.

- Figma: [🚧 Mobile-Components / Base `_BaseItem`](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=4400-213&m=dev)
- Spec: [team-design / bezier-v3 / components / BaseItem.md](https://github.com/channel-io/team-design/blob/main/bezier-v3/components/BaseItem.md)
- Linear: [MOB-6444](https://linear.app/channel/issue/MOB-6444)

## 주요 구현

- **3슬롯 구조**: `leading` / `centerContent(title + description)` / `trailing`
  - SwiftUI: 제네릭 `@ViewBuilder` 슬롯 `<Leading, CenterSlot, Trailing>` (`where CenterSlot == EmptyView` 편의 init)
  - UIKit: `leadingContent` / `centerSlot` / `trailingContent: UIView?` 슬롯 프로퍼티
- **size** `small`(40) / `medium`(48) / `large`(52) — leading 24/24/36, radius 8, gap 10 (Figma 파일 실측 SSOT)
- **description**: medium·large만 지원 (small 미지원, Figma variant에 노드 자체 부재)
- **인터랙션** (`onTap` 제공 시): pressed 배경 `fillNeutralLighter` + **콘텐츠 press-scale**(0.97, release 오버슈트 `[0.97,1.004,1.0]`) + disabled opacity. Reduce Motion 시 scale 비활성
  - press-scale은 `ch-desk-ios`의 `ListItemPressFeedback`을 이식
- Examples 앱 BaseItem 카탈로그 등록 (SwiftUI/UIKit 병렬 프리뷰)

## 검증 (`figma-component-spec` 사이클)

- **Phase 2** SPEC ⊆ Figma 7개 차원 검증(Properties/Layout/Color/Typography/Asset/Noise/ImplRef) ✅
- **Phase 3** 구현 == SPEC UIKit·SwiftUI Validator ✅
- BezierSwift clean build + Examples build ✅, 시뮬레이터 시각 검증 완료

> SSOT 관련: Figma 모바일 파일이 design-team spec md와 일부 수치(radius 8 vs 16 등)에서 충돌 — 스킬 규칙(Figma 파일=SSOT)에 따라 파일 값을 채택.

## 데모

<!-- 스크린샷 · 영상 첨부 -->
<img width="350" alt="baseitem_catalog_medium" src="https://github.com/user-attachments/assets/18cea8a9-545e-4fe5-8d41-ddf8cb0465c0" />
<img width="350" alt="baseitem_pressed" src="https://github.com/user-attachments/assets/71902d2a-73cf-4a1b-ad7d-a538f90f479f" />

https://github.com/user-attachments/assets/a2a72145-302d-42f5-88b4-43d69375252f



🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

- **새로운 기능**
  - SwiftUI와 UIKit에서 사용할 수 있는 `BaseItem` 컴포넌트를 추가했습니다.
  - 작은/중간/큰 크기 지원 및 앞·가운데·뒤 콘텐츠 슬롯 구성.
  - 탭 동작, 비활성화 상태(시각·터치), 눌림 피드백을 제공하며 접근성 “모션 감소” 설정을 반영합니다.
- **예제 및 문서**
  - 컴포넌트 카탈로그에 `BaseItem` 예제를 추가했습니다.
  - 레이아웃/스타일/상호작용 규칙을 정리한 명세 문서를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
