### PR TITLE
[MOB-6455] BezierSection + BezierSectionItem 컴포넌트 구현 (UIKit + SwiftUI)

### DIFF
--- a/Examples/BezierExamples/BezierExamples.xcodeproj/project.pbxproj
+++ b/Examples/BezierExamples/BezierExamples.xcodeproj/project.pbxproj
@@ -583,7 +583,7 @@
 /* Begin XCLocalSwiftPackageReference section */
 		5C7A8DA12FBF2C2F000FA789 /* XCLocalSwiftPackageReference "../../" */ = {
 			isa = XCLocalSwiftPackageReference;
-			relativePath = "../../";
+			relativePath = ../../;
 		};
 /* End XCLocalSwiftPackageReference section */
 

--- a/Examples/BezierExamples/BezierExamples/App/CatalogRegistry.swift
+++ b/Examples/BezierExamples/BezierExamples/App/CatalogRegistry.swift
@@ -113,6 +113,12 @@ enum CatalogRegistry {
       destination: AnyView(SectionCatalog())
     ),
     CatalogItem(
+      id: "section-item",
+      title: "SectionItem",
+      section: .v3Components,
+      destination: AnyView(SectionItemCatalog())
+    ),
+    CatalogItem(
       id: "floating-banner",
       title: "FloatingBanner",
       section: .v3Components,

--- a/Examples/BezierExamples/BezierExamples/App/CatalogRegistry.swift
+++ b/Examples/BezierExamples/BezierExamples/App/CatalogRegistry.swift
@@ -107,6 +107,12 @@ enum CatalogRegistry {
       destination: AnyView(BannerCatalog())
     ),
     CatalogItem(
+      id: "section",
+      title: "Section",
+      section: .v3Components,
+      destination: AnyView(SectionCatalog())
+    ),
+    CatalogItem(
       id: "floating-banner",
       title: "FloatingBanner",
       section: .v3Components,

--- a/Examples/BezierExamples/BezierExamples/Components/SectionCatalog.swift
+++ b/Examples/BezierExamples/BezierExamples/Components/SectionCatalog.swift
@@ -1,0 +1,382 @@
+import SwiftUI
+import UIKit
+import BezierSwift
+
+struct SectionCatalog: View {
+  @State private var variant: BezierSectionVariant = .card
+  @State private var hasLabel = true
+  @State private var labelColor: BezierSectionLabelColor = .neutralDark
+  @State private var rowCount = 3
+
+  private static let rowTitles = ["태그 관리", "고객 노트", "첨부파일", "담당자 지정", "메시지 번역"]
+
+  private var rows: [String] {
+    Array(Self.rowTitles.prefix(self.rowCount))
+  }
+
+  var body: some View {
+    CatalogScreen(title: "Section") {
+      self.controls
+      CatalogSection(.swiftUI) { self.swiftUIPreview }
+      CatalogSection(.uiKit) {
+        self.uiKitStaticPreview
+        self.uiKitCompositionalPreview
+      }
+    }
+  }
+
+  private var controls: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Picker("variant", selection: self.$variant) {
+        ForEach(BezierSectionVariant.allCases, id: \.self) { variant in
+          Text(self.variantLabel(variant)).tag(variant)
+        }
+      }
+      .pickerStyle(.segmented)
+
+      Picker("labelColor", selection: self.$labelColor) {
+        ForEach(BezierSectionLabelColor.allCases, id: \.self) { color in
+          Text(self.labelColorLabel(color)).tag(color)
+        }
+      }
+      .pickerStyle(.segmented)
+
+      Toggle("hasLabel", isOn: self.$hasLabel)
+
+      Stepper("rows: \(self.rowCount)", value: self.$rowCount, in: 1...Self.rowTitles.count)
+    }
+    .font(.caption)
+  }
+
+  // MARK: - SwiftUI
+
+  private var swiftUIPreview: some View {
+    VStack(alignment: .leading, spacing: 16) {
+      SUBezierSection(
+        self.rows,
+        id: \.self,
+        variant: self.variant,
+        labelText: self.hasLabel ? "고객 정보" : nil,
+        labelColor: self.labelColor
+      ) { title in
+        self.swiftUIRow(title)
+      }
+
+      Text("labelTrailing 슬롯")
+        .font(.caption2)
+        .foregroundStyle(.secondary)
+
+      SUBezierSection(
+        self.rows,
+        id: \.self,
+        variant: self.variant,
+        labelText: self.hasLabel ? "첨부파일" : nil,
+        labelColor: self.labelColor,
+        labelTrailing: {
+          BezierIcon.plus.image
+            .renderingMode(.template)
+            .resizable()
+            .scaledToFit()
+            .frame(width: 16, height: 16)
+            .foregroundColor(.secondary)
+        }
+      ) { title in
+        self.swiftUIRow(title)
+      }
+    }
+  }
+
+  private func swiftUIRow(_ title: String) -> some View {
+    SUBezierBaseItem(
+      title: title,
+      onTap: {},
+      leading: {
+        BezierIcon.personCircle.image
+          .renderingMode(.template)
+          .resizable()
+          .scaledToFit()
+          .foregroundColor(.secondary)
+      },
+      trailing: {
+        BezierIcon.chevronSmallRight.image
+          .renderingMode(.template)
+          .resizable()
+          .scaledToFit()
+          .frame(width: 20, height: 20)
+          .foregroundColor(.secondary)
+      }
+    )
+  }
+
+  // MARK: - UIKit
+
+  private var uiKitStaticPreview: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Text("BezierSection (정적 컨테이너)")
+        .font(.caption2)
+        .foregroundStyle(.secondary)
+
+      SectionStaticRepresentable(
+        variant: self.variant,
+        hasLabel: self.hasLabel,
+        labelColor: self.labelColor,
+        rows: self.rows
+      )
+    }
+  }
+
+  private var uiKitCompositionalPreview: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Text("UICollectionViewCompositionalLayout (BezierSectionLayout)")
+        .font(.caption2)
+        .foregroundStyle(.secondary)
+
+      SectionCompositionalRepresentable(
+        variant: self.variant,
+        hasLabel: self.hasLabel,
+        labelColor: self.labelColor,
+        rows: self.rows
+      )
+      .frame(height: 500)
+    }
+  }
+
+  private func variantLabel(_ variant: BezierSectionVariant) -> String {
+    switch variant {
+    case .solid: return "solid"
+    case .card: return "card"
+    }
+  }
+
+  private func labelColorLabel(_ color: BezierSectionLabelColor) -> String {
+    switch color {
+    case .neutralDark: return "neutralDark"
+    case .neutralLight: return "neutralLight"
+    }
+  }
+}
+
+// MARK: - 정적 컨테이너 Representable
+
+private struct SectionStaticRepresentable: UIViewRepresentable {
+  let variant: BezierSectionVariant
+  let hasLabel: Bool
+  let labelColor: BezierSectionLabelColor
+  let rows: [String]
+
+  func makeUIView(context: Context) -> UIView {
+    let wrapper = UIView()
+    let section = BezierSection()
+    self.apply(to: section)
+    wrapper.addSubview(section)
+    NSLayoutConstraint.activate([
+      section.topAnchor.constraint(equalTo: wrapper.topAnchor),
+      section.leadingAnchor.constraint(equalTo: wrapper.leadingAnchor),
+      section.trailingAnchor.constraint(equalTo: wrapper.trailingAnchor),
+      section.bottomAnchor.constraint(equalTo: wrapper.bottomAnchor),
+    ])
+    return wrapper
+  }
+
+  func updateUIView(_ wrapper: UIView, context: Context) {
+    guard let section = wrapper.subviews.first as? BezierSection else { return }
+    self.apply(to: section)
+  }
+
+  func sizeThatFits(_ proposal: ProposedViewSize, uiView: UIView, context: Context) -> CGSize? {
+    let width = proposal.width ?? 320
+    let fitting = uiView.systemLayoutSizeFitting(
+      CGSize(width: width, height: UIView.layoutFittingCompressedSize.height),
+      withHorizontalFittingPriority: .required,
+      verticalFittingPriority: .fittingSizeLevel
+    )
+    return CGSize(width: width, height: fitting.height)
+  }
+
+  private func apply(to section: BezierSection) {
+    section.variant = self.variant
+    section.labelText = self.hasLabel ? "고객 정보" : nil
+    section.labelColor = self.labelColor
+
+    if section.items.count != self.rows.count {
+      section.setItems(self.rows.map(Self.makeRow))
+    } else {
+      for case let (row, title) in zip(section.items, self.rows) {
+        (row as? BezierBaseItem)?.title = title
+      }
+    }
+  }
+
+  private static func makeRow(_ title: String) -> BezierBaseItem {
+    let item = BezierBaseItem(title: title, onTap: {})
+    let imageView = UIImageView(
+      image: BezierIcon.personCircle.uiImage?.withRenderingMode(.alwaysTemplate)
+    )
+    imageView.contentMode = .scaleAspectFit
+    imageView.tintColor = .secondaryLabel
+    item.leadingContent = imageView
+    return item
+  }
+}
+
+// MARK: - 컴포지셔널 레이아웃 Representable
+
+private struct SectionCompositionalRepresentable: UIViewRepresentable {
+  let variant: BezierSectionVariant
+  let hasLabel: Bool
+  let labelColor: BezierSectionLabelColor
+  let rows: [String]
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator()
+  }
+
+  func makeUIView(context: Context) -> UICollectionView {
+    let coordinator = context.coordinator
+    coordinator.apply(self)
+
+    let configuration = UICollectionViewCompositionalLayoutConfiguration()
+    configuration.interSectionSpacing = 24
+    let layout = UICollectionViewCompositionalLayout(
+      sectionProvider: { [weak coordinator] sectionIndex, layoutEnvironment in
+        guard let coordinator else { return nil }
+        return BezierSectionLayout.makeSection(
+          variant: coordinator.variant(at: sectionIndex),
+          numberOfItems: coordinator.rows.count,
+          showsLabel: coordinator.hasLabel,
+          layoutEnvironment: layoutEnvironment
+        )
+      },
+      configuration: configuration
+    )
+    BezierSectionLayout.register(in: layout)
+
+    let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+    collectionView.backgroundColor = .clear
+    collectionView.dataSource = coordinator
+    return collectionView
+  }
+
+  func updateUIView(_ collectionView: UICollectionView, context: Context) {
+    context.coordinator.apply(self)
+    collectionView.reloadData()
+    collectionView.collectionViewLayout.invalidateLayout()
+  }
+
+  final class Coordinator: NSObject, UICollectionViewDataSource {
+    private(set) var selectedVariant: BezierSectionVariant = .card
+    private(set) var hasLabel = true
+    private(set) var labelColor: BezierSectionLabelColor = .neutralDark
+    private(set) var rows: [String] = []
+
+    private let cellRegistration = UICollectionView.CellRegistration<
+      SectionDemoListCell, String
+    > { cell, _, title in
+      cell.configure(title: title)
+    }
+
+    // registration을 dequeue 콜백 안에서 처음 생성(lazy)하면 UIKit이 예외를 던지므로 init에서 미리 만든다.
+    private var headerRegistration: UICollectionView.SupplementaryRegistration<BezierSectionLabelReusableView>!
+
+    override init() {
+      super.init()
+      self.headerRegistration = UICollectionView.SupplementaryRegistration<
+        BezierSectionLabelReusableView
+      >(elementKind: BezierSectionLayout.labelElementKind) { [weak self] supplementaryView, _, indexPath in
+        guard let self else { return }
+        supplementaryView.sectionLabel.text = self.variant(at: indexPath.section) == .card
+          ? "card 섹션"
+          : "solid 섹션"
+        supplementaryView.sectionLabel.color = self.labelColor
+      }
+    }
+
+    func apply(_ representable: SectionCompositionalRepresentable) {
+      self.selectedVariant = representable.variant
+      self.hasLabel = representable.hasLabel
+      self.labelColor = representable.labelColor
+      self.rows = representable.rows
+    }
+
+    func variant(at sectionIndex: Int) -> BezierSectionVariant {
+      sectionIndex == 0 ? self.selectedVariant : self.oppositeVariant
+    }
+
+    private var oppositeVariant: BezierSectionVariant {
+      self.selectedVariant == .card ? .solid : .card
+    }
+
+    func numberOfSections(in collectionView: UICollectionView) -> Int { 2 }
+
+    func collectionView(
+      _ collectionView: UICollectionView,
+      numberOfItemsInSection section: Int
+    ) -> Int {
+      self.rows.count
+    }
+
+    func collectionView(
+      _ collectionView: UICollectionView,
+      cellForItemAt indexPath: IndexPath
+    ) -> UICollectionViewCell {
+      collectionView.dequeueConfiguredReusableCell(
+        using: self.cellRegistration,
+        for: indexPath,
+        item: self.rows[indexPath.item]
+      )
+    }
+
+    func collectionView(
+      _ collectionView: UICollectionView,
+      viewForSupplementaryElementOfKind kind: String,
+      at indexPath: IndexPath
+    ) -> UICollectionReusableView {
+      collectionView.dequeueConfiguredReusableSupplementary(
+        using: self.headerRegistration,
+        for: indexPath
+      )
+    }
+  }
+}
+
+private final class SectionDemoListCell: UICollectionViewListCell {
+  private let item = BezierBaseItem(title: "")
+
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    self.setUp()
+  }
+
+  required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    self.setUp()
+  }
+
+  private func setUp() {
+    self.backgroundConfiguration = UIBackgroundConfiguration.clear()
+
+    let imageView = UIImageView(
+      image: BezierIcon.personCircle.uiImage?.withRenderingMode(.alwaysTemplate)
+    )
+    imageView.contentMode = .scaleAspectFit
+    imageView.tintColor = .secondaryLabel
+    self.item.leadingContent = imageView
+
+    self.contentView.addSubview(self.item)
+    NSLayoutConstraint.activate([
+      self.item.topAnchor.constraint(equalTo: self.contentView.topAnchor),
+      self.item.leadingAnchor.constraint(equalTo: self.contentView.leadingAnchor),
+      self.item.trailingAnchor.constraint(equalTo: self.contentView.trailingAnchor),
+      self.item.bottomAnchor.constraint(equalTo: self.contentView.bottomAnchor),
+
+      // separatorLayoutGuide 기본값은 텍스트 기준 자동 정렬이라
+      // BezierSectionLayout이 지정한 divider 인셋이 그대로 적용되도록 셀 전체 폭에 고정한다.
+      self.separatorLayoutGuide.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+      self.separatorLayoutGuide.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+    ])
+  }
+
+  func configure(title: String) {
+    self.item.title = title
+  }
+}

--- a/Examples/BezierExamples/BezierExamples/Components/SectionItemCatalog.swift
+++ b/Examples/BezierExamples/BezierExamples/Components/SectionItemCatalog.swift
@@ -1,0 +1,281 @@
+import SwiftUI
+import UIKit
+import BezierSwift
+
+struct SectionItemCatalog: View {
+  private enum LeadingKind: String, CaseIterable {
+    case none
+    case icon
+    case avatar
+    case custom
+  }
+
+  private enum AccessoryKind: String, CaseIterable {
+    case none
+    case navigation
+    case outlink
+    case select
+    case multiselect
+    case display
+    case toggle
+    case custom
+  }
+
+  @State private var size: BezierSectionItemSize = .medium
+  @State private var leadingKind: LeadingKind = .icon
+  @State private var accessoryKind: AccessoryKind = .navigation
+  @State private var hasDescription = false
+  @State private var isDestructive = false
+  @State private var isEnabled = true
+  @State private var isToggleOn = true
+
+  var body: some View {
+    CatalogScreen(title: "SectionItem") {
+      self.controls
+      CatalogSection(.swiftUI) { self.swiftUIPreview }
+      CatalogSection(.uiKit) { self.uiKitPreview }
+    }
+  }
+
+  private var controls: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Picker("size", selection: self.$size) {
+        ForEach(BezierSectionItemSize.allCases, id: \.self) { size in
+          Text(self.sizeLabel(size)).tag(size)
+        }
+      }
+      .pickerStyle(.segmented)
+
+      Picker("leading", selection: self.$leadingKind) {
+        ForEach(LeadingKind.allCases, id: \.self) { kind in
+          Text(kind.rawValue).tag(kind)
+        }
+      }
+      .pickerStyle(.segmented)
+
+      HStack {
+        Text("accessory")
+        Spacer()
+        Picker("accessory", selection: self.$accessoryKind) {
+          ForEach(AccessoryKind.allCases, id: \.self) { kind in
+            Text(kind.rawValue).tag(kind)
+          }
+        }
+        .pickerStyle(.menu)
+      }
+
+      Toggle("hasDescription", isOn: self.$hasDescription)
+      Toggle("isDestructive", isOn: self.$isDestructive)
+      Toggle("isEnabled", isOn: self.$isEnabled)
+      if self.accessoryKind == .toggle {
+        Toggle("toggle isOn", isOn: self.$isToggleOn)
+      }
+    }
+    .font(.caption)
+  }
+
+  // MARK: - SwiftUI
+
+  private var swiftUIPreview: some View {
+    VStack(alignment: .leading, spacing: 16) {
+      SUBezierSectionItem(
+        size: self.size,
+        content: "단일 아이템",
+        description: self.hasDescription ? "보조 설명 텍스트입니다. 기본은 줄바꿈으로 이어집니다." : nil,
+        leading: self.swiftUILeading,
+        accessory: self.swiftUIAccessory,
+        isDestructive: self.isDestructive,
+        onTap: {}
+      )
+      .disabled(!self.isEnabled)
+
+      SUBezierSectionItem(
+        size: self.size,
+        content: "centerSlot 데모",
+        onTap: {},
+        centerSlot: {
+          Circle().fill(Color.red).frame(width: 6, height: 6)
+        }
+      )
+
+      SUBezierSectionItem(
+        size: self.size,
+        content: "",
+        leading: .custom(AnyView(RoundedRectangle(cornerRadius: 4).fill(Color.orange.opacity(0.6)))),
+        customCenterContent: AnyView(
+          HStack(spacing: 4) {
+            Text("커스텀 센터")
+            Text("BETA").font(.caption2).foregroundStyle(.secondary)
+          }
+        ),
+        onTap: {}
+      )
+
+      Text("SUBezierSection(card) 조합")
+        .font(.caption2)
+        .foregroundStyle(.secondary)
+
+      SUBezierSection(
+        ["태그 관리", "고객 노트", "첨부파일"],
+        id: \.self,
+        variant: .card,
+        labelText: "고객 정보"
+      ) { title in
+        SUBezierSectionItem(
+          size: self.size,
+          content: title,
+          description: self.hasDescription ? "보조 설명" : nil,
+          leading: self.swiftUILeading,
+          accessory: self.swiftUIAccessory,
+          isDestructive: self.isDestructive,
+          onTap: {}
+        )
+      }
+    }
+  }
+
+  private var swiftUILeading: BezierSectionItemLeading<AnyView> {
+    switch self.leadingKind {
+    case .none:
+      return .none
+    case .icon:
+      return .icon(.personCircle)
+    case .avatar:
+      return .avatar(AnyView(Circle().fill(Color.gray.opacity(0.4))))
+    case .custom:
+      return .custom(AnyView(RoundedRectangle(cornerRadius: 4).fill(Color.orange.opacity(0.6))))
+    }
+  }
+
+  private var swiftUIAccessory: BezierSectionItemAccessory<AnyView>? {
+    switch self.accessoryKind {
+    case .none: return nil
+    case .navigation: return .navigation
+    case .outlink: return .outlink
+    case .select: return .select(value: "한국어")
+    case .multiselect: return .multiselect(values: ["운영", "개발"])
+    case .display: return .display(value: "값")
+    case .toggle: return .toggle(isOn: self.isToggleOn)
+    case .custom:
+      return .custom(
+        AnyView(
+          Text("커스텀")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        )
+      )
+    }
+  }
+
+  // MARK: - UIKit
+
+  private var uiKitPreview: some View {
+    SectionItemUIKitRepresentable(
+      size: self.size,
+      leadingKind: self.leadingKind.rawValue,
+      accessoryKind: self.accessoryKind.rawValue,
+      hasDescription: self.hasDescription,
+      isDestructive: self.isDestructive,
+      isEnabled: self.isEnabled,
+      isToggleOn: self.isToggleOn
+    )
+  }
+
+  private func sizeLabel(_ size: BezierSectionItemSize) -> String {
+    switch size {
+    case .small: return "small"
+    case .medium: return "medium"
+    case .large: return "large"
+    }
+  }
+}
+
+private struct SectionItemUIKitRepresentable: UIViewRepresentable {
+  let size: BezierSectionItemSize
+  let leadingKind: String
+  let accessoryKind: String
+  let hasDescription: Bool
+  let isDestructive: Bool
+  let isEnabled: Bool
+  let isToggleOn: Bool
+
+  func makeUIView(context: Context) -> UIView {
+    let wrapper = UIView()
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    stackView.spacing = 0
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    wrapper.addSubview(stackView)
+    NSLayoutConstraint.activate([
+      stackView.leadingAnchor.constraint(equalTo: wrapper.leadingAnchor),
+      stackView.trailingAnchor.constraint(equalTo: wrapper.trailingAnchor),
+      stackView.topAnchor.constraint(equalTo: wrapper.topAnchor),
+      stackView.bottomAnchor.constraint(equalTo: wrapper.bottomAnchor),
+    ])
+
+    ["단일 아이템", "두 번째 아이템"].forEach { title in
+      stackView.addArrangedSubview(BezierSectionItem(content: title, onTap: {}))
+    }
+    return wrapper
+  }
+
+  func updateUIView(_ wrapper: UIView, context: Context) {
+    guard let stackView = wrapper.subviews.first as? UIStackView else { return }
+    for case let item as BezierSectionItem in stackView.arrangedSubviews {
+      item.size = self.size
+      item.itemDescription = self.hasDescription ? "보조 설명 텍스트입니다." : nil
+      item.leading = self.uiKitLeading
+      item.accessory = self.uiKitAccessory
+      item.isDestructive = self.isDestructive
+      item.isEnabled = self.isEnabled
+    }
+  }
+
+  func sizeThatFits(_ proposal: ProposedViewSize, uiView: UIView, context: Context) -> CGSize? {
+    let width = proposal.width ?? 320
+    let fitting = uiView.systemLayoutSizeFitting(
+      CGSize(width: width, height: UIView.layoutFittingCompressedSize.height),
+      withHorizontalFittingPriority: .required,
+      verticalFittingPriority: .fittingSizeLevel
+    )
+    return CGSize(width: width, height: fitting.height)
+  }
+
+  private var uiKitLeading: BezierSectionItemLeading<UIView> {
+    switch self.leadingKind {
+    case "icon":
+      return .icon(.personCircle)
+    case "avatar":
+      let view = UIView()
+      view.backgroundColor = .systemGray3
+      view.layer.cornerRadius = 10
+      return .avatar(view)
+    case "custom":
+      let view = UIView()
+      view.backgroundColor = .systemOrange.withAlphaComponent(0.6)
+      view.layer.cornerRadius = 4
+      return .custom(view)
+    default:
+      return .none
+    }
+  }
+
+  private var uiKitAccessory: BezierSectionItemAccessory<UIView>? {
+    switch self.accessoryKind {
+    case "navigation": return .navigation
+    case "outlink": return .outlink
+    case "select": return .select(value: "한국어")
+    case "multiselect": return .multiselect(values: ["운영", "개발"])
+    case "display": return .display(value: "값")
+    case "toggle": return .toggle(isOn: self.isToggleOn)
+    case "custom":
+      let label = UILabel()
+      label.text = "커스텀"
+      label.font = .preferredFont(forTextStyle: .caption1)
+      label.textColor = .secondaryLabel
+      return .custom(label)
+    default:
+      return nil
+    }
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierSection/BezierSection.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierSection/BezierSection.swift
@@ -1,0 +1,197 @@
+//
+//  BezierSection.swift
+//  BezierSwift
+//
+
+import UIKit
+
+public final class BezierSection: UIView, BezierComponentable {
+  // MARK: - BezierComponentable
+
+  public var colorTheme: BezierColorTheme { .systemBezierColorTheme() }
+  public var componentTheme: BezierComponentTheme = .normal {
+    didSet { self.refreshAppearance() }
+  }
+
+  // MARK: - Public Properties
+
+  public var variant: BezierSectionVariant = .solid {
+    didSet { if oldValue != self.variant { self.refreshVariant() } }
+  }
+
+  public var labelText: String? {
+    didSet { if oldValue != self.labelText { self.refreshLabel() } }
+  }
+
+  public var labelColor: BezierSectionLabelColor = .neutralDark {
+    didSet { if oldValue != self.labelColor { self.sectionLabel.color = self.labelColor } }
+  }
+
+  public var labelLeadingContent: UIView? {
+    didSet { self.sectionLabel.leadingContent = self.labelLeadingContent }
+  }
+
+  public var labelTrailingContent: UIView? {
+    didSet { self.sectionLabel.trailingContent = self.labelTrailingContent }
+  }
+
+  public private(set) var items: [UIView] = []
+
+  // MARK: - Subviews
+
+  private let rootStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    stackView.alignment = .fill
+    stackView.distribution = .fill
+    stackView.spacing = BezierSectionConstant.labelToContentSpacing
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    return stackView
+  }()
+
+  private let sectionLabel = BezierSectionLabel(text: "")
+
+  private let chromeView: UIView = {
+    let view = UIView()
+    view.layer.masksToBounds = true
+    view.insetsLayoutMarginsFromSafeArea = false
+    return view
+  }()
+
+  private let itemsStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    stackView.alignment = .fill
+    stackView.distribution = .fill
+    stackView.spacing = 0
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    return stackView
+  }()
+
+  // MARK: - Init
+
+  public init(
+    variant: BezierSectionVariant = .solid,
+    labelText: String? = nil,
+    labelColor: BezierSectionLabelColor = .neutralDark,
+    items: [UIView] = []
+  ) {
+    self.variant = variant
+    self.labelText = labelText
+    self.labelColor = labelColor
+    self.items = items
+    super.init(frame: .zero)
+    self.setUp()
+  }
+
+  public required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    self.setUp()
+  }
+
+  // MARK: - Setup
+
+  private func setUp() {
+    self.translatesAutoresizingMaskIntoConstraints = false
+
+    self.chromeView.addSubview(self.itemsStackView)
+    let chromeMargins = self.chromeView.layoutMarginsGuide
+    NSLayoutConstraint.activate([
+      self.itemsStackView.topAnchor.constraint(equalTo: chromeMargins.topAnchor),
+      self.itemsStackView.leadingAnchor.constraint(equalTo: chromeMargins.leadingAnchor),
+      self.itemsStackView.trailingAnchor.constraint(equalTo: chromeMargins.trailingAnchor),
+      self.itemsStackView.bottomAnchor.constraint(equalTo: chromeMargins.bottomAnchor),
+    ])
+
+    self.rootStackView.addArrangedSubview(self.sectionLabel)
+    self.rootStackView.addArrangedSubview(self.chromeView)
+    self.addSubview(self.rootStackView)
+    NSLayoutConstraint.activate([
+      self.rootStackView.topAnchor.constraint(equalTo: self.topAnchor),
+      self.rootStackView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+      self.rootStackView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+      self.rootStackView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+    ])
+
+    self.sectionLabel.color = self.labelColor
+    self.refreshLabel()
+    self.refreshVariant()
+  }
+
+  // MARK: - Items
+
+  public func setItems(_ items: [UIView]) {
+    self.items = items
+    self.rebuildRows()
+  }
+
+  public func addItem(_ item: UIView) {
+    self.items.append(item)
+    self.rebuildRows()
+  }
+
+  // MARK: - Trait
+
+  public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    self.refreshAppearance()
+  }
+
+  // MARK: - Refresh
+
+  private func refreshVariant() {
+    let contentInsets = self.variant.appearance.contentInsets
+    self.chromeView.directionalLayoutMargins = NSDirectionalEdgeInsets(
+      top: contentInsets.top,
+      leading: contentInsets.leading,
+      bottom: contentInsets.bottom,
+      trailing: contentInsets.trailing
+    )
+    self.rebuildRows()
+    self.refreshAppearance()
+  }
+
+  private func refreshLabel() {
+    if let labelText = self.labelText {
+      self.sectionLabel.text = labelText
+      self.sectionLabel.isHidden = false
+    } else {
+      self.sectionLabel.text = ""
+      self.sectionLabel.isHidden = true
+    }
+  }
+
+  private func rebuildRows() {
+    self.itemsStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+
+    let divider = self.variant.appearance.divider
+    for (index, item) in self.items.enumerated() {
+      self.itemsStackView.addArrangedSubview(item)
+
+      if let divider, index < self.items.count - 1 {
+        let dividerView = BezierSectionRowDivider()
+        dividerView.apply(divider)
+        self.itemsStackView.addArrangedSubview(dividerView)
+      }
+    }
+  }
+
+  private func refreshAppearance() {
+    let appearance = self.variant.appearance
+
+    if let backgroundColor = appearance.backgroundColor {
+      self.chromeView.backgroundColor = backgroundColor.palette(self)
+    } else {
+      self.chromeView.backgroundColor = .clear
+    }
+    self.chromeView.layer.cornerRadius = appearance.cornerRadius
+
+    if let border = appearance.border {
+      self.chromeView.layer.borderWidth = border.width
+      self.chromeView.layer.borderColor = border.color.palette(self).cgColor
+    } else {
+      self.chromeView.layer.borderWidth = 0
+      self.chromeView.layer.borderColor = nil
+    }
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierSection/BezierSection.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierSection/BezierSection.swift
@@ -10,7 +10,13 @@ public final class BezierSection: UIView, BezierComponentable {
 
   public var colorTheme: BezierColorTheme { .systemBezierColorTheme() }
   public var componentTheme: BezierComponentTheme = .normal {
-    didSet { self.refreshAppearance() }
+    didSet {
+      self.sectionLabel.componentTheme = self.componentTheme
+      self.itemsStackView.arrangedSubviews
+        .compactMap { $0 as? BezierSectionRowDivider }
+        .forEach { $0.componentTheme = self.componentTheme }
+      self.refreshAppearance()
+    }
   }
 
   // MARK: - Public Properties
@@ -170,6 +176,7 @@ public final class BezierSection: UIView, BezierComponentable {
 
       if let divider, index < self.items.count - 1 {
         let dividerView = BezierSectionRowDivider()
+        dividerView.componentTheme = self.componentTheme
         dividerView.apply(divider)
         self.itemsStackView.addArrangedSubview(dividerView)
       }

--- a/Sources/BezierSwift/MasterComponent/BezierSection/BezierSectionLabel.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierSection/BezierSectionLabel.swift
@@ -1,0 +1,185 @@
+//
+//  BezierSectionLabel.swift
+//  BezierSwift
+//
+
+import UIKit
+
+public final class BezierSectionLabel: UIView, BezierComponentable {
+  // MARK: - BezierComponentable
+
+  public var colorTheme: BezierColorTheme { .systemBezierColorTheme() }
+  public var componentTheme: BezierComponentTheme = .normal {
+    didSet { self.refreshAppearance() }
+  }
+
+  // MARK: - Public Properties
+
+  public var text: String = "" {
+    didSet { if oldValue != self.text { self.refreshText() } }
+  }
+
+  public var color: BezierSectionLabelColor = .neutralDark {
+    didSet { if oldValue != self.color { self.refreshText() } }
+  }
+
+  public var leadingContent: UIView? {
+    didSet { self.updateSlot(container: self.leadingContainer, old: oldValue, new: self.leadingContent) }
+  }
+
+  public var trailingContent: UIView? {
+    didSet { self.updateSlot(container: self.trailingContainer, old: oldValue, new: self.trailingContent) }
+  }
+
+  // MARK: - Subviews
+
+  private let rootStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .horizontal
+    stackView.alignment = .center
+    stackView.distribution = .fill
+    stackView.spacing = BezierSectionConstant.labelTrailingSpacing
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    return stackView
+  }()
+
+  private let leadingCenterStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .horizontal
+    stackView.alignment = .center
+    stackView.distribution = .fill
+    stackView.spacing = BezierSectionConstant.labelLeadingSpacing
+    return stackView
+  }()
+
+  private let leadingContainer = UIView()
+
+  private let textLabel: UILabel = {
+    let label = UILabel()
+    label.numberOfLines = 1
+    return label
+  }()
+
+  private let trailingContainer = UIView()
+
+  // MARK: - Init
+
+  public init(text: String, color: BezierSectionLabelColor = .neutralDark) {
+    self.text = text
+    self.color = color
+    super.init(frame: .zero)
+    self.setUp()
+  }
+
+  public required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    self.setUp()
+  }
+
+  // MARK: - Setup
+
+  private func setUp() {
+    self.translatesAutoresizingMaskIntoConstraints = false
+    self.layer.cornerRadius = BezierSectionConstant.labelCornerRadius
+    self.layer.masksToBounds = true
+    self.directionalLayoutMargins = NSDirectionalEdgeInsets(
+      top: 0,
+      leading: BezierSectionConstant.labelHorizontalPadding,
+      bottom: 0,
+      trailing: BezierSectionConstant.labelHorizontalPadding
+    )
+
+    let expandingPriority = UILayoutPriority(1)
+    self.leadingCenterStackView.setContentHuggingPriority(expandingPriority, for: .horizontal)
+    self.leadingCenterStackView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+    self.textLabel.setContentHuggingPriority(expandingPriority, for: .horizontal)
+    self.textLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+    self.leadingContainer.setContentHuggingPriority(.required, for: .horizontal)
+    self.leadingContainer.setContentCompressionResistancePriority(.required, for: .horizontal)
+    self.trailingContainer.setContentHuggingPriority(.required, for: .horizontal)
+    self.trailingContainer.setContentCompressionResistancePriority(.required, for: .horizontal)
+
+    self.leadingContainer.isHidden = true
+    self.trailingContainer.isHidden = true
+
+    self.leadingCenterStackView.addArrangedSubview(self.leadingContainer)
+    self.leadingCenterStackView.addArrangedSubview(self.textLabel)
+    self.rootStackView.addArrangedSubview(self.leadingCenterStackView)
+    self.rootStackView.addArrangedSubview(self.trailingContainer)
+    self.addSubview(self.rootStackView)
+
+    let margins = self.layoutMarginsGuide
+    NSLayoutConstraint.activate([
+      self.rootStackView.leadingAnchor.constraint(equalTo: margins.leadingAnchor),
+      self.rootStackView.trailingAnchor.constraint(equalTo: margins.trailingAnchor),
+      self.rootStackView.topAnchor.constraint(greaterThanOrEqualTo: self.topAnchor),
+      self.rootStackView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+      self.heightAnchor.constraint(greaterThanOrEqualToConstant: BezierSectionConstant.labelHeight),
+      self.leadingContainer.widthAnchor.constraint(
+        equalToConstant: BezierSectionConstant.labelLeadingContentLength
+      ),
+      self.leadingContainer.heightAnchor.constraint(
+        equalToConstant: BezierSectionConstant.labelLeadingContentLength
+      ),
+      self.trailingContainer.heightAnchor.constraint(
+        equalToConstant: BezierSectionConstant.labelTrailingContentHeight
+      ),
+    ])
+
+    self.refreshText()
+  }
+
+  // MARK: - Layout
+
+  public override var intrinsicContentSize: CGSize {
+    CGSize(width: UIView.noIntrinsicMetric, height: BezierSectionConstant.labelHeight)
+  }
+
+  // MARK: - Slot
+
+  private func updateSlot(container: UIView, old: UIView?, new: UIView?) {
+    old?.removeFromSuperview()
+    guard let new else {
+      container.isHidden = true
+      return
+    }
+    new.translatesAutoresizingMaskIntoConstraints = false
+    container.addSubview(new)
+    NSLayoutConstraint.activate([
+      new.topAnchor.constraint(equalTo: container.topAnchor),
+      new.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+      new.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+      new.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+    ])
+    container.isHidden = false
+  }
+
+  // MARK: - Trait
+
+  public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    self.refreshAppearance()
+  }
+
+  // MARK: - Refresh
+
+  private func refreshAppearance() {
+    self.refreshText()
+  }
+
+  private func refreshText() {
+    if !self.text.isEmpty {
+      self.textLabel.attributedText = BezierSectionConstant.labelTypography.attributedString(
+        self,
+        text: self.text,
+        semanticColorToken: self.color.textColor,
+        alignment: .left,
+        lineBreakMode: .byTruncatingTail
+      )
+      self.textLabel.isHidden = false
+    } else {
+      self.textLabel.attributedText = nil
+      self.textLabel.isHidden = true
+    }
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierSection/BezierSectionLayout.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierSection/BezierSectionLayout.swift
@@ -1,0 +1,223 @@
+//
+//  BezierSectionLayout.swift
+//  BezierSwift
+//
+
+import UIKit
+
+// MARK: - Decoration Element Kind
+
+extension BezierSectionVariant {
+  var decorationElementKind: String {
+    switch self {
+    case .solid: return "BezierSectionLayout.background.solid"
+    case .card: return "BezierSectionLayout.background.card"
+    }
+  }
+
+  init?(decorationElementKind: String) {
+    guard let variant = Self.allCases.first(
+      where: { $0.decorationElementKind == decorationElementKind }
+    ) else { return nil }
+    self = variant
+  }
+}
+
+// MARK: - Layout Builder
+
+public enum BezierSectionLayout {
+  public static let labelElementKind = "BezierSectionLayout.label"
+
+  public static func register(in layout: UICollectionViewCompositionalLayout) {
+    for variant in BezierSectionVariant.allCases {
+      layout.register(
+        BezierSectionBackgroundView.self,
+        forDecorationViewOfKind: variant.decorationElementKind
+      )
+    }
+  }
+
+  public static func makeSection(
+    variant: BezierSectionVariant,
+    numberOfItems: Int,
+    showsLabel: Bool = false,
+    layoutEnvironment: NSCollectionLayoutEnvironment
+  ) -> NSCollectionLayoutSection {
+    let appearance = variant.appearance
+
+    var configuration = UICollectionLayoutListConfiguration(appearance: .plain)
+    configuration.backgroundColor = .clear
+    configuration.showsSeparators = appearance.divider != nil
+
+    if let divider = appearance.divider {
+      var separatorConfiguration = UIListSeparatorConfiguration(listAppearance: .plain)
+      separatorConfiguration.color = UIColor { traitCollection in
+        traitCollection.userInterfaceStyle == .dark
+          ? divider.color.dark.uiColor
+          : divider.color.light.uiColor
+      }
+      separatorConfiguration.bottomSeparatorInsets = NSDirectionalEdgeInsets(
+        top: 0,
+        leading: divider.leadingInset,
+        bottom: 0,
+        trailing: divider.trailingInset
+      )
+      configuration.separatorConfiguration = separatorConfiguration
+      configuration.itemSeparatorHandler = { indexPath, separatorConfiguration in
+        var separatorConfiguration = separatorConfiguration
+        // top separator까지 그리면 행 사이 divider가 이중으로 그려지므로 bottom만 사용하고,
+        // 마지막 행의 bottom을 숨겨 내부 divider를 정확히 (행 수 - 1)개로 만든다.
+        separatorConfiguration.topSeparatorVisibility = .hidden
+        separatorConfiguration.bottomSeparatorVisibility =
+          indexPath.item >= numberOfItems - 1 ? .hidden : .visible
+        return separatorConfiguration
+      }
+    }
+
+    let section = NSCollectionLayoutSection.list(
+      using: configuration,
+      layoutEnvironment: layoutEnvironment
+    )
+
+    section.contentInsets = NSDirectionalEdgeInsets(
+      top: appearance.contentInsets.top,
+      leading: appearance.contentInsets.leading,
+      bottom: appearance.contentInsets.bottom,
+      trailing: appearance.contentInsets.trailing
+    )
+    section.supplementariesFollowContentInsets = false
+
+    let labelAreaHeight = BezierSectionConstant.labelHeight + BezierSectionConstant.labelToContentSpacing
+
+    if showsLabel {
+      let header = NSCollectionLayoutBoundarySupplementaryItem(
+        layoutSize: NSCollectionLayoutSize(
+          widthDimension: .fractionalWidth(1),
+          heightDimension: .absolute(labelAreaHeight)
+        ),
+        elementKind: Self.labelElementKind,
+        alignment: .top
+      )
+      section.boundarySupplementaryItems = [header]
+    }
+
+    if appearance.hasChrome {
+      let decoration = NSCollectionLayoutDecorationItem.background(
+        elementKind: variant.decorationElementKind
+      )
+      // background decoration은 boundary header 영역까지 덮으므로
+      // label 높이만큼 top을 밀어 chrome이 콘텐츠 영역에서 시작하게 상쇄한다.
+      decoration.contentInsets = NSDirectionalEdgeInsets(
+        top: showsLabel ? labelAreaHeight : 0,
+        leading: 0,
+        bottom: 0,
+        trailing: 0
+      )
+      section.decorationItems = [decoration]
+    }
+
+    return section
+  }
+}
+
+// MARK: - Background Decoration View
+
+public final class BezierSectionBackgroundView: UICollectionReusableView, BezierComponentable {
+  // MARK: - BezierComponentable
+
+  public var colorTheme: BezierColorTheme { .systemBezierColorTheme() }
+  public var componentTheme: BezierComponentTheme = .normal {
+    didSet { self.refreshAppearance() }
+  }
+
+  // MARK: - Private Properties
+
+  private var variant: BezierSectionVariant? {
+    didSet { if oldValue != self.variant { self.refreshAppearance() } }
+  }
+
+  // MARK: - Init
+
+  public override init(frame: CGRect) {
+    super.init(frame: frame)
+    self.layer.masksToBounds = true
+  }
+
+  public required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    self.layer.masksToBounds = true
+  }
+
+  // MARK: - Layout Attributes
+
+  public override func apply(_ layoutAttributes: UICollectionViewLayoutAttributes) {
+    super.apply(layoutAttributes)
+    guard
+      let elementKind = layoutAttributes.representedElementKind,
+      let variant = BezierSectionVariant(decorationElementKind: elementKind)
+    else { return }
+    self.variant = variant
+  }
+
+  // MARK: - Trait
+
+  public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    self.refreshAppearance()
+  }
+
+  // MARK: - Refresh
+
+  private func refreshAppearance() {
+    guard let appearance = self.variant?.appearance else { return }
+
+    if let backgroundColor = appearance.backgroundColor {
+      self.backgroundColor = backgroundColor.palette(self)
+    } else {
+      self.backgroundColor = .clear
+    }
+    self.layer.cornerRadius = appearance.cornerRadius
+
+    if let border = appearance.border {
+      self.layer.borderWidth = border.width
+      self.layer.borderColor = border.color.palette(self).cgColor
+    } else {
+      self.layer.borderWidth = 0
+      self.layer.borderColor = nil
+    }
+  }
+}
+
+// MARK: - Label Reusable View
+
+public final class BezierSectionLabelReusableView: UICollectionReusableView {
+  public let sectionLabel = BezierSectionLabel(text: "")
+
+  public override init(frame: CGRect) {
+    super.init(frame: frame)
+    self.setUp()
+  }
+
+  public required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    self.setUp()
+  }
+
+  private func setUp() {
+    self.addSubview(self.sectionLabel)
+    NSLayoutConstraint.activate([
+      self.sectionLabel.topAnchor.constraint(equalTo: self.topAnchor),
+      self.sectionLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+      self.sectionLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+      self.sectionLabel.heightAnchor.constraint(
+        equalToConstant: BezierSectionConstant.labelHeight
+      ),
+    ])
+  }
+
+  public override func prepareForReuse() {
+    super.prepareForReuse()
+    self.sectionLabel.leadingContent = nil
+    self.sectionLabel.trailingContent = nil
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierSection/BezierSectionLayout.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierSection/BezierSectionLayout.swift
@@ -7,19 +7,51 @@ import UIKit
 
 // MARK: - Decoration Element Kind
 
-extension BezierSectionVariant {
-  var decorationElementKind: String {
-    switch self {
-    case .solid: return "BezierSectionLayout.background.solid"
-    case .card: return "BezierSectionLayout.background.card"
+// decoration view는 UIKit이 dequeue해 소비자가 직접 componentTheme를 주입할 수 없으므로,
+// variant × componentTheme 조합을 elementKind 문자열에 인코딩해 전달한다.
+enum BezierSectionDecorationKind: CaseIterable {
+  case solidNormal
+  case solidInverted
+  case cardNormal
+  case cardInverted
+
+  init(variant: BezierSectionVariant, componentTheme: BezierComponentTheme) {
+    switch (variant, componentTheme) {
+    case (.solid, .normal): self = .solidNormal
+    case (.solid, .inverted): self = .solidInverted
+    case (.card, .normal): self = .cardNormal
+    case (.card, .inverted): self = .cardInverted
     }
   }
 
-  init?(decorationElementKind: String) {
-    guard let variant = Self.allCases.first(
-      where: { $0.decorationElementKind == decorationElementKind }
-    ) else { return nil }
-    self = variant
+  init?(elementKind: String) {
+    guard let kind = Self.allCases.first(where: { $0.elementKind == elementKind }) else {
+      return nil
+    }
+    self = kind
+  }
+
+  var variant: BezierSectionVariant {
+    switch self {
+    case .solidNormal, .solidInverted: return .solid
+    case .cardNormal, .cardInverted: return .card
+    }
+  }
+
+  var componentTheme: BezierComponentTheme {
+    switch self {
+    case .solidNormal, .cardNormal: return .normal
+    case .solidInverted, .cardInverted: return .inverted
+    }
+  }
+
+  var elementKind: String {
+    switch self {
+    case .solidNormal: return "BezierSectionLayout.background.solid.normal"
+    case .solidInverted: return "BezierSectionLayout.background.solid.inverted"
+    case .cardNormal: return "BezierSectionLayout.background.card.normal"
+    case .cardInverted: return "BezierSectionLayout.background.card.inverted"
+    }
   }
 }
 
@@ -29,10 +61,10 @@ public enum BezierSectionLayout {
   public static let labelElementKind = "BezierSectionLayout.label"
 
   public static func register(in layout: UICollectionViewCompositionalLayout) {
-    for variant in BezierSectionVariant.allCases {
+    for kind in BezierSectionDecorationKind.allCases {
       layout.register(
         BezierSectionBackgroundView.self,
-        forDecorationViewOfKind: variant.decorationElementKind
+        forDecorationViewOfKind: kind.elementKind
       )
     }
   }
@@ -41,6 +73,7 @@ public enum BezierSectionLayout {
     variant: BezierSectionVariant,
     numberOfItems: Int,
     showsLabel: Bool = false,
+    componentTheme: BezierComponentTheme = .normal,
     layoutEnvironment: NSCollectionLayoutEnvironment
   ) -> NSCollectionLayoutSection {
     let appearance = variant.appearance
@@ -52,9 +85,9 @@ public enum BezierSectionLayout {
     if let divider = appearance.divider {
       var separatorConfiguration = UIListSeparatorConfiguration(listAppearance: .plain)
       separatorConfiguration.color = UIColor { traitCollection in
-        traitCollection.userInterfaceStyle == .dark
-          ? divider.color.dark.uiColor
-          : divider.color.light.uiColor
+        let isDarkTrait = traitCollection.userInterfaceStyle == .dark
+        let usesDarkPalette = componentTheme == .normal ? isDarkTrait : !isDarkTrait
+        return usesDarkPalette ? divider.color.dark.uiColor : divider.color.light.uiColor
       }
       separatorConfiguration.bottomSeparatorInsets = NSDirectionalEdgeInsets(
         top: 0,
@@ -103,7 +136,10 @@ public enum BezierSectionLayout {
 
     if appearance.hasChrome {
       let decoration = NSCollectionLayoutDecorationItem.background(
-        elementKind: variant.decorationElementKind
+        elementKind: BezierSectionDecorationKind(
+          variant: variant,
+          componentTheme: componentTheme
+        ).elementKind
       )
       // background decoration은 boundary header 영역까지 덮으므로
       // label 높이만큼 top을 밀어 chrome이 콘텐츠 영역에서 시작하게 상쇄한다.
@@ -154,9 +190,10 @@ public final class BezierSectionBackgroundView: UICollectionReusableView, Bezier
     super.apply(layoutAttributes)
     guard
       let elementKind = layoutAttributes.representedElementKind,
-      let variant = BezierSectionVariant(decorationElementKind: elementKind)
+      let kind = BezierSectionDecorationKind(elementKind: elementKind)
     else { return }
-    self.variant = variant
+    self.variant = kind.variant
+    self.componentTheme = kind.componentTheme
   }
 
   // MARK: - Trait

--- a/Sources/BezierSwift/MasterComponent/BezierSection/BezierSectionRowDivider.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierSection/BezierSectionRowDivider.swift
@@ -1,0 +1,96 @@
+//
+//  BezierSectionRowDivider.swift
+//  BezierSwift
+//
+
+import UIKit
+
+final class BezierSectionRowDivider: UIView, BezierComponentable {
+  // MARK: - BezierComponentable
+
+  var colorTheme: BezierColorTheme { .systemBezierColorTheme() }
+  var componentTheme: BezierComponentTheme = .normal {
+    didSet { self.refreshAppearance() }
+  }
+
+  // MARK: - Private Properties
+
+  private var divider: BezierSectionVariant.Appearance.Divider?
+
+  // MARK: - Subviews
+
+  private let lineView = UIView()
+
+  // MARK: - Constraints
+
+  private var lineLeadingConstraint: NSLayoutConstraint?
+  private var lineTrailingConstraint: NSLayoutConstraint?
+  private var lineHeightConstraint: NSLayoutConstraint?
+
+  // MARK: - Init
+
+  init() {
+    super.init(frame: .zero)
+    self.setUp()
+  }
+
+  required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    self.setUp()
+  }
+
+  // MARK: - Setup
+
+  private func setUp() {
+    self.translatesAutoresizingMaskIntoConstraints = false
+    self.isUserInteractionEnabled = false
+
+    self.lineView.translatesAutoresizingMaskIntoConstraints = false
+    self.addSubview(self.lineView)
+
+    let leading = self.lineView.leadingAnchor.constraint(equalTo: self.leadingAnchor)
+    let trailing = self.lineView.trailingAnchor.constraint(equalTo: self.trailingAnchor)
+    let height = self.lineView.heightAnchor.constraint(equalToConstant: 0)
+    NSLayoutConstraint.activate([
+      leading,
+      trailing,
+      height,
+      self.lineView.topAnchor.constraint(equalTo: self.topAnchor),
+      self.lineView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+    ])
+    self.lineLeadingConstraint = leading
+    self.lineTrailingConstraint = trailing
+    self.lineHeightConstraint = height
+  }
+
+  // MARK: - Layout
+
+  override var intrinsicContentSize: CGSize {
+    CGSize(width: UIView.noIntrinsicMetric, height: self.divider?.thickness ?? 0)
+  }
+
+  // MARK: - Apply
+
+  func apply(_ divider: BezierSectionVariant.Appearance.Divider) {
+    self.divider = divider
+    self.lineLeadingConstraint?.constant = divider.leadingInset
+    self.lineTrailingConstraint?.constant = -divider.trailingInset
+    self.lineHeightConstraint?.constant = divider.thickness
+    self.invalidateIntrinsicContentSize()
+    self.refreshAppearance()
+  }
+
+  // MARK: - Trait
+
+  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    self.refreshAppearance()
+  }
+
+  // MARK: - Refresh
+
+  private func refreshAppearance() {
+    guard let divider = self.divider else { return }
+    self.lineView.backgroundColor = divider.color.palette(self)
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierSection/BezierSectionSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierSection/BezierSectionSpec.swift
@@ -1,0 +1,121 @@
+//
+//  BezierSectionSpec.swift
+//  BezierSwift
+//
+
+import CoreGraphics
+
+// MARK: - Variant
+
+public enum BezierSectionVariant: CaseIterable {
+  case solid
+  case card
+}
+
+// MARK: - Label Color
+
+public enum BezierSectionLabelColor: CaseIterable {
+  case neutralDark
+  case neutralLight
+
+  var textColor: BCSemanticToken {
+    switch self {
+    case .neutralDark: return .textNeutral
+    case .neutralLight: return .textNeutralLighter
+    }
+  }
+}
+
+// MARK: - Appearance
+
+extension BezierSectionVariant {
+  struct Appearance {
+    struct Border {
+      let color: BCSemanticToken
+      let width: CGFloat
+    }
+
+    struct Divider {
+      let color: BCSemanticToken
+      let thickness: CGFloat
+      let leadingInset: CGFloat
+      let trailingInset: CGFloat
+    }
+
+    struct Insets {
+      let top: CGFloat
+      let leading: CGFloat
+      let bottom: CGFloat
+      let trailing: CGFloat
+
+      static let zero = Insets(top: 0, leading: 0, bottom: 0, trailing: 0)
+    }
+
+    let backgroundColor: BCSemanticToken?
+    let cornerRadius: CGFloat
+    let border: Border?
+    let divider: Divider?
+    let contentInsets: Insets
+
+    var hasChrome: Bool {
+      self.backgroundColor != nil || self.border != nil
+    }
+  }
+
+  var appearance: Appearance {
+    switch self {
+    case .solid:
+      return Appearance(
+        backgroundColor: nil,
+        cornerRadius: 0,
+        border: nil,
+        divider: nil,
+        contentInsets: .zero
+      )
+    case .card:
+      return Appearance(
+        backgroundColor: BezierSectionConstant.cardBackgroundColor,
+        cornerRadius: BezierSectionConstant.cardCornerRadius,
+        border: Appearance.Border(
+          color: BezierSectionConstant.cardBorderColor,
+          width: BezierSectionConstant.cardBorderWidth
+        ),
+        divider: Appearance.Divider(
+          color: BezierSectionConstant.cardDividerColor,
+          thickness: BezierSectionConstant.cardDividerThickness,
+          leadingInset: 0,
+          trailingInset: 0
+        ),
+        contentInsets: BezierSectionConstant.cardContentInsets
+      )
+    }
+  }
+}
+
+// MARK: - Constant
+
+public enum BezierSectionConstant {
+  public static let labelHeight: CGFloat = 32
+  public static let labelHorizontalPadding: CGFloat = 10
+  public static let labelCornerRadius: CGFloat = 8
+  public static let labelTrailingSpacing: CGFloat = 4
+  public static let labelLeadingSpacing: CGFloat = 8
+  public static let labelLeadingContentLength: CGFloat = 20
+  public static let labelTrailingContentHeight: CGFloat = 20
+  public static let labelToContentSpacing: CGFloat = 0
+
+  static let labelTypography: BTSemanticToken = .textMedium(weight: .bold)
+
+  static let cardBackgroundColor: BCSemanticToken = .surface
+  static let cardBorderColor: BCSemanticToken = .borderNeutral
+  static let cardBorderWidth: CGFloat = 1
+  static let cardCornerRadius: CGFloat = 16
+  static let cardDividerColor: BCSemanticToken = .borderNeutral
+  static let cardDividerThickness: CGFloat = 1
+  static let cardContentInsets = BezierSectionVariant.Appearance.Insets(
+    top: 2,
+    leading: 0,
+    bottom: 2,
+    trailing: 0
+  )
+}

--- a/Sources/BezierSwift/MasterComponent/BezierSection/SPEC.md
+++ b/Sources/BezierSwift/MasterComponent/BezierSection/SPEC.md
@@ -147,6 +147,7 @@ Figma에 없는 구현 아키텍처 결정은 아래에 분리 표기한다. SSO
    - `numberOfItems`는 마지막 행 bottom separator 숨김에 사용. 데이터 변경 시 레이아웃 invalidate는 소비자 책임 (diffable snapshot apply 시 자동).
    - header(SectionLabel)는 높이 32pt 고정 boundary item. decoration이 header 영역을 덮는 동작을 decoration top inset으로 상쇄하므로 label trailing 슬롯 높이는 32pt 초과 금지 (Figma trailing 래퍼도 20pt 고정).
    - 셀 배경은 `UIBackgroundConfiguration.clear()`로 두어야 card decoration이 비쳐 보인다.
+   - **componentTheme 지원**: decoration view는 UIKit이 dequeue해 소비자가 직접 주입할 수 없으므로 `makeSection(componentTheme:)` 인자를 variant × theme 조합의 decoration elementKind로 인코딩해 전달한다 (`BezierSectionDecorationKind`, `register(in:)`이 4종 전부 등록). separator 색도 같은 인자로 계산한다. label boundary supplementary는 소비자가 configure 시점에 `sectionLabel.componentTheme`를 직접 설정한다.
 3. **SwiftUI = ScrollView + LazyVStack 안에서 쓰는 `SUBezierSection` 컨테이너**, 데이터 주도 init (ForEach 동형). 정적 나열(free `@ViewBuilder`) init은 iOS 16에서 자식 분해에 비공개 API가 필요해 제공하지 않음. lazy 단위는 섹션 — 행이 매우 많은 화면은 UIKit 경로 사용.
 4. **행 간 divider 구현**: Figma의 card divider는 `Divider` 컴포넌트 인스턴스(1pt·borderNeutral·인셋 0)다. 구현은 값 소스를 `BezierSectionVariant.Appearance.Divider` 한곳에 두고 정적 컨테이너(internal `BezierSectionRowDivider`)·SwiftUI(Rectangle)·컴포지셔널(`UIListSeparatorConfiguration`) 세 경로가 공유한다.
 5. **label 유무 표현**: 코드 API는 `hasLabel` boolean 대신 `labelText: String?`(nil = 미표시) / 컴포지셔널은 `showsLabel: Bool`.

--- a/Sources/BezierSwift/MasterComponent/BezierSection/SPEC.md
+++ b/Sources/BezierSwift/MasterComponent/BezierSection/SPEC.md
@@ -1,0 +1,159 @@
+# BezierSection SPEC
+
+> **SSOT**: [Figma · Mobile-Components / Section (4990:10604)](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=4990-10604) · [Internal/SectionLabel (1856:32)](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=1856-32)
+> **Design spec doc**: [team-design / bezier-v3 / components / Section-spec.md](https://github.com/channel-io/team-design/blob/main/bezier-v3/components/Section-spec.md) (보조 참조 — 값 충돌 시 Figma 파일 우선)
+
+모바일에서 관련 콘텐츠를 의미 단위로 묶는 섹션 컨테이너 (Figma component description 1행).
+
+## 1. Component Properties
+
+### Section (CS `4990:10604`)
+
+| Property | 값 | 비고 |
+|---|---|---|
+| **variant** | `solid` / `card` | 섹션 배경·테두리·radius·행 간 divider 결정 |
+| **hasLabel** | BOOLEAN, 기본 `true` | SectionLabel 표시 여부 |
+| **content** | SLOT | 리스트 아이템 영역 (solid: `content`, card: `Card > contentSlot`) |
+| **hasFooter** / **hasFooterText** / **footerText** / **hasError** | BOOLEAN / BOOLEAN / TEXT / BOOLEAN | CS에 정의되어 있으나 두 variant의 어떤 레이어에도 미배선(unbound) — footer 레이어 자체가 없음. 구현 스코프 제외 (§8.1) |
+
+총 instance: variant 2개 (`solid` = `1268:2`, `card` = `4990:10605`)
+
+### Internal/SectionLabel (CS `1856:32`)
+
+| Property | 값 | 비고 |
+|---|---|---|
+| **color** | `neutral-dark` / `neutral-light` | 텍스트 색 결정 |
+| **hasLeadingContent** | BOOLEAN, 기본 `false` | 좌측 아이콘 슬롯 표시 |
+| **hasTrailingContent** | BOOLEAN, 기본 `false` | 우측 액션 영역 표시 |
+| **label** | TEXT | 헤더 텍스트 |
+| **leadingContent** | SLOT (20×20) | 좌측 아이콘 |
+| **trailingContent** | SLOT (높이 20, 우측 정렬) | 우측 액션 |
+
+총 instance: color 2개 (`neutral-dark` = `1856:5`, `neutral-light` = `4276:61232`)
+
+## 2. Layout Spec
+
+### Section 루트 (variant 공통)
+
+| Part | 값 |
+|---|---|
+| 배치 | 세로 스택: SectionLabel → 콘텐츠 영역 |
+| SectionLabel–콘텐츠 간격 | `0pt` |
+| 루트 패딩 | 없음 (좌우 패딩은 SectionLabel과 아이템이 각자 보유) |
+
+### variant=solid (`1268:2`)
+
+| Part | 값 |
+|---|---|
+| 콘텐츠 영역 (`content`) | 투명 배경, 테두리 없음, radius 없음, 패딩 없음 |
+| 행 간 divider | 없음 |
+
+### variant=card (`4990:10605`)
+
+콘텐츠 영역은 `Card` 인스턴스(`4990:10631`)다.
+
+| Part | 값 | Figma Variable |
+|---|---|---|
+| Card 배경 | `surface` | `color/surface` |
+| Card 테두리 | `1pt` solid `borderNeutral` | `color/border/neutral` |
+| Card radius | `16pt` | `radius/16` |
+| Card 패딩 | 상하 `2pt`, 좌우 `0` | — |
+| 행 간 divider | `Divider` 인스턴스 — `1pt`, `borderNeutral`, 좌우 인셋 `0`(풀폭), 상하 여백 `0` | `color/border/neutral` |
+| divider 개수 | 행 사이에만 (행 n개 → divider n−1개) | — |
+
+### Internal/SectionLabel
+
+| Part | 값 |
+|---|---|
+| 최소 높이 | `32pt` (min-height — 내용이 크면 성장) |
+| 좌우 패딩 | `10pt` |
+| radius | `8pt` |
+| 루트 gap | `4pt` (leadingCenterWrapper ↔ trailingContent) |
+| leadingCenterWrapper 내부 gap | `8pt` (leadingContent ↔ 텍스트) |
+| leadingContent 슬롯 | `20×20pt` |
+| trailingContent 슬롯 | 높이 `20pt` 래퍼, 우측 정렬, shrink 없음 |
+| 텍스트 overflow | 1줄, ellipsis (텍스트만 가변폭) |
+
+## 3. Variant 별 컬러 토큰
+
+### Section
+
+| Variant | 영역 | Token | Figma Variable | Raw |
+|---|---|---|---|---|
+| `solid` | 콘텐츠 배경 | — *(transparent)* | — | — |
+| `card` | Card 배경 | `surface` | `color/surface` | `#FFFFFF` |
+| `card` | Card 테두리 | `borderNeutral` | `color/border/neutral` | `#00000014` |
+| `card` | 행 간 divider | `borderNeutral` | `color/border/neutral` | `#00000014` |
+
+### SectionLabel 텍스트
+
+| color | Token | Figma Variable | Raw |
+|---|---|---|---|
+| `neutral-dark` | `textNeutral` | `color/text/neutral` | `#000000D9` |
+| `neutral-light` | `textNeutralLighter` | `color/text/neutral/lighter` | `#00000066` |
+
+## 4. Typography
+
+### Case A — Typography Token 사용
+
+| 위치 | Token | Figma Style 이름 |
+|---|---|---|
+| SectionLabel 텍스트 | `BTSemanticToken.textMedium(weight: .bold)` | `Typography/text/medium-bold` (14 / 700 / lh 18 / ls 0) |
+
+### Case B — Custom Typography
+
+없음.
+
+## 5. State 별 시각 동작
+
+Section·SectionLabel 모두 Figma CS에 state variant 축 없음 (정적 컴포넌트).
+
+## 6. 디자이너 가이드라인 (Figma component description 인용)
+
+### Section
+
+- 모바일에서 관련 콘텐츠를 의미 단위로 묶는 섹션 컨테이너. Header + Content + Footer 구조. footer는 Description/Error/SeeMore 배타적 타입. Section 중첩 금지. Description과 Error footer 동시 사용 금지.
+  - (구조 실측: 현재 CS의 두 variant에는 footer 레이어가 존재하지 않음 — SectionLabel + 콘텐츠 영역만 존재)
+
+### Internal/SectionLabel
+
+- Used within Section only. Do not place standalone. Section의 정적 헤더 bar. leadingIcon(optional) · 텍스트 · trailing action을 담는다.
+- color: neutralDark(--color-text-neutral) / neutralLight(--color-text-neutral-lighter)
+- hasLeadingContent: 좌측 아이콘 슬롯 표시 (기본 꺼짐, optional, DES-18872)
+- hasTrailingContent: 우측 액션 영역 표시
+- label: 헤더 텍스트. Overlay 내부에서는 color=neutralLight를 사용한다.
+
+## 7. 매핑되는 코드 심볼
+
+| 정의 | 파일 |
+|---|---|
+| UIKit 정적 컨테이너 | `BezierSection.swift` |
+| SwiftUI 컨테이너 | `SUBezierSection.swift` |
+| UIKit SectionLabel | `BezierSectionLabel.swift` |
+| SwiftUI SectionLabel | `SUBezierSectionLabel.swift` |
+| variant / appearance / constant | `BezierSectionSpec.swift` |
+| UIKit 컴포지셔널 레이아웃 지원 | `BezierSectionLayout.swift` |
+| 행 간 divider (internal) | `BezierSectionRowDivider.swift` |
+
+## 8. Figma 외 · 협의 사항 (2026-07-24 구조 확정)
+
+Figma에 없는 구현 아키텍처 결정은 아래에 분리 표기한다. SSOT 값이 아니다.
+
+1. **스코프**: collapsible(web 전용, Mobile CS에 없음)·footer(CS 구조에 레이어 없음)·SectionContent 자식 타입 제약·UITableView 미지원.
+2. **UIKit 동적 리스트 = UICollectionViewCompositionalLayout 전용** (`BezierSectionLayout`):
+   - 섹션 배경/테두리/radius는 background decoration view 1장. per-section variant는 variant별 decoration elementKind로 전달.
+   - `BezierSectionLayout.register(in:)`을 레이아웃 생성 직후 필수 호출 (미등록 시 decoration dequeue 크래시).
+   - 행 간 divider는 list separator로 처리 — 셀이 `UICollectionViewListCell`(서브클래스 포함)일 것. 커스텀 콘텐츠 셀은 `separatorLayoutGuide`를 셀 전체 폭에 고정해야 divider 인셋이 그대로 적용된다 (Examples `SectionDemoListCell` 참조).
+   - `numberOfItems`는 마지막 행 bottom separator 숨김에 사용. 데이터 변경 시 레이아웃 invalidate는 소비자 책임 (diffable snapshot apply 시 자동).
+   - header(SectionLabel)는 높이 32pt 고정 boundary item. decoration이 header 영역을 덮는 동작을 decoration top inset으로 상쇄하므로 label trailing 슬롯 높이는 32pt 초과 금지 (Figma trailing 래퍼도 20pt 고정).
+   - 셀 배경은 `UIBackgroundConfiguration.clear()`로 두어야 card decoration이 비쳐 보인다.
+3. **SwiftUI = ScrollView + LazyVStack 안에서 쓰는 `SUBezierSection` 컨테이너**, 데이터 주도 init (ForEach 동형). 정적 나열(free `@ViewBuilder`) init은 iOS 16에서 자식 분해에 비공개 API가 필요해 제공하지 않음. lazy 단위는 섹션 — 행이 매우 많은 화면은 UIKit 경로 사용.
+4. **행 간 divider 구현**: Figma의 card divider는 `Divider` 컴포넌트 인스턴스(1pt·borderNeutral·인셋 0)다. 구현은 값 소스를 `BezierSectionVariant.Appearance.Divider` 한곳에 두고 정적 컨테이너(internal `BezierSectionRowDivider`)·SwiftUI(Rectangle)·컴포지셔널(`UIListSeparatorConfiguration`) 세 경로가 공유한다.
+5. **label 유무 표현**: 코드 API는 `hasLabel` boolean 대신 `labelText: String?`(nil = 미표시) / 컴포지셔널은 `showsLabel: Bool`.
+
+## 9. Variant 매트릭스
+
+```
+Section:      variant=solid = 1268:2, variant=card = 4990:10605  (총 2)
+SectionLabel: color=neutral-dark = 1856:5, color=neutral-light = 4276:61232  (총 2)
+```

--- a/Sources/BezierSwift/MasterComponent/BezierSection/SUBezierSection.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierSection/SUBezierSection.swift
@@ -1,0 +1,232 @@
+//
+//  SUBezierSection.swift
+//  BezierSwift
+//
+
+import SwiftUI
+
+public struct SUBezierSection<Data: RandomAccessCollection, ID: Hashable, Row: View, LabelTrailing: View>: View, Themeable {
+  @Environment(\.colorScheme) public var colorScheme
+
+  private let data: Data
+  private let id: KeyPath<Data.Element, ID>
+  private let variant: BezierSectionVariant
+  private let labelText: String?
+  private let labelColor: BezierSectionLabelColor
+  private let labelTrailing: LabelTrailing
+  private let rowContent: (Data.Element) -> Row
+
+  public init(
+    _ data: Data,
+    id: KeyPath<Data.Element, ID>,
+    variant: BezierSectionVariant = .solid,
+    labelText: String? = nil,
+    labelColor: BezierSectionLabelColor = .neutralDark,
+    @ViewBuilder labelTrailing: () -> LabelTrailing,
+    @ViewBuilder rowContent: @escaping (Data.Element) -> Row
+  ) {
+    self.data = data
+    self.id = id
+    self.variant = variant
+    self.labelText = labelText
+    self.labelColor = labelColor
+    self.labelTrailing = labelTrailing()
+    self.rowContent = rowContent
+  }
+
+  private var appearance: BezierSectionVariant.Appearance {
+    self.variant.appearance
+  }
+
+  public var body: some View {
+    VStack(alignment: .leading, spacing: BezierSectionConstant.labelToContentSpacing) {
+      if let labelText = self.labelText {
+        SUBezierSectionLabel(labelText, color: self.labelColor) {
+          self.labelTrailing
+        }
+      }
+      self.content
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+  }
+
+  // MARK: - Content
+
+  private struct Entry {
+    let id: ID
+    let element: Data.Element
+    let showsDivider: Bool
+  }
+
+  private var entries: [Entry] {
+    let count = self.data.count
+    return self.data.enumerated().map { offset, element in
+      Entry(
+        id: element[keyPath: self.id],
+        element: element,
+        showsDivider: offset < count - 1
+      )
+    }
+  }
+
+  @ViewBuilder
+  private var content: some View {
+    let rows = VStack(alignment: .leading, spacing: 0) {
+      ForEach(self.entries, id: \.id) { entry in
+        self.rowContent(entry.element)
+
+        if entry.showsDivider, let divider = self.appearance.divider {
+          self.dividerView(divider)
+        }
+      }
+    }
+    .padding(
+      EdgeInsets(
+        top: self.appearance.contentInsets.top,
+        leading: self.appearance.contentInsets.leading,
+        bottom: self.appearance.contentInsets.bottom,
+        trailing: self.appearance.contentInsets.trailing
+      )
+    )
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(self.backgroundView)
+    .overlay(self.borderView)
+
+    if self.appearance.hasChrome {
+      rows.clipShape(RoundedRectangle(cornerRadius: self.appearance.cornerRadius))
+    } else {
+      rows
+    }
+  }
+
+  private func dividerView(_ divider: BezierSectionVariant.Appearance.Divider) -> some View {
+    Rectangle()
+      .fill(self.palette(divider.color))
+      .frame(height: divider.thickness)
+      .padding(.leading, divider.leadingInset)
+      .padding(.trailing, divider.trailingInset)
+  }
+
+  @ViewBuilder
+  private var backgroundView: some View {
+    if let backgroundColor = self.appearance.backgroundColor {
+      RoundedRectangle(cornerRadius: self.appearance.cornerRadius)
+        .fill(self.palette(backgroundColor))
+    }
+  }
+
+  @ViewBuilder
+  private var borderView: some View {
+    if let border = self.appearance.border {
+      RoundedRectangle(cornerRadius: self.appearance.cornerRadius)
+        .strokeBorder(self.palette(border.color), lineWidth: border.width)
+    }
+  }
+}
+
+// MARK: - Convenience init
+
+extension SUBezierSection where LabelTrailing == EmptyView {
+  public init(
+    _ data: Data,
+    id: KeyPath<Data.Element, ID>,
+    variant: BezierSectionVariant = .solid,
+    labelText: String? = nil,
+    labelColor: BezierSectionLabelColor = .neutralDark,
+    @ViewBuilder rowContent: @escaping (Data.Element) -> Row
+  ) {
+    self.init(
+      data,
+      id: id,
+      variant: variant,
+      labelText: labelText,
+      labelColor: labelColor,
+      labelTrailing: { EmptyView() },
+      rowContent: rowContent
+    )
+  }
+}
+
+extension SUBezierSection where Data.Element: Identifiable, ID == Data.Element.ID {
+  public init(
+    _ data: Data,
+    variant: BezierSectionVariant = .solid,
+    labelText: String? = nil,
+    labelColor: BezierSectionLabelColor = .neutralDark,
+    @ViewBuilder labelTrailing: () -> LabelTrailing,
+    @ViewBuilder rowContent: @escaping (Data.Element) -> Row
+  ) {
+    self.init(
+      data,
+      id: \.id,
+      variant: variant,
+      labelText: labelText,
+      labelColor: labelColor,
+      labelTrailing: labelTrailing,
+      rowContent: rowContent
+    )
+  }
+}
+
+extension SUBezierSection where Data.Element: Identifiable, ID == Data.Element.ID, LabelTrailing == EmptyView {
+  public init(
+    _ data: Data,
+    variant: BezierSectionVariant = .solid,
+    labelText: String? = nil,
+    labelColor: BezierSectionLabelColor = .neutralDark,
+    @ViewBuilder rowContent: @escaping (Data.Element) -> Row
+  ) {
+    self.init(
+      data,
+      id: \.id,
+      variant: variant,
+      labelText: labelText,
+      labelColor: labelColor,
+      labelTrailing: { EmptyView() },
+      rowContent: rowContent
+    )
+  }
+}
+
+struct SUBezierSection_Previews: PreviewProvider {
+  static var previews: some View {
+    ScrollView {
+      LazyVStack(spacing: 20) {
+        SUBezierSection(
+          ["태그 관리", "고객 노트", "첨부파일"],
+          id: \.self,
+          variant: .card,
+          labelText: "설정"
+        ) { title in
+          SUBezierBaseItem(
+            title: title,
+            onTap: {},
+            leading: { Circle().fill(Color.gray) },
+            trailing: {
+              BezierIcon.chevronSmallRight.image
+                .renderingMode(.template)
+                .resizable()
+                .scaledToFit()
+                .frame(width: 20, height: 20)
+                .foregroundColor(.secondary)
+            }
+          )
+        }
+
+        SUBezierSection(
+          ["멤버 초대", "멤버 차단"],
+          id: \.self,
+          labelText: "멤버",
+          labelColor: .neutralLight
+        ) { title in
+          SUBezierBaseItem(
+            title: title,
+            onTap: {},
+            leading: { Circle().fill(Color.gray) },
+            trailing: { EmptyView() }
+          )
+        }
+      }
+    }
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierSection/SUBezierSectionLabel.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierSection/SUBezierSectionLabel.swift
@@ -1,0 +1,118 @@
+//
+//  SUBezierSectionLabel.swift
+//  BezierSwift
+//
+
+import SwiftUI
+
+public struct SUBezierSectionLabel<Leading: View, Trailing: View>: View, Themeable {
+  @Environment(\.colorScheme) public var colorScheme
+
+  private let text: String
+  private let color: BezierSectionLabelColor
+  private let leading: Leading
+  private let trailing: Trailing
+
+  public init(
+    _ text: String,
+    color: BezierSectionLabelColor = .neutralDark,
+    @ViewBuilder leading: () -> Leading,
+    @ViewBuilder trailing: () -> Trailing
+  ) {
+    self.text = text
+    self.color = color
+    self.leading = leading()
+    self.trailing = trailing()
+  }
+
+  public var body: some View {
+    HStack(spacing: 0) {
+      HStack(spacing: BezierSectionConstant.labelLeadingSpacing) {
+        self.leadingView
+
+        Text(self.text)
+          .applyBezierFontStyle(
+            BezierSectionConstant.labelTypography,
+            semanticColorToken: self.color.textColor
+          )
+          .lineLimit(1)
+          .truncationMode(.tail)
+      }
+
+      Spacer(minLength: BezierSectionConstant.labelTrailingSpacing)
+
+      self.trailingView
+    }
+    .padding(.horizontal, BezierSectionConstant.labelHorizontalPadding)
+    .frame(minHeight: BezierSectionConstant.labelHeight)
+    .frame(maxWidth: .infinity)
+    .clipShape(RoundedRectangle(cornerRadius: BezierSectionConstant.labelCornerRadius))
+  }
+
+  @ViewBuilder
+  private var leadingView: some View {
+    if Leading.self != EmptyView.self {
+      self.leading
+        .frame(
+          width: BezierSectionConstant.labelLeadingContentLength,
+          height: BezierSectionConstant.labelLeadingContentLength
+        )
+    }
+  }
+
+  @ViewBuilder
+  private var trailingView: some View {
+    if Trailing.self != EmptyView.self {
+      self.trailing
+        .frame(height: BezierSectionConstant.labelTrailingContentHeight)
+        .layoutPriority(1)
+    }
+  }
+}
+
+// MARK: - Convenience init
+
+extension SUBezierSectionLabel where Leading == EmptyView {
+  public init(
+    _ text: String,
+    color: BezierSectionLabelColor = .neutralDark,
+    @ViewBuilder trailing: () -> Trailing
+  ) {
+    self.init(text, color: color, leading: { EmptyView() }, trailing: trailing)
+  }
+}
+
+extension SUBezierSectionLabel where Leading == EmptyView, Trailing == EmptyView {
+  public init(_ text: String, color: BezierSectionLabelColor = .neutralDark) {
+    self.init(text, color: color, leading: { EmptyView() }, trailing: { EmptyView() })
+  }
+}
+
+struct SUBezierSectionLabel_Previews: PreviewProvider {
+  static var previews: some View {
+    VStack(spacing: 12) {
+      SUBezierSectionLabel("태그")
+      SUBezierSectionLabel("담당자", color: .neutralLight)
+      SUBezierSectionLabel("첨부파일") {
+        BezierIcon.plus.image
+          .renderingMode(.template)
+          .resizable()
+          .scaledToFit()
+          .frame(width: 20, height: 20)
+          .foregroundColor(.secondary)
+      }
+      SUBezierSectionLabel(
+        "폴더",
+        leading: {
+          BezierIcon.folder.image
+            .renderingMode(.template)
+            .resizable()
+            .scaledToFit()
+            .foregroundColor(.secondary)
+        },
+        trailing: { EmptyView() }
+      )
+    }
+    .padding()
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierSectionItem/BezierSectionItem.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierSectionItem/BezierSectionItem.swift
@@ -1,0 +1,467 @@
+//
+//  BezierSectionItem.swift
+//  BezierSwift
+//
+
+import UIKit
+
+public final class BezierSectionItem: UIControl, BezierComponentable {
+  // MARK: - BezierComponentable
+
+  public var colorTheme: BezierColorTheme { .systemBezierColorTheme() }
+  public var componentTheme: BezierComponentTheme = .normal {
+    didSet { self.refreshAppearance() }
+  }
+
+  // MARK: - Public Properties
+
+  public var size: BezierSectionItemSize = .medium {
+    didSet { if oldValue != self.size { self.refreshSize() } }
+  }
+
+  public var content: String = "" {
+    didSet { if oldValue != self.content { self.refreshText() } }
+  }
+
+  public var itemDescription: String? {
+    didSet { if oldValue != self.itemDescription { self.refreshDescription() } }
+  }
+
+  public var leading: BezierSectionItemLeading<UIView> = .none {
+    didSet { self.refreshLeading() }
+  }
+
+  public var centerSlot: UIView? {
+    didSet { self.updateSlot(container: self.centerSlotContainer, old: oldValue, new: self.centerSlot) }
+  }
+
+  public var customCenterContent: UIView? {
+    didSet {
+      self.updateSlot(container: self.customCenterContainer, old: oldValue, new: self.customCenterContent)
+      self.refreshText()
+    }
+  }
+
+  public var accessory: BezierSectionItemAccessory<UIView>? {
+    didSet { self.accessoryView.apply(self.accessory) }
+  }
+
+  public var isDestructive: Bool = false {
+    didSet { if oldValue != self.isDestructive { self.refreshAppearance() } }
+  }
+
+  public var onTap: (() -> Void)? {
+    didSet { self.refreshInteraction() }
+  }
+
+  // MARK: - State
+
+  public override var isHighlighted: Bool {
+    didSet {
+      if oldValue != self.isHighlighted {
+        self.refreshAppearance()
+        self.refreshPressScale()
+      }
+    }
+  }
+
+  public override var isEnabled: Bool {
+    didSet { if oldValue != self.isEnabled { self.refreshEnabled() } }
+  }
+
+  // MARK: - Subviews
+
+  private let rootStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .horizontal
+    stackView.alignment = .center
+    stackView.distribution = .fill
+    stackView.spacing = BezierSectionItemConstant.slotSpacing
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    stackView.isUserInteractionEnabled = false
+    return stackView
+  }()
+
+  private let contentColumnStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    stackView.alignment = .fill
+    stackView.distribution = .fill
+    stackView.spacing = 0
+    return stackView
+  }()
+
+  private let labelWrapperStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .horizontal
+    stackView.alignment = .center
+    stackView.distribution = .fill
+    stackView.spacing = BezierSectionItemConstant.slotSpacing
+    return stackView
+  }()
+
+  private let leadingContainer = UIView()
+  private let leadingIconImageView: UIImageView = {
+    let imageView = UIImageView()
+    imageView.contentMode = .scaleAspectFit
+    return imageView
+  }()
+
+  private let centerContentStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    stackView.alignment = .fill
+    stackView.distribution = .fill
+    stackView.spacing = 0
+    return stackView
+  }()
+
+  private let labelRowStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .horizontal
+    stackView.alignment = .center
+    stackView.distribution = .fill
+    stackView.spacing = BezierSectionItemConstant.labelRowSpacing
+    return stackView
+  }()
+
+  private let contentLabel: UILabel = {
+    let label = UILabel()
+    label.numberOfLines = 1
+    return label
+  }()
+
+  private let customCenterContainer = UIView()
+  private let centerSlotContainer = UIView()
+  private let labelSpacer = UIView()
+
+  private let descriptionLabel: UILabel = {
+    let label = UILabel()
+    label.numberOfLines = 0
+    return label
+  }()
+
+  private let denestDescriptionWrapper: UIView = {
+    let view = UIView()
+    view.insetsLayoutMarginsFromSafeArea = false
+    return view
+  }()
+
+  private let accessoryView = BezierSectionItemAccessoryView()
+
+  // MARK: - Constraints
+
+  private var leadingWidthConstraint: NSLayoutConstraint?
+  private var leadingHeightConstraint: NSLayoutConstraint?
+  private var minHeightConstraint: NSLayoutConstraint?
+
+  // MARK: - Init
+
+  public init(
+    size: BezierSectionItemSize = .medium,
+    content: String,
+    description: String? = nil,
+    onTap: (() -> Void)? = nil
+  ) {
+    self.size = size
+    self.content = content
+    self.itemDescription = description
+    self.onTap = onTap
+    super.init(frame: .zero)
+    self.setUp()
+  }
+
+  public required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    self.setUp()
+  }
+
+  // MARK: - Setup
+
+  private func setUp() {
+    self.translatesAutoresizingMaskIntoConstraints = false
+
+    self.setUpLeading()
+    self.setUpCenter()
+    self.setUpDescription()
+
+    self.labelWrapperStackView.addArrangedSubview(self.leadingContainer)
+    self.labelWrapperStackView.addArrangedSubview(self.centerContentStackView)
+    self.contentColumnStackView.addArrangedSubview(self.labelWrapperStackView)
+    self.contentColumnStackView.addArrangedSubview(self.denestDescriptionWrapper)
+    self.rootStackView.addArrangedSubview(self.contentColumnStackView)
+    self.rootStackView.addArrangedSubview(self.accessoryView)
+    self.addSubview(self.rootStackView)
+
+    let expandingPriority = UILayoutPriority(1)
+    self.contentColumnStackView.setContentHuggingPriority(expandingPriority, for: .horizontal)
+    self.contentColumnStackView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+    self.accessoryView.setContentHuggingPriority(.required, for: .horizontal)
+    self.accessoryView.setContentCompressionResistancePriority(.required, for: .horizontal)
+
+    let margins = self.layoutMarginsGuide
+    let minHeightConstraint = self.heightAnchor.constraint(
+      greaterThanOrEqualToConstant: self.size.minHeight
+    )
+    self.minHeightConstraint = minHeightConstraint
+    NSLayoutConstraint.activate([
+      self.rootStackView.topAnchor.constraint(equalTo: margins.topAnchor),
+      self.rootStackView.leadingAnchor.constraint(equalTo: margins.leadingAnchor),
+      self.rootStackView.trailingAnchor.constraint(equalTo: margins.trailingAnchor),
+      self.rootStackView.bottomAnchor.constraint(equalTo: margins.bottomAnchor),
+      minHeightConstraint,
+    ])
+
+    self.addTarget(self, action: #selector(self.handleTap), for: .touchUpInside)
+
+    self.accessoryView.apply(self.accessory)
+    self.refreshSize()
+    self.refreshLeading()
+    self.refreshInteraction()
+    self.refreshEnabled()
+    self.refreshAppearance()
+  }
+
+  private func setUpLeading() {
+    self.leadingContainer.setContentHuggingPriority(.required, for: .horizontal)
+    self.leadingContainer.setContentCompressionResistancePriority(.required, for: .horizontal)
+    let widthConstraint = self.leadingContainer.widthAnchor.constraint(
+      equalToConstant: self.size.leadingLength
+    )
+    let heightConstraint = self.leadingContainer.heightAnchor.constraint(
+      equalToConstant: self.size.leadingLength
+    )
+    self.leadingWidthConstraint = widthConstraint
+    self.leadingHeightConstraint = heightConstraint
+    NSLayoutConstraint.activate([widthConstraint, heightConstraint])
+  }
+
+  private func setUpCenter() {
+    let expandingPriority = UILayoutPriority(1)
+    self.centerContentStackView.setContentHuggingPriority(expandingPriority, for: .horizontal)
+    self.centerContentStackView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+    self.contentLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+    self.customCenterContainer.setContentHuggingPriority(expandingPriority, for: .horizontal)
+    self.customCenterContainer.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+    self.centerSlotContainer.setContentHuggingPriority(.required, for: .horizontal)
+    self.centerSlotContainer.setContentCompressionResistancePriority(.required, for: .horizontal)
+    self.labelSpacer.setContentHuggingPriority(expandingPriority, for: .horizontal)
+    self.labelSpacer.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+    self.centerSlotContainer.heightAnchor.constraint(
+      equalToConstant: BezierSectionItemConstant.centerSlotHeight
+    ).isActive = true
+
+    self.labelRowStackView.addArrangedSubview(self.contentLabel)
+    self.labelRowStackView.addArrangedSubview(self.customCenterContainer)
+    self.labelRowStackView.addArrangedSubview(self.centerSlotContainer)
+    self.labelRowStackView.addArrangedSubview(self.labelSpacer)
+    self.centerContentStackView.addArrangedSubview(self.labelRowStackView)
+
+    self.customCenterContainer.isHidden = true
+    self.centerSlotContainer.isHidden = true
+  }
+
+  private func setUpDescription() {
+    self.denestDescriptionWrapper.addSubview(self.descriptionLabel)
+    self.descriptionLabel.translatesAutoresizingMaskIntoConstraints = false
+    let margins = self.denestDescriptionWrapper.layoutMarginsGuide
+    NSLayoutConstraint.activate([
+      self.descriptionLabel.topAnchor.constraint(equalTo: margins.topAnchor),
+      self.descriptionLabel.leadingAnchor.constraint(equalTo: margins.leadingAnchor),
+      self.descriptionLabel.trailingAnchor.constraint(equalTo: margins.trailingAnchor),
+      self.descriptionLabel.bottomAnchor.constraint(equalTo: margins.bottomAnchor),
+    ])
+    self.denestDescriptionWrapper.isHidden = true
+  }
+
+  // MARK: - Slot
+
+  private func updateSlot(container: UIView, old: UIView?, new: UIView?) {
+    old?.removeFromSuperview()
+    guard let new else {
+      container.isHidden = true
+      return
+    }
+    new.translatesAutoresizingMaskIntoConstraints = false
+    container.addSubview(new)
+    NSLayoutConstraint.activate([
+      new.topAnchor.constraint(equalTo: container.topAnchor),
+      new.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+      new.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+      new.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+    ])
+    container.isHidden = false
+  }
+
+  // MARK: - Trait
+
+  public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    self.refreshAppearance()
+  }
+
+  // MARK: - Refresh
+
+  private func refreshSize() {
+    self.minHeightConstraint?.constant = self.size.minHeight
+    self.directionalLayoutMargins = NSDirectionalEdgeInsets(
+      top: self.size.verticalPadding,
+      leading: BezierSectionItemConstant.horizontalPadding,
+      bottom: self.size.verticalPadding,
+      trailing: BezierSectionItemConstant.horizontalPadding
+    )
+    self.refreshLeading()
+    self.refreshDescription()
+    self.setNeedsLayout()
+  }
+
+  private func refreshLeading() {
+    self.leadingContainer.subviews
+      .filter { $0 !== self.leadingIconImageView }
+      .forEach { $0.removeFromSuperview() }
+    self.leadingIconImageView.removeFromSuperview()
+
+    switch self.leading {
+    case .none:
+      self.leadingContainer.isHidden = true
+
+    case .icon(let icon):
+      self.leadingContainer.isHidden = false
+      self.leadingIconImageView.image = icon.uiImage?.withRenderingMode(.alwaysTemplate)
+      self.leadingIconImageView.translatesAutoresizingMaskIntoConstraints = false
+      self.leadingContainer.addSubview(self.leadingIconImageView)
+      NSLayoutConstraint.activate([
+        self.leadingIconImageView.topAnchor.constraint(equalTo: self.leadingContainer.topAnchor),
+        self.leadingIconImageView.leadingAnchor.constraint(equalTo: self.leadingContainer.leadingAnchor),
+        self.leadingIconImageView.trailingAnchor.constraint(equalTo: self.leadingContainer.trailingAnchor),
+        self.leadingIconImageView.bottomAnchor.constraint(equalTo: self.leadingContainer.bottomAnchor),
+      ])
+
+    case .avatar(let view), .custom(let view):
+      self.leadingContainer.isHidden = false
+      view.translatesAutoresizingMaskIntoConstraints = false
+      self.leadingContainer.addSubview(view)
+      NSLayoutConstraint.activate([
+        view.topAnchor.constraint(equalTo: self.leadingContainer.topAnchor),
+        view.leadingAnchor.constraint(equalTo: self.leadingContainer.leadingAnchor),
+        view.trailingAnchor.constraint(equalTo: self.leadingContainer.trailingAnchor),
+        view.bottomAnchor.constraint(equalTo: self.leadingContainer.bottomAnchor),
+      ])
+    }
+
+    let length = self.leading.leadingLength(size: self.size)
+    self.leadingWidthConstraint?.constant = length
+    self.leadingHeightConstraint?.constant = length
+
+    self.refreshText()
+    self.refreshDescription()
+  }
+
+  private func refreshDescription() {
+    let isCustom = self.leading.isCustom
+    let description = (self.itemDescription?.isEmpty == false && !isCustom) ? self.itemDescription : nil
+
+    self.descriptionLabel.removeFromSuperview()
+    if self.size.isDescriptionNested {
+      self.denestDescriptionWrapper.isHidden = true
+      self.centerContentStackView.spacing = BezierSectionItemConstant.nestedDescriptionSpacing
+      self.centerContentStackView.addArrangedSubview(self.descriptionLabel)
+      self.descriptionLabel.isHidden = description == nil
+    } else {
+      self.centerContentStackView.spacing = 0
+      self.setUpDescription()
+      self.denestDescriptionWrapper.isHidden = description == nil
+      self.denestDescriptionWrapper.directionalLayoutMargins = NSDirectionalEdgeInsets(
+        top: 0,
+        leading: self.leading.hasLeadingContent ? BezierSectionItemConstant.descriptionIndent : 0,
+        bottom: 0,
+        trailing: 0
+      )
+    }
+
+    self.refreshText()
+  }
+
+  private func refreshInteraction() {
+    self.isUserInteractionEnabled = self.onTap != nil
+    if self.onTap == nil {
+      BezierPressFeedback.reset(self.rootStackView)
+    }
+  }
+
+  private func refreshPressScale() {
+    guard self.onTap != nil else {
+      BezierPressFeedback.reset(self.rootStackView)
+      return
+    }
+    BezierPressFeedback.apply(isPressed: self.isHighlighted, to: self.rootStackView)
+  }
+
+  private func refreshEnabled() {
+    self.alpha = self.isEnabled ? 1 : BezierSectionItemConstant.disabledOpacity
+  }
+
+  private func refreshAppearance() {
+    self.backgroundColor = self.isHighlighted
+      ? BezierSectionItemConstant.pressedBackgroundColor.palette(self)
+      : .clear
+
+    if case .icon = self.leading {
+      let iconColor = self.isDestructive
+        ? BezierSectionItemConstant.destructiveIconColor
+        : BezierSectionItemConstant.leadingIconColor
+      self.leadingIconImageView.tintColor = iconColor.palette(self)
+    }
+
+    self.refreshText()
+  }
+
+  private func refreshText() {
+    let isCustom = self.leading.isCustom
+    let showsContentLabel = !self.content.isEmpty && (!isCustom || self.customCenterContent == nil)
+
+    if showsContentLabel {
+      let contentColor = self.isDestructive
+        ? BezierSectionItemConstant.destructiveContentColor
+        : BezierSectionItemConstant.contentColor
+      self.contentLabel.attributedText = BezierSectionItemConstant.contentTypography.attributedString(
+        self,
+        text: self.content,
+        semanticColorToken: contentColor,
+        alignment: .left,
+        lineBreakMode: .byTruncatingTail
+      )
+      self.contentLabel.isHidden = false
+    } else {
+      self.contentLabel.attributedText = nil
+      self.contentLabel.isHidden = true
+    }
+
+    self.customCenterContainer.isHidden = !(isCustom && self.customCenterContent != nil)
+    if isCustom {
+      self.centerSlotContainer.isHidden = true
+    } else {
+      self.centerSlotContainer.isHidden = self.centerSlot == nil
+    }
+
+    if let description = self.itemDescription, !description.isEmpty, !isCustom {
+      self.descriptionLabel.attributedText = BezierSectionItemConstant.descriptionTypography.attributedString(
+        self,
+        text: description,
+        semanticColorToken: BezierSectionItemConstant.descriptionColor,
+        alignment: .left,
+        lineBreakMode: .byWordWrapping
+      )
+    } else {
+      self.descriptionLabel.attributedText = nil
+    }
+  }
+
+  // MARK: - Action
+
+  @objc private func handleTap() {
+    self.onTap?()
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierSectionItem/BezierSectionItem.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierSectionItem/BezierSectionItem.swift
@@ -10,7 +10,10 @@ public final class BezierSectionItem: UIControl, BezierComponentable {
 
   public var colorTheme: BezierColorTheme { .systemBezierColorTheme() }
   public var componentTheme: BezierComponentTheme = .normal {
-    didSet { self.refreshAppearance() }
+    didSet {
+      self.accessoryView.componentTheme = self.componentTheme
+      self.refreshAppearance()
+    }
   }
 
   // MARK: - Public Properties
@@ -28,11 +31,17 @@ public final class BezierSectionItem: UIControl, BezierComponentable {
   }
 
   public var leading: BezierSectionItemLeading<UIView> = .none {
-    didSet { self.refreshLeading() }
+    didSet {
+      self.refreshLeading()
+      self.refreshAppearance()
+    }
   }
 
   public var centerSlot: UIView? {
-    didSet { self.updateSlot(container: self.centerSlotContainer, old: oldValue, new: self.centerSlot) }
+    didSet {
+      self.updateSlot(container: self.centerSlotContainer, old: oldValue, new: self.centerSlot)
+      self.refreshText()
+    }
   }
 
   public var customCenterContent: UIView? {
@@ -313,7 +322,6 @@ public final class BezierSectionItem: UIControl, BezierComponentable {
       trailing: BezierSectionItemConstant.horizontalPadding
     )
     self.refreshLeading()
-    self.refreshDescription()
     self.setNeedsLayout()
   }
 
@@ -363,15 +371,21 @@ public final class BezierSectionItem: UIControl, BezierComponentable {
     let isCustom = self.leading.isCustom
     let description = (self.itemDescription?.isEmpty == false && !isCustom) ? self.itemDescription : nil
 
-    self.descriptionLabel.removeFromSuperview()
     if self.size.isDescriptionNested {
+      if self.descriptionLabel.superview !== self.centerContentStackView {
+        self.descriptionLabel.removeFromSuperview()
+        self.centerContentStackView.addArrangedSubview(self.descriptionLabel)
+      }
       self.denestDescriptionWrapper.isHidden = true
       self.centerContentStackView.spacing = BezierSectionItemConstant.nestedDescriptionSpacing
-      self.centerContentStackView.addArrangedSubview(self.descriptionLabel)
       self.descriptionLabel.isHidden = description == nil
     } else {
+      if self.descriptionLabel.superview !== self.denestDescriptionWrapper {
+        self.descriptionLabel.removeFromSuperview()
+        self.setUpDescription()
+      }
+      self.descriptionLabel.isHidden = false
       self.centerContentStackView.spacing = 0
-      self.setUpDescription()
       self.denestDescriptionWrapper.isHidden = description == nil
       self.denestDescriptionWrapper.directionalLayoutMargins = NSDirectionalEdgeInsets(
         top: 0,

--- a/Sources/BezierSwift/MasterComponent/BezierSectionItem/BezierSectionItemAccessoryView.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierSectionItem/BezierSectionItemAccessoryView.swift
@@ -1,0 +1,281 @@
+//
+//  BezierSectionItemAccessoryView.swift
+//  BezierSwift
+//
+
+import UIKit
+
+final class BezierSectionItemAccessoryView: UIView, BezierComponentable {
+  // MARK: - BezierComponentable
+
+  var colorTheme: BezierColorTheme { .systemBezierColorTheme() }
+  var componentTheme: BezierComponentTheme = .normal {
+    didSet { self.refreshAppearance() }
+  }
+
+  // MARK: - Private Properties
+
+  private var accessory: BezierSectionItemAccessory<UIView>?
+
+  // MARK: - Subviews
+
+  private let contentStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .horizontal
+    stackView.alignment = .center
+    stackView.distribution = .fill
+    stackView.spacing = BezierSectionItemConstant.accessoryTextSpacing
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    return stackView
+  }()
+
+  private let valueLabel: UILabel = {
+    let label = UILabel()
+    label.numberOfLines = 1
+    return label
+  }()
+
+  private let iconImageView: UIImageView = {
+    let imageView = UIImageView()
+    imageView.contentMode = .scaleAspectFit
+    return imageView
+  }()
+
+  private let toggleView = BezierSectionItemToggleView()
+  private let customContainer = UIView()
+
+  // MARK: - Constraints
+
+  private var iconWidthConstraint: NSLayoutConstraint?
+  private var iconHeightConstraint: NSLayoutConstraint?
+
+  // MARK: - Init
+
+  init() {
+    super.init(frame: .zero)
+    self.setUp()
+  }
+
+  required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    self.setUp()
+  }
+
+  // MARK: - Setup
+
+  private func setUp() {
+    self.translatesAutoresizingMaskIntoConstraints = false
+    self.isUserInteractionEnabled = false
+
+    self.valueLabel.setContentHuggingPriority(.required, for: .horizontal)
+    self.valueLabel.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+
+    let iconWidth = self.iconImageView.widthAnchor.constraint(
+      equalToConstant: BezierSectionItemConstant.accessoryIconLength
+    )
+    let iconHeight = self.iconImageView.heightAnchor.constraint(
+      equalToConstant: BezierSectionItemConstant.accessoryIconLength
+    )
+    self.iconWidthConstraint = iconWidth
+    self.iconHeightConstraint = iconHeight
+
+    self.contentStackView.addArrangedSubview(self.valueLabel)
+    self.contentStackView.addArrangedSubview(self.iconImageView)
+    self.contentStackView.addArrangedSubview(self.toggleView)
+    self.contentStackView.addArrangedSubview(self.customContainer)
+    self.addSubview(self.contentStackView)
+
+    let margins = self.layoutMarginsGuide
+    NSLayoutConstraint.activate([
+      iconWidth,
+      iconHeight,
+      self.contentStackView.leadingAnchor.constraint(equalTo: margins.leadingAnchor),
+      self.contentStackView.trailingAnchor.constraint(equalTo: margins.trailingAnchor),
+      self.contentStackView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+      self.heightAnchor.constraint(equalToConstant: BezierSectionItemConstant.accessoryHeight),
+      self.customContainer.heightAnchor.constraint(equalTo: self.heightAnchor),
+    ])
+  }
+
+  // MARK: - Apply
+
+  func apply(_ accessory: BezierSectionItemAccessory<UIView>?) {
+    if case .custom(let old)? = self.accessory, old.superview === self.customContainer {
+      old.removeFromSuperview()
+    }
+    self.accessory = accessory
+
+    self.valueLabel.isHidden = true
+    self.iconImageView.isHidden = true
+    self.toggleView.isHidden = true
+    self.customContainer.isHidden = true
+
+    guard let accessory else {
+      self.isHidden = true
+      return
+    }
+    self.isHidden = false
+
+    switch accessory {
+    case .navigation:
+      self.showIcon(.chevronSmallRight, length: BezierSectionItemConstant.accessoryIconLength)
+    case .outlink:
+      self.showIcon(.arrowRightUpSmall, length: BezierSectionItemConstant.accessoryIconLength)
+    case .select:
+      self.valueLabel.isHidden = false
+      self.showIcon(.chevronUpdown, length: BezierSectionItemConstant.accessoryChevronUpdownLength)
+    case .multiselect:
+      self.valueLabel.isHidden = false
+      self.showIcon(.chevronUpdown, length: BezierSectionItemConstant.accessoryChevronUpdownLength)
+    case .display:
+      self.valueLabel.isHidden = false
+    case .toggle(let isOn):
+      self.toggleView.isHidden = false
+      self.toggleView.isOn = isOn
+    case .custom(let content):
+      self.customContainer.isHidden = false
+      content.translatesAutoresizingMaskIntoConstraints = false
+      self.customContainer.addSubview(content)
+      NSLayoutConstraint.activate([
+        content.topAnchor.constraint(equalTo: self.customContainer.topAnchor),
+        content.leadingAnchor.constraint(equalTo: self.customContainer.leadingAnchor),
+        content.trailingAnchor.constraint(equalTo: self.customContainer.trailingAnchor),
+        content.bottomAnchor.constraint(equalTo: self.customContainer.bottomAnchor),
+      ])
+    }
+
+    self.refreshTextPadding()
+    self.refreshAppearance()
+  }
+
+  private func showIcon(_ icon: BezierIcon, length: CGFloat) {
+    self.iconImageView.isHidden = false
+    self.iconImageView.image = icon.uiImage?.withRenderingMode(.alwaysTemplate)
+    self.iconWidthConstraint?.constant = length
+    self.iconHeightConstraint?.constant = length
+  }
+
+  private func refreshTextPadding() {
+    let padding = self.valueLabel.isHidden ? 0 : BezierSectionItemConstant.accessoryTextHorizontalPadding
+    self.directionalLayoutMargins = NSDirectionalEdgeInsets(
+      top: 0,
+      leading: padding,
+      bottom: 0,
+      trailing: padding
+    )
+  }
+
+  // MARK: - Trait
+
+  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    self.refreshAppearance()
+  }
+
+  // MARK: - Refresh
+
+  private func refreshAppearance() {
+    guard let accessory = self.accessory else { return }
+
+    self.iconImageView.tintColor = BezierSectionItemConstant.accessoryIconColor.palette(self)
+
+    let value: String?
+    switch accessory {
+    case .select(let selectedValue): value = selectedValue
+    case .multiselect(let values): value = BezierSectionItemConstant.multiselectText(values: values)
+    case .display(let displayValue): value = displayValue
+    default: value = nil
+    }
+
+    if let value {
+      self.valueLabel.attributedText = BezierSectionItemConstant.accessoryTextTypography.attributedString(
+        self,
+        text: value,
+        semanticColorToken: BezierSectionItemConstant.accessoryTextColor,
+        alignment: .right,
+        lineBreakMode: .byTruncatingTail
+      )
+    } else {
+      self.valueLabel.attributedText = nil
+    }
+  }
+}
+
+// MARK: - Toggle Indicator
+
+final class BezierSectionItemToggleView: UIView, BezierComponentable {
+  var colorTheme: BezierColorTheme { .systemBezierColorTheme() }
+  var componentTheme: BezierComponentTheme = .normal {
+    didSet { self.refreshAppearance() }
+  }
+
+  var isOn: Bool = false {
+    didSet { if oldValue != self.isOn { self.refresh() } }
+  }
+
+  private let thumbView = UIView()
+  private var thumbLeadingConstraint: NSLayoutConstraint?
+
+  init() {
+    super.init(frame: .zero)
+    self.setUp()
+  }
+
+  required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    self.setUp()
+  }
+
+  private func setUp() {
+    self.translatesAutoresizingMaskIntoConstraints = false
+    self.isUserInteractionEnabled = false
+    self.layer.cornerRadius = BezierSectionItemConstant.toggleCornerRadius
+
+    self.thumbView.translatesAutoresizingMaskIntoConstraints = false
+    self.thumbView.layer.cornerRadius = BezierSectionItemConstant.toggleThumbLength / 2
+    self.thumbView.layer.shadowColor = UIColor.black.cgColor
+    self.thumbView.layer.shadowOpacity = BezierSectionItemConstant.toggleThumbShadowOpacity
+    self.thumbView.layer.shadowOffset = BezierSectionItemConstant.toggleThumbShadowOffset
+    self.thumbView.layer.shadowRadius = BezierSectionItemConstant.toggleThumbShadowRadius
+    self.addSubview(self.thumbView)
+
+    let thumbLeading = self.thumbView.leadingAnchor.constraint(
+      equalTo: self.leadingAnchor,
+      constant: BezierSectionItemConstant.toggleThumbInset
+    )
+    self.thumbLeadingConstraint = thumbLeading
+    NSLayoutConstraint.activate([
+      self.widthAnchor.constraint(equalToConstant: BezierSectionItemConstant.toggleWidth),
+      self.heightAnchor.constraint(equalToConstant: BezierSectionItemConstant.toggleHeight),
+      thumbLeading,
+      self.thumbView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+      self.thumbView.widthAnchor.constraint(equalToConstant: BezierSectionItemConstant.toggleThumbLength),
+      self.thumbView.heightAnchor.constraint(equalToConstant: BezierSectionItemConstant.toggleThumbLength),
+    ])
+
+    self.refresh()
+  }
+
+  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    self.refreshAppearance()
+  }
+
+  private func refresh() {
+    self.thumbLeadingConstraint?.constant = self.isOn
+      ? BezierSectionItemConstant.toggleWidth
+        - BezierSectionItemConstant.toggleThumbInset
+        - BezierSectionItemConstant.toggleThumbLength
+      : BezierSectionItemConstant.toggleThumbInset
+    self.refreshAppearance()
+  }
+
+  private func refreshAppearance() {
+    self.backgroundColor = (
+      self.isOn
+        ? BezierSectionItemConstant.toggleTrackOnColor
+        : BezierSectionItemConstant.toggleTrackOffColor
+    ).palette(self)
+    self.thumbView.backgroundColor = BezierSectionItemConstant.toggleThumbColor.palette(self)
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierSectionItem/BezierSectionItemAccessoryView.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierSectionItem/BezierSectionItemAccessoryView.swift
@@ -10,7 +10,10 @@ final class BezierSectionItemAccessoryView: UIView, BezierComponentable {
 
   var colorTheme: BezierColorTheme { .systemBezierColorTheme() }
   var componentTheme: BezierComponentTheme = .normal {
-    didSet { self.refreshAppearance() }
+    didSet {
+      self.toggleView.componentTheme = self.componentTheme
+      self.refreshAppearance()
+    }
   }
 
   // MARK: - Private Properties

--- a/Sources/BezierSwift/MasterComponent/BezierSectionItem/BezierSectionItemSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierSectionItem/BezierSectionItemSpec.swift
@@ -1,0 +1,132 @@
+//
+//  BezierSectionItemSpec.swift
+//  BezierSwift
+//
+
+import CoreGraphics
+
+// MARK: - Size
+
+public enum BezierSectionItemSize: CaseIterable {
+  case small
+  case medium
+  case large
+
+  var minHeight: CGFloat {
+    switch self {
+    case .small: return 40
+    case .medium: return 48
+    case .large: return 52
+    }
+  }
+
+  var verticalPadding: CGFloat {
+    switch self {
+    case .small: return 6
+    case .medium: return 8
+    case .large: return 6
+    }
+  }
+
+  var leadingLength: CGFloat {
+    switch self {
+    case .small, .medium: return 24
+    case .large: return 36
+    }
+  }
+
+  var customLeadingLength: CGFloat {
+    switch self {
+    case .small, .medium: return 20
+    case .large: return 36
+    }
+  }
+
+  var isDescriptionNested: Bool {
+    self == .large
+  }
+}
+
+// MARK: - Leading
+
+public enum BezierSectionItemLeading<Content> {
+  case none
+  case icon(BezierIcon)
+  case avatar(Content)
+  case custom(Content)
+
+  var isCustom: Bool {
+    if case .custom = self { return true }
+    return false
+  }
+
+  var hasLeadingContent: Bool {
+    if case .none = self { return false }
+    return true
+  }
+
+  func leadingLength(size: BezierSectionItemSize) -> CGFloat {
+    self.isCustom ? size.customLeadingLength : size.leadingLength
+  }
+}
+
+// MARK: - Accessory
+
+public enum BezierSectionItemAccessory<Content> {
+  case navigation
+  case outlink
+  case select(value: String)
+  case multiselect(values: [String])
+  case display(value: String)
+  case toggle(isOn: Bool)
+  case custom(Content)
+}
+
+// MARK: - Constant
+
+public enum BezierSectionItemConstant {
+  public static let horizontalPadding: CGFloat = 10
+  public static let slotSpacing: CGFloat = 10
+  public static let labelRowSpacing: CGFloat = 4
+  public static let centerSlotHeight: CGFloat = 24
+  public static let descriptionIndent: CGFloat = 34
+  public static let nestedDescriptionSpacing: CGFloat = 2
+  public static let accessoryHeight: CGFloat = 32
+  public static let accessoryIconLength: CGFloat = 24
+  public static let accessoryChevronUpdownLength: CGFloat = 16
+  public static let accessoryTextSpacing: CGFloat = 6
+  public static let accessoryTextHorizontalPadding: CGFloat = 4
+  public static let toggleWidth: CGFloat = 50
+  public static let toggleHeight: CGFloat = 28
+  public static let toggleCornerRadius: CGFloat = 14
+  public static let toggleThumbLength: CGFloat = 24
+  public static let toggleThumbInset: CGFloat = 2
+  // Figma Switch(1095:19) thumb drop-shadow 실측: offset (0,2) / blur 4 / black 25%
+  // CALayer shadowRadius와 SwiftUI .shadow(radius:)는 gaussian σ 단위라 blur 4 = radius 2
+  public static let toggleThumbShadowOpacity: Float = 0.25
+  public static let toggleThumbShadowOffset = CGSize(width: 0, height: 2)
+  public static let toggleThumbShadowRadius: CGFloat = 2
+
+  static let disabledOpacity: CGFloat = BOGlobalToken.disabled
+
+  static let contentTypography: BTSemanticToken = .textXLarge(weight: .regular)
+  static let descriptionTypography: BTSemanticToken = .captionMedium(weight: .regular)
+  static let accessoryTextTypography: BTSemanticToken = .textLarge(weight: .regular)
+
+  static let contentColor: BCSemanticToken = .textNeutral
+  static let descriptionColor: BCSemanticToken = .textNeutralLighter
+  static let leadingIconColor: BCSemanticToken = .iconNeutralHeavy
+  static let pressedBackgroundColor: BCSemanticToken = .fillNeutralLighter
+  static let destructiveContentColor: BCSemanticToken = .textAccentRed
+  static let destructiveIconColor: BCSemanticToken = .iconAccentRed
+
+  static let accessoryTextColor: BCSemanticToken = .textNeutralLighter
+  static let accessoryIconColor: BCSemanticToken = .iconNeutral
+  static let toggleTrackOffColor: BCSemanticToken = .fillNeutralHeavy
+  static let toggleTrackOnColor: BCSemanticToken = .fillNeutralHeaviest
+  static let toggleThumbColor: BCSemanticToken = .iconInverseHeavier
+
+  static func multiselectText(values: [String]) -> String {
+    values.joined(separator: ", ")
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierSectionItem/SPEC.md
+++ b/Sources/BezierSwift/MasterComponent/BezierSectionItem/SPEC.md
@@ -1,0 +1,191 @@
+# BezierSectionItem SPEC
+
+> **SSOT**: [Figma · Mobile-Components / Internal/SectionItem (4762:196)](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=4762-196) · [Internal/SectionItemAccessory (5230:51815)](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=5230-51815)
+> **Design spec doc**: [team-design / bezier-v3 / components / Section-spec.md §13](https://github.com/channel-io/team-design/blob/main/bezier-v3/components/Section-spec.md) (보조 참조 — 값 충돌 시 Figma 파일 우선)
+
+Section 내부 리스트 아이템(Mobile) (Figma component description 1행).
+
+## 1. Component Properties
+
+### Internal/SectionItem (CS `4762:196`)
+
+| Property | 값 | 비고 |
+|---|---|---|
+| **size** | `small` / `medium`(기본) / `large` | 행 높이·leading 크기·description 구조 결정 |
+| **leadingType** | `none` / `icon` / `avatar` / `custom` | leading 콘텐츠 유형 |
+| **state** | `default` / `pressed` / `disabled` | |
+| **content** | TEXT (기본 "Label") | 레이블 (custom 제외) |
+| **hasDescription** | BOOLEAN, 기본 `false` | custom 미지원 |
+| **description** | TEXT (기본 "Description text") | 보조 설명 (custom 제외) |
+| **hasCenterSlot** | BOOLEAN, 기본 `false` | custom 미지원 |
+| **centerSlot** | SLOT (높이 24) | label 우측 인라인 슬롯 (custom 제외) |
+| **leadingIconSource** | SLOT | icon variant의 leading |
+| **leadingContent** | SLOT | custom variant의 leading (avatar variant는 Avatar 인스턴스) |
+| **centerContent** | SLOT | custom variant 전용 — label 대신 자유 콘텐츠 (기본 placeholder는 Label 텍스트) |
+| **hasAccessory** | BOOLEAN, 기본 `false` | |
+| **accessorySource** | INSTANCE_SWAP, 기본 `navigation` | SectionItemAccessory 7종 |
+
+총 instance: leadingType 4 × state 3 × size 3 = **36개**
+
+### Internal/SectionItemAccessory (CS `5230:51815`)
+
+| Property | 값 |
+|---|---|
+| **type** | `navigation`(기본) / `outlink` / `toggle` / `select` / `multiselect` / `display` / `custom` |
+| **content** | SLOT | custom variant 전용 자유 콘텐츠 |
+
+총 instance: **7개**
+
+## 2. Layout Spec
+
+### SectionItem 공통
+
+| Part | 값 |
+|---|---|
+| 루트 | 가로 배치, 세로 중앙 정렬, gap `10pt`, cornerRadius `0` |
+| 좌우 패딩 | `10pt` |
+| labelRow | label ↔ centerSlot gap `4pt`, centerSlot 높이 `24pt` |
+| accessory 영역 | 높이 `32pt` 고정, 행 우측 끝, 세로 중앙 |
+| 텍스트(label) | 1줄 (whitespace-nowrap) |
+
+### size 별
+
+| size | min-height | 상하 패딩 | leading (icon/avatar) | leading (custom) | description 구조 |
+|---|---|---|---|---|---|
+| `small` | `40pt` | `6pt` | `24×24` | `20×20` | de-nest (행 전체 아래) |
+| `medium` | `48pt` | `8pt` | `24×24` | `20×20` | de-nest (행 전체 아래) |
+| `large` | `52pt` | `6pt` | `36×36` | `36×36` | nested (centerContent 안, labelRow와 gap `2pt`) |
+
+### description 좌측 인덴트 (de-nest 구조: small/medium)
+
+| leadingType | 인덴트 |
+|---|---|
+| `none` | `0` |
+| `icon` | `34pt` |
+| `avatar` | `34pt` |
+| `custom` | — (description 미지원) |
+
+large(nested)는 인덴트 없음 (centerContent 좌측 정렬).
+
+### custom variant 구조 (flat)
+
+루트 직속: leadingContent SLOT → centerContent SLOT(flex-1, 세로 중앙). contentWrapper/labelWrapper 없음.
+
+### Accessory type 별
+
+| type | 구성 | 치수 |
+|---|---|---|
+| `navigation` | `icon/chevron-small-right` | 아이콘 `24×24` |
+| `outlink` | `icon/arrow-right-up-small` | 아이콘 `24×24` |
+| `select` | 값 텍스트 + `icon/chevron-updown`, gap `6pt`, 좌우 패딩 `4pt` | 아이콘 `16×16` |
+| `multiselect` | 콤마 나열 텍스트("Value1, Value2") + `icon/chevron-updown`, gap `6pt`, 좌우 패딩 `4pt` | 아이콘 `16×16` |
+| `display` | 값 텍스트만, 좌우 패딩 `4pt` | — |
+| `toggle` | Switch 인스턴스(비인터랙티브 상태 표시) | `50×28`, track radius `14`, thumb `24×24` (top `2`, left off `2` / on `24`) |
+| `custom` | 자유 SLOT | 높이 컨테이너 채움 |
+
+## 3. Color
+
+### SectionItem
+
+| 역할 | Token | Figma Variable | Raw |
+|---|---|---|---|
+| label 텍스트 | `textNeutral` | `color/text/neutral` | `#000000D9` |
+| description 텍스트 | `textNeutralLighter` | `color/text/neutral/lighter` | `#00000066` |
+| leading 아이콘 (icon variant 기본) | `iconNeutralHeavy` | `color/icon/neutral/heavy` | `#00000099` |
+| └ 실측 편차 | — | icon variant 9개 중 기본 variant(icon/default/medium)만 `color/icon/neutral/heavy`, 나머지 8개는 `color/icon/neutral`(#00000066)로 실측됨 | — |
+| pressed 배경 | `fillNeutralLighter` | `color/fill/neutral/lighter` | rgba(0,0,0,0.03) |
+| disabled | opacity `0.4` | — | — |
+
+### destructive (Figma component description 명시 — 코드 전용 boolean, variant 축 아님)
+
+| 역할 | Token |
+|---|---|
+| leading 아이콘 | `color/icon/accent/red` |
+| label 텍스트 | `color/text/red` |
+
+### Accessory
+
+| 역할 | Token | Figma Variable | Raw |
+|---|---|---|---|
+| 값 텍스트 (select/multiselect/display) | `textNeutralLighter` | `color/text/neutral/lighter` | `#00000066` |
+| 아이콘 (chevron-small-right / chevron-updown / arrow-right-up-small) | `iconNeutral` | `color/icon/neutral` | `#00000066` |
+| toggle track (off) | `fillNeutralHeavy` | `color/fill/neutral/heavy` | `#00000026` |
+| toggle track (on) | `fillNeutralHeaviest` | `color/fill/neutral/heaviest` | rgba(0,0,0,0.85) |
+| toggle thumb | `iconInverseHeavier` | `color/icon/inverse/heavier` | `#FFFFFF` |
+
+## 4. Typography
+
+### Case A — Typography Token 사용
+
+| 위치 | Token | Figma Style 이름 |
+|---|---|---|
+| label | `BTSemanticToken.textXLarge(weight: .regular)` | `Typography/text/xlarge` (16 / 400 / lh 24 / ls −0.1) |
+| description | `BTSemanticToken.captionMedium(weight: .regular)` | `Typography/caption/medium` (12 / 400 / lh 16 / ls 0) |
+| accessory 값 텍스트 | `BTSemanticToken.textLarge(weight: .regular)` | `Typography/text/large` (15 / 400 / lh 20 / ls −0.1) |
+
+### Case B — Custom Typography
+
+없음.
+
+## 5. State 별 시각 동작
+
+| State | 변경점 |
+|---|---|
+| `default` | 기본 |
+| `pressed` | 루트 배경 `fillNeutralLighter` |
+| `disabled` | 루트 전체 opacity `0.4`, 상호작용 차단 |
+
+## 6. 디자이너 가이드라인 (Figma component description 인용)
+
+### Internal/SectionItem
+
+- Used within Section / CollapsibleSection only. Do not place standalone.
+- size: small(40dp, leadingContent 24x24) / medium(48dp, 기본) / large(52dp, leadingContent 36x36, description nest 구조) — 전 variant 공통 적용
+- leadingType=custom: leadingContent(SLOT)+centerContent(SLOT) flat 구조. hasDescription/centerSlot 미지원
+- cornerRadius: 전 variant 0dp (DL-113)
+- trigger(display/navigate/outlink/select/multiselect/toggle/action)는 코드 prop이며 Figma variant 축이 아니다
+- trailingAccessory: hasAccessory + accessorySource(7종, 기본값 navigation). custom은 자유 SLOT — 허용: Text+Badge/StatusIndicator 등 HORIZONTAL 조합, 금지: focusable 요소
+- 단일 탭 타겟 불변식(Mobile): trailing에 Button/IconButton/Link/TextField 등 포커서블 컨트롤 배치 금지 — toggle의 Switch도 독립 컨트롤이 아닌 상태 표시자
+- destructive: 코드 전용 boolean(기본 false). true 시 leading 아이콘 color/icon/accent/red, title color/text/red
+- description은 비권장 — 정말 필요할 때만
+
+### Internal/SectionItemAccessory
+
+- Used within SectionItem only. Do not place standalone. 인터랙티브 컨트롤 없음(단일 탭 타겟 불변식).
+- trigger→기본 accessory는 이름이 대부분 1:1 대응(navigate→navigation, select→select, multiselect→multiselect, outlink→outlink, toggle→toggle, action/display→display)
+
+## 7. 매핑되는 코드 심볼
+
+| 정의 | 파일 |
+|---|---|
+| UIKit 구현 | `BezierSectionItem.swift` |
+| SwiftUI 구현 | `SUBezierSectionItem.swift` |
+| size / accessory / constant 정의 | `BezierSectionItemSpec.swift` |
+| accessory 뷰 (UIKit, internal) | `BezierSectionItemAccessoryView.swift` |
+
+아이콘 자산: `BezierIcon.chevronSmallRight` / `BezierIcon.arrowRightUpSmall` / `BezierIcon.chevronUpdown` (모두 실재 확인).
+
+## 8. Figma 외 · 협의 사항
+
+Figma에 없는 구현 결정은 아래에 분리 표기한다. SSOT 값이 아니다.
+
+1. **leadingType 코드 표현**: Figma variant 축을 코드에서는 `BezierSectionItemLeading` enum(`none` / `icon(BezierIcon)` / `avatar(뷰·View)` / `custom(뷰·View)`)으로 표현 — 단일 클래스/뷰가 4종을 흡수한다. custom일 때 `centerContent` 슬롯이 nil이면 `content` 텍스트를 기본 표시(Figma custom centerContent SLOT의 기본 placeholder가 Label 텍스트인 것과 대응).
+2. **trigger enum 스코프 제외**: trigger는 코드 prop(Figma 축 아님)이나, 탭 시맨틱(즉시저장·롤백·토스트)은 앱 영역이므로 이번 구현은 `onTap` 클로저 + `accessory` 직접 지정 API로 제공한다. trigger→accessory 기본값 파생은 소비자/후속 몫.
+3. **accessory 코드 표현**: `BezierSectionItemAccessory` enum — `navigation` / `outlink` / `select(value:)` / `multiselect(values:)` (콤마 결합 표시) / `display(value:)` / `toggle(isOn:)` / `custom(콘텐츠)`. 전부 비인터랙티브 표시자 (단일 탭 타겟 불변식).
+4. **toggle 표시자**: Switch 컴포넌트(`1095:19`)가 BezierSwift에 아직 없어, accessory 내부에 Switch의 Figma 실측값(50×28·radius 14·track off `fillNeutralHeavy`/on `fillNeutralHeaviest`·thumb 24 흰색, top 2, left 2/24)으로 비인터랙티브 시각을 직접 그린다. thumb 그림자 실측: offset (0, 2), blur 4, black 25% (thumb 벡터의 drop-shadow 필터). BezierSwitch 컴포넌트가 생기면 교체 대상.
+5. **description 인덴트 적용 규칙**: 구현은 de-nest 인덴트를 "leading 표시 시 34 / 없음(none) 0"으로 적용한다 (§2 표와 동일 — icon·avatar 공통 34).
+6. **BezierBaseItem 미재사용**: 좌우 패딩(6↔10)·radius(8↔0)·상하 패딩 축·description 배치 구조(de-nest/nested)가 BaseItem과 달라 코드 재사용 대신 동일 컨벤션의 독립 구현으로 간다.
+7. **press scale 적용**: Figma pressed state는 배경 fill 변화만 정의하나, BaseItem과 동일한 press scale 피드백(콘텐츠 0.97 축소 → release 오버슈트 복귀, reduce motion 시 비활성)을 협의로 적용한다 (2026-07-24). 구현은 internal 유틸 `BezierPressFeedback`(`Util/BezierPressFeedback.swift`) — public 승격·BaseItem 마이그레이션은 MOB-6471.
+8. **state 코드 매핑**: pressed → UIKit `isHighlighted` / SwiftUI ButtonStyle `isPressed`, disabled → `isEnabled`/`.disabled()`. `onTap == nil`이면 비인터랙티브(pressed 없음).
+9. **leading 아이콘 색 heavy 고정**: §3의 실측 편차(기본 variant만 heavy, 8개 variant는 neutral)에 대해 구현은 `iconNeutralHeavy`를 전 state·size에 고정 적용한다 — 근거: defaultVariant가 heavy이고, §5의 state 정의(배경/opacity만 변경)와 team-design Section-spec.md §13의 토큰 기재가 heavy를 지지.
+
+## 9. Variant 매트릭스
+
+```
+SectionItem: leadingType(none/icon/avatar/custom) × state(default/pressed/disabled) × size(small/medium/large) = 36
+  대표: icon/default/medium = 4762:151, icon/pressed/medium = 4762:159, icon/disabled/medium = 4762:167,
+        icon/default/small = 5265:16148, icon/default/large = 5266:613,
+        custom/default/medium = 4762:175, avatar/default/medium = 4906:253
+Accessory: navigation = 5230:51761, outlink = 5238:15987, toggle = 5230:51769, select = 5230:51773,
+           multiselect = 5238:15981, display = 5263:11526, custom = 5431:670
+```

--- a/Sources/BezierSwift/MasterComponent/BezierSectionItem/SPEC.md
+++ b/Sources/BezierSwift/MasterComponent/BezierSectionItem/SPEC.md
@@ -29,9 +29,9 @@ Section 내부 리스트 아이템(Mobile) (Figma component description 1행).
 
 ### Internal/SectionItemAccessory (CS `5230:51815`)
 
-| Property | 값 |
-|---|---|
-| **type** | `navigation`(기본) / `outlink` / `toggle` / `select` / `multiselect` / `display` / `custom` |
+| Property | 값 | 비고 |
+|---|---|---|
+| **type** | `navigation`(기본) / `outlink` / `toggle` / `select` / `multiselect` / `display` / `custom` | |
 | **content** | SLOT | custom variant 전용 자유 콘텐츠 |
 
 총 instance: **7개**

--- a/Sources/BezierSwift/MasterComponent/BezierSectionItem/SUBezierSectionItem.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierSectionItem/SUBezierSectionItem.swift
@@ -1,0 +1,365 @@
+//
+//  SUBezierSectionItem.swift
+//  BezierSwift
+//
+
+import SwiftUI
+
+public struct SUBezierSectionItem<CenterSlot: View>: View, Themeable {
+  @Environment(\.colorScheme) public var colorScheme
+  @Environment(\.isEnabled) private var isEnabled
+
+  private let size: BezierSectionItemSize
+  private let content: String
+  private let itemDescription: String?
+  private let leading: BezierSectionItemLeading<AnyView>
+  private let customCenterContent: AnyView?
+  private let accessory: BezierSectionItemAccessory<AnyView>?
+  private let isDestructive: Bool
+  private let onTap: (() -> Void)?
+  private let centerSlot: CenterSlot
+
+  public init(
+    size: BezierSectionItemSize = .medium,
+    content: String,
+    description: String? = nil,
+    leading: BezierSectionItemLeading<AnyView> = .none,
+    customCenterContent: AnyView? = nil,
+    accessory: BezierSectionItemAccessory<AnyView>? = nil,
+    isDestructive: Bool = false,
+    onTap: (() -> Void)? = nil,
+    @ViewBuilder centerSlot: () -> CenterSlot
+  ) {
+    self.size = size
+    self.content = content
+    self.itemDescription = description
+    self.leading = leading
+    self.customCenterContent = customCenterContent
+    self.accessory = accessory
+    self.isDestructive = isDestructive
+    self.onTap = onTap
+    self.centerSlot = centerSlot()
+  }
+
+  public var body: some View {
+    Group {
+      if let onTap = self.onTap {
+        Button(action: onTap) { self.row }
+          .buttonStyle(SUBezierSectionItemStyle(size: self.size))
+      } else {
+        self.row.modifier(SUBezierSectionItemContainer(size: self.size, isPressed: false))
+      }
+    }
+    .opacity(self.isEnabled ? 1 : BezierSectionItemConstant.disabledOpacity)
+    .allowsHitTesting(self.isEnabled)
+  }
+
+  private var row: some View {
+    HStack(spacing: BezierSectionItemConstant.slotSpacing) {
+      self.contentColumn
+      self.accessoryView
+    }
+  }
+
+  private var contentColumn: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      HStack(spacing: BezierSectionItemConstant.slotSpacing) {
+        self.leadingView
+
+        VStack(
+          alignment: .leading,
+          spacing: BezierSectionItemConstant.nestedDescriptionSpacing
+        ) {
+          self.labelRow
+
+          if self.size.isDescriptionNested {
+            self.descriptionView
+          }
+        }
+      }
+
+      if !self.size.isDescriptionNested {
+        self.descriptionView
+          .padding(
+            .leading,
+            self.leading.hasLeadingContent ? BezierSectionItemConstant.descriptionIndent : 0
+          )
+      }
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+  }
+
+  private var labelRow: some View {
+    HStack(spacing: BezierSectionItemConstant.labelRowSpacing) {
+      if self.leading.isCustom, let customCenterContent = self.customCenterContent {
+        customCenterContent
+      } else if !self.content.isEmpty {
+        Text(self.content)
+          .applyBezierFontStyle(
+            BezierSectionItemConstant.contentTypography,
+            semanticColorToken: self.isDestructive
+              ? BezierSectionItemConstant.destructiveContentColor
+              : BezierSectionItemConstant.contentColor
+          )
+          .lineLimit(1)
+          .truncationMode(.tail)
+      }
+
+      if !self.leading.isCustom, CenterSlot.self != EmptyView.self {
+        self.centerSlot
+          .frame(height: BezierSectionItemConstant.centerSlotHeight)
+      }
+
+      Spacer(minLength: 0)
+    }
+  }
+
+  @ViewBuilder
+  private var leadingView: some View {
+    switch self.leading {
+    case .none:
+      EmptyView()
+    case .icon(let icon):
+      icon.image
+        .renderingMode(.template)
+        .resizable()
+        .scaledToFit()
+        .foregroundColor(
+          self.palette(
+            self.isDestructive
+              ? BezierSectionItemConstant.destructiveIconColor
+              : BezierSectionItemConstant.leadingIconColor
+          )
+        )
+        .frame(
+          width: self.leading.leadingLength(size: self.size),
+          height: self.leading.leadingLength(size: self.size)
+        )
+    case .avatar(let view), .custom(let view):
+      view
+        .frame(
+          width: self.leading.leadingLength(size: self.size),
+          height: self.leading.leadingLength(size: self.size)
+        )
+    }
+  }
+
+  @ViewBuilder
+  private var descriptionView: some View {
+    if !self.leading.isCustom, let itemDescription = self.itemDescription, !itemDescription.isEmpty {
+      Text(itemDescription)
+        .applyBezierFontStyle(
+          BezierSectionItemConstant.descriptionTypography,
+          semanticColorToken: BezierSectionItemConstant.descriptionColor
+        )
+        .fixedSize(horizontal: false, vertical: true)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+  }
+
+  @ViewBuilder
+  private var accessoryView: some View {
+    if let accessory = self.accessory {
+      SUBezierSectionItemAccessoryView(accessory: accessory)
+    }
+  }
+}
+
+// MARK: - Convenience init (centerSlot 생략)
+
+extension SUBezierSectionItem where CenterSlot == EmptyView {
+  public init(
+    size: BezierSectionItemSize = .medium,
+    content: String,
+    description: String? = nil,
+    leading: BezierSectionItemLeading<AnyView> = .none,
+    customCenterContent: AnyView? = nil,
+    accessory: BezierSectionItemAccessory<AnyView>? = nil,
+    isDestructive: Bool = false,
+    onTap: (() -> Void)? = nil
+  ) {
+    self.init(
+      size: size,
+      content: content,
+      description: description,
+      leading: leading,
+      customCenterContent: customCenterContent,
+      accessory: accessory,
+      isDestructive: isDestructive,
+      onTap: onTap,
+      centerSlot: { EmptyView() }
+    )
+  }
+}
+
+// MARK: - Container
+
+private struct SUBezierSectionItemContainer: ViewModifier, Themeable {
+  @Environment(\.colorScheme) var colorScheme
+
+  let size: BezierSectionItemSize
+  let isPressed: Bool
+
+  func body(content: Content) -> some View {
+    content
+      // 콘텐츠만 축소 — pressed 배경은 full-size 유지
+      .bezierPressScale(isPressed: self.isPressed)
+      .padding(.horizontal, BezierSectionItemConstant.horizontalPadding)
+      .padding(.vertical, self.size.verticalPadding)
+      .frame(minHeight: self.size.minHeight)
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .background(
+        self.isPressed
+          ? self.palette(BezierSectionItemConstant.pressedBackgroundColor)
+          : Color.clear
+      )
+      .contentShape(Rectangle())
+  }
+}
+
+// MARK: - ButtonStyle (pressed 배경)
+
+private struct SUBezierSectionItemStyle: ButtonStyle {
+  let size: BezierSectionItemSize
+
+  func makeBody(configuration: Configuration) -> some View {
+    configuration.label
+      .modifier(SUBezierSectionItemContainer(size: self.size, isPressed: configuration.isPressed))
+  }
+}
+
+// MARK: - Accessory
+
+struct SUBezierSectionItemAccessoryView: View, Themeable {
+  @Environment(\.colorScheme) var colorScheme
+
+  let accessory: BezierSectionItemAccessory<AnyView>
+
+  var body: some View {
+    Group {
+      switch self.accessory {
+      case .navigation:
+        self.icon(.chevronSmallRight, length: BezierSectionItemConstant.accessoryIconLength)
+      case .outlink:
+        self.icon(.arrowRightUpSmall, length: BezierSectionItemConstant.accessoryIconLength)
+      case .select(let value):
+        self.valueWithChevron(value)
+      case .multiselect(let values):
+        self.valueWithChevron(BezierSectionItemConstant.multiselectText(values: values))
+      case .display(let value):
+        self.valueText(value)
+          .padding(.horizontal, BezierSectionItemConstant.accessoryTextHorizontalPadding)
+      case .toggle(let isOn):
+        SUBezierSectionItemToggleIndicator(isOn: isOn)
+      case .custom(let content):
+        content
+      }
+    }
+    .frame(height: BezierSectionItemConstant.accessoryHeight)
+  }
+
+  private func valueWithChevron(_ value: String) -> some View {
+    HStack(spacing: BezierSectionItemConstant.accessoryTextSpacing) {
+      self.valueText(value)
+      self.icon(.chevronUpdown, length: BezierSectionItemConstant.accessoryChevronUpdownLength)
+    }
+    .padding(.horizontal, BezierSectionItemConstant.accessoryTextHorizontalPadding)
+  }
+
+  private func valueText(_ value: String) -> some View {
+    Text(value)
+      .applyBezierFontStyle(
+        BezierSectionItemConstant.accessoryTextTypography,
+        semanticColorToken: BezierSectionItemConstant.accessoryTextColor
+      )
+      .lineLimit(1)
+      .truncationMode(.tail)
+  }
+
+  private func icon(_ icon: BezierIcon, length: CGFloat) -> some View {
+    icon.image
+      .renderingMode(.template)
+      .resizable()
+      .scaledToFit()
+      .foregroundColor(self.palette(BezierSectionItemConstant.accessoryIconColor))
+      .frame(width: length, height: length)
+  }
+}
+
+// MARK: - Toggle Indicator
+
+struct SUBezierSectionItemToggleIndicator: View, Themeable {
+  @Environment(\.colorScheme) var colorScheme
+
+  let isOn: Bool
+
+  var body: some View {
+    ZStack(alignment: self.isOn ? .trailing : .leading) {
+      RoundedRectangle(cornerRadius: BezierSectionItemConstant.toggleCornerRadius)
+        .fill(
+          self.palette(
+            self.isOn
+              ? BezierSectionItemConstant.toggleTrackOnColor
+              : BezierSectionItemConstant.toggleTrackOffColor
+          )
+        )
+
+      Circle()
+        .fill(self.palette(BezierSectionItemConstant.toggleThumbColor))
+        .frame(
+          width: BezierSectionItemConstant.toggleThumbLength,
+          height: BezierSectionItemConstant.toggleThumbLength
+        )
+        .shadow(
+          color: Color.black.opacity(Double(BezierSectionItemConstant.toggleThumbShadowOpacity)),
+          radius: BezierSectionItemConstant.toggleThumbShadowRadius,
+          x: BezierSectionItemConstant.toggleThumbShadowOffset.width,
+          y: BezierSectionItemConstant.toggleThumbShadowOffset.height
+        )
+        .padding(BezierSectionItemConstant.toggleThumbInset)
+    }
+    .frame(
+      width: BezierSectionItemConstant.toggleWidth,
+      height: BezierSectionItemConstant.toggleHeight
+    )
+  }
+}
+
+struct SUBezierSectionItem_Previews: PreviewProvider {
+  static var previews: some View {
+    ScrollView {
+      VStack(spacing: 0) {
+        SUBezierSectionItem(
+          content: "다음 화면 이동",
+          leading: .icon(.folder),
+          accessory: .navigation,
+          onTap: {}
+        )
+        SUBezierSectionItem(
+          content: "언어",
+          leading: .icon(.globe),
+          accessory: .select(value: "한국어"),
+          onTap: {}
+        )
+        SUBezierSectionItem(
+          content: "알림",
+          accessory: .toggle(isOn: true),
+          onTap: {}
+        )
+        SUBezierSectionItem(
+          size: .large,
+          content: "설명 있는 행",
+          description: "large는 description이 label 아래 nested로 배치됩니다.",
+          leading: .icon(.folder),
+          onTap: {}
+        )
+        SUBezierSectionItem(
+          content: "삭제",
+          leading: .icon(.trash),
+          isDestructive: true,
+          onTap: {}
+        )
+      }
+    }
+  }
+}

--- a/Sources/BezierSwift/Util/BezierPressFeedback.swift
+++ b/Sources/BezierSwift/Util/BezierPressFeedback.swift
@@ -1,0 +1,90 @@
+//
+//  BezierPressFeedback.swift
+//  BezierSwift
+//
+
+import SwiftUI
+import UIKit
+
+// 아이템형 컴포넌트 공통 press 피드백 (Figma 외 · 협의 — ch-desk-ios ListItemPressFeedback 참조)
+// 콘텐츠가 눌림 시 0.97로 축소되고, 뗄 때 살짝 오버슈트하며 복귀한다.
+// 대상은 콘텐츠 뷰만 — pressed 배경은 컴포넌트가 full-size로 유지한다.
+// public 승격 + BezierBaseItem 마이그레이션은 MOB-6471에서 다룬다.
+enum BezierPressFeedback {
+  static let pressScale: CGFloat = 0.97
+  static let pressInDuration: TimeInterval = 0.10
+  static let releaseDuration: TimeInterval = 0.40
+  static let releaseScaleValues: [NSNumber] = [0.97, 1.004, 1.0]
+  static let releaseScaleKeyTimes: [NSNumber] = [0, 0.55, 1.0]
+  static let springResponse: Double = 0.34
+  static let springDampingFraction: Double = 0.62
+
+  private static let releaseAnimationKey = "bezierPressFeedbackRelease"
+
+  // MARK: - UIKit
+
+  @MainActor
+  static func apply(isPressed: Bool, to contentView: UIView) {
+    guard !UIAccessibility.isReduceMotionEnabled else {
+      self.reset(contentView)
+      return
+    }
+
+    if isPressed {
+      contentView.layer.removeAnimation(forKey: self.releaseAnimationKey)
+      UIView.animate(
+        withDuration: self.pressInDuration,
+        delay: 0,
+        options: [.curveEaseInOut, .beginFromCurrentState]
+      ) {
+        contentView.transform = CGAffineTransform(
+          scaleX: self.pressScale,
+          y: self.pressScale
+        )
+      }
+    } else {
+      contentView.transform = .identity
+      let keyframe = CAKeyframeAnimation(keyPath: "transform.scale")
+      keyframe.values = self.releaseScaleValues
+      keyframe.keyTimes = self.releaseScaleKeyTimes
+      keyframe.duration = self.releaseDuration
+      keyframe.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+      keyframe.isRemovedOnCompletion = true
+      contentView.layer.add(keyframe, forKey: self.releaseAnimationKey)
+    }
+  }
+
+  @MainActor
+  static func reset(_ contentView: UIView) {
+    contentView.layer.removeAnimation(forKey: self.releaseAnimationKey)
+    contentView.transform = .identity
+  }
+}
+
+// MARK: - SwiftUI
+
+struct BezierPressScaleModifier: ViewModifier {
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+  let isPressed: Bool
+
+  func body(content: Content) -> some View {
+    content
+      .scaleEffect(
+        (self.isPressed && !self.reduceMotion) ? BezierPressFeedback.pressScale : 1
+      )
+      .animation(
+        .spring(
+          response: BezierPressFeedback.springResponse,
+          dampingFraction: BezierPressFeedback.springDampingFraction
+        ),
+        value: self.isPressed
+      )
+  }
+}
+
+extension View {
+  func bezierPressScale(isPressed: Bool) -> some View {
+    self.modifier(BezierPressScaleModifier(isPressed: isPressed))
+  }
+}

--- a/Tests/BezierSwiftTests/BezierSectionItemTests.swift
+++ b/Tests/BezierSwiftTests/BezierSectionItemTests.swift
@@ -1,0 +1,132 @@
+import Testing
+import UIKit
+@testable import BezierSwift
+
+// MARK: - Size Spec 해석
+
+@Suite("BezierSectionItemSize Spec 해석")
+struct BezierSectionItemSizeTests {
+  @Test("min-height는 40/48/52다")
+  func minHeights() {
+    #expect(BezierSectionItemSize.small.minHeight == 40)
+    #expect(BezierSectionItemSize.medium.minHeight == 48)
+    #expect(BezierSectionItemSize.large.minHeight == 52)
+  }
+
+  @Test("상하 패딩은 6/8/6이다")
+  func verticalPaddings() {
+    #expect(BezierSectionItemSize.small.verticalPadding == 6)
+    #expect(BezierSectionItemSize.medium.verticalPadding == 8)
+    #expect(BezierSectionItemSize.large.verticalPadding == 6)
+  }
+
+  @Test("leading 길이는 icon/avatar 24/24/36, custom 20/20/36이다")
+  func leadingLengths() {
+    #expect(BezierSectionItemSize.small.leadingLength == 24)
+    #expect(BezierSectionItemSize.medium.leadingLength == 24)
+    #expect(BezierSectionItemSize.large.leadingLength == 36)
+    #expect(BezierSectionItemSize.small.customLeadingLength == 20)
+    #expect(BezierSectionItemSize.medium.customLeadingLength == 20)
+    #expect(BezierSectionItemSize.large.customLeadingLength == 36)
+  }
+
+  @Test("description은 large만 nested다")
+  func descriptionNesting() {
+    #expect(BezierSectionItemSize.small.isDescriptionNested == false)
+    #expect(BezierSectionItemSize.medium.isDescriptionNested == false)
+    #expect(BezierSectionItemSize.large.isDescriptionNested == true)
+  }
+}
+
+// MARK: - Leading 해석
+
+@Suite("BezierSectionItemLeading 해석")
+@MainActor
+struct BezierSectionItemLeadingTests {
+  @Test("custom 판별과 leading 길이 선택")
+  func customLeadingLength() {
+    let custom = BezierSectionItemLeading<UIView>.custom(UIView())
+    let icon = BezierSectionItemLeading<UIView>.icon(.folder)
+    let none = BezierSectionItemLeading<UIView>.none
+
+    #expect(custom.isCustom)
+    #expect(custom.hasLeadingContent)
+    #expect(custom.leadingLength(size: .medium) == 20)
+    #expect(icon.isCustom == false)
+    #expect(icon.leadingLength(size: .medium) == 24)
+    #expect(none.hasLeadingContent == false)
+  }
+}
+
+// MARK: - Accessory
+
+@Suite("BezierSectionItemAccessory")
+@MainActor
+struct BezierSectionItemAccessoryTests {
+  @Test("multiselect 값은 콤마로 결합된다")
+  func multiselectJoin() {
+    #expect(BezierSectionItemConstant.multiselectText(values: ["Value1", "Value2"]) == "Value1, Value2")
+  }
+
+  @Test("toggle 표시자는 isOn에 따라 thumb 위치가 바뀐다")
+  func toggleThumbPosition() {
+    let toggle = BezierSectionItemToggleView()
+    toggle.isOn = false
+    toggle.layoutIfNeeded()
+
+    toggle.isOn = true
+    let onLeading = BezierSectionItemConstant.toggleWidth
+      - BezierSectionItemConstant.toggleThumbInset
+      - BezierSectionItemConstant.toggleThumbLength
+    #expect(onLeading == 24)
+  }
+
+  @Test("accessory 뷰는 높이 32 제약을 가진다")
+  func accessoryHeight() {
+    #expect(BezierSectionItemConstant.accessoryHeight == 32)
+  }
+}
+
+// MARK: - UIKit 구조
+
+@Suite("BezierSectionItem UIKit 구조", .serialized)
+@MainActor
+struct BezierSectionItemStructureTests {
+  @Test("custom leading은 description과 centerSlot을 숨긴다")
+  func customHidesDescriptionAndCenterSlot() {
+    let item = BezierSectionItem(content: "Label", description: "desc")
+    item.centerSlot = UIView()
+    item.leading = .custom(UIView())
+
+    let labels = Self.allLabels(in: item)
+    let visibleDescription = labels.contains {
+      $0.attributedText?.string == "desc" && !$0.isHidden
+    }
+    #expect(visibleDescription == false)
+  }
+
+  @Test("onTap이 없으면 상호작용이 비활성화된다")
+  func nonInteractiveWithoutOnTap() {
+    let item = BezierSectionItem(content: "Label")
+    #expect(item.isUserInteractionEnabled == false)
+
+    item.onTap = {}
+    #expect(item.isUserInteractionEnabled)
+  }
+
+  @Test("disabled면 alpha가 0.4다")
+  func disabledAlpha() {
+    let item = BezierSectionItem(content: "Label", onTap: {})
+    item.isEnabled = false
+    #expect(abs(item.alpha - 0.4) < 0.001)
+  }
+
+  private static func allLabels(in view: UIView) -> [UILabel] {
+    var result: [UILabel] = []
+    for subview in view.subviews {
+      if let label = subview as? UILabel { result.append(label) }
+      result.append(contentsOf: self.allLabels(in: subview))
+    }
+    return result
+  }
+}

--- a/Tests/BezierSwiftTests/BezierSectionItemTests.swift
+++ b/Tests/BezierSwiftTests/BezierSectionItemTests.swift
@@ -60,7 +60,7 @@ struct BezierSectionItemLeadingTests {
 
 // MARK: - Accessory
 
-@Suite("BezierSectionItemAccessory")
+@Suite("BezierSectionItemAccessory", .serialized)
 @MainActor
 struct BezierSectionItemAccessoryTests {
   @Test("multiselect 값은 콤마로 결합된다")
@@ -68,17 +68,27 @@ struct BezierSectionItemAccessoryTests {
     #expect(BezierSectionItemConstant.multiselectText(values: ["Value1", "Value2"]) == "Value1, Value2")
   }
 
-  @Test("toggle 표시자는 isOn에 따라 thumb 위치가 바뀐다")
+  @Test("toggle 표시자는 isOn에 따라 thumb 실측 위치가 바뀐다")
   func toggleThumbPosition() {
+    let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
     let toggle = BezierSectionItemToggleView()
+    window.addSubview(toggle)
+    NSLayoutConstraint.activate([
+      toggle.leadingAnchor.constraint(equalTo: window.leadingAnchor),
+      toggle.topAnchor.constraint(equalTo: window.topAnchor),
+    ])
+
     toggle.isOn = false
-    toggle.layoutIfNeeded()
+    window.layoutIfNeeded()
+    let thumb = toggle.subviews.first
+    #expect(thumb?.frame.minX == BezierSectionItemConstant.toggleThumbInset)
 
     toggle.isOn = true
+    window.layoutIfNeeded()
     let onLeading = BezierSectionItemConstant.toggleWidth
       - BezierSectionItemConstant.toggleThumbInset
       - BezierSectionItemConstant.toggleThumbLength
-    #expect(onLeading == 24)
+    #expect(thumb?.frame.minX == onLeading)
   }
 
   @Test("accessory 뷰는 높이 32 제약을 가진다")
@@ -95,7 +105,8 @@ struct BezierSectionItemStructureTests {
   @Test("custom leading은 description과 centerSlot을 숨긴다")
   func customHidesDescriptionAndCenterSlot() {
     let item = BezierSectionItem(content: "Label", description: "desc")
-    item.centerSlot = UIView()
+    let slotView = UIView()
+    item.centerSlot = slotView
     item.leading = .custom(UIView())
 
     let labels = Self.allLabels(in: item)
@@ -103,6 +114,20 @@ struct BezierSectionItemStructureTests {
       $0.attributedText?.string == "desc" && !$0.isHidden
     }
     #expect(visibleDescription == false)
+    #expect(slotView.superview?.isHidden == true)
+  }
+
+  @Test("custom leading 이후에 설정한 centerSlot도 숨겨진다")
+  func centerSlotSetAfterCustomLeadingStaysHidden() {
+    let item = BezierSectionItem(content: "Label")
+    item.leading = .custom(UIView())
+
+    let slotView = UIView()
+    item.centerSlot = slotView
+    #expect(slotView.superview?.isHidden == true)
+
+    item.leading = .icon(.folder)
+    #expect(slotView.superview?.isHidden == false)
   }
 
   @Test("onTap이 없으면 상호작용이 비활성화된다")

--- a/Tests/BezierSwiftTests/BezierSectionTests.swift
+++ b/Tests/BezierSwiftTests/BezierSectionTests.swift
@@ -43,21 +43,28 @@ struct BezierSectionAppearanceTests {
     #expect(divider.trailingInset == 0)
   }
 
-  @Test("decoration elementKind는 왕복 변환된다", arguments: BezierSectionVariant.allCases)
-  func decorationElementKindRoundTrips(variant: BezierSectionVariant) {
-    let kind = variant.decorationElementKind
-    #expect(BezierSectionVariant(decorationElementKind: kind) == variant)
+  @Test("decoration elementKind는 왕복 변환된다", arguments: BezierSectionDecorationKind.allCases)
+  func decorationElementKindRoundTrips(kind: BezierSectionDecorationKind) {
+    let parsed = BezierSectionDecorationKind(elementKind: kind.elementKind)
+    #expect(parsed == kind)
+    #expect(
+      BezierSectionDecorationKind(
+        variant: kind.variant,
+        componentTheme: kind.componentTheme
+      ) == kind
+    )
   }
 
-  @Test("variant마다 decoration elementKind가 유일하다")
+  @Test("variant × componentTheme마다 decoration elementKind가 유일하다")
   func decorationElementKindsAreUnique() {
-    let kinds = BezierSectionVariant.allCases.map(\.decorationElementKind)
+    let kinds = BezierSectionDecorationKind.allCases.map(\.elementKind)
     #expect(Set(kinds).count == kinds.count)
+    #expect(kinds.count == BezierSectionVariant.allCases.count * 2)
   }
 
-  @Test("알 수 없는 elementKind는 variant로 해석되지 않는다")
+  @Test("알 수 없는 elementKind는 해석되지 않는다")
   func unknownElementKindReturnsNil() {
-    #expect(BezierSectionVariant(decorationElementKind: "unknown") == nil)
+    #expect(BezierSectionDecorationKind(elementKind: "unknown") == nil)
   }
 }
 

--- a/Tests/BezierSwiftTests/BezierSectionTests.swift
+++ b/Tests/BezierSwiftTests/BezierSectionTests.swift
@@ -1,0 +1,159 @@
+import Testing
+import UIKit
+@testable import BezierSwift
+
+// MARK: - Appearance 해석
+
+@Suite("BezierSectionVariant Appearance 해석")
+struct BezierSectionAppearanceTests {
+  @Test("solid는 chrome/divider가 없다")
+  func solidHasNoChrome() {
+    let appearance = BezierSectionVariant.solid.appearance
+
+    #expect(appearance.backgroundColor == nil)
+    #expect(appearance.border == nil)
+    #expect(appearance.divider == nil)
+    #expect(appearance.hasChrome == false)
+    #expect(appearance.contentInsets.top == 0)
+    #expect(appearance.contentInsets.leading == 0)
+    #expect(appearance.contentInsets.bottom == 0)
+    #expect(appearance.contentInsets.trailing == 0)
+  }
+
+  @Test("card는 surface 배경/테두리/라운드/divider를 가진다")
+  func cardHasChromeAndDivider() throws {
+    let appearance = BezierSectionVariant.card.appearance
+
+    #expect(appearance.backgroundColor == .surface)
+    #expect(appearance.cornerRadius == 16)
+    #expect(appearance.hasChrome == true)
+    #expect(appearance.contentInsets.top == 2)
+    #expect(appearance.contentInsets.leading == 0)
+    #expect(appearance.contentInsets.bottom == 2)
+    #expect(appearance.contentInsets.trailing == 0)
+
+    let border = try #require(appearance.border)
+    #expect(border.color == .borderNeutral)
+    #expect(border.width == 1)
+
+    let divider = try #require(appearance.divider)
+    #expect(divider.color == .borderNeutral)
+    #expect(divider.thickness == 1)
+    #expect(divider.leadingInset == 0)
+    #expect(divider.trailingInset == 0)
+  }
+
+  @Test("decoration elementKind는 왕복 변환된다", arguments: BezierSectionVariant.allCases)
+  func decorationElementKindRoundTrips(variant: BezierSectionVariant) {
+    let kind = variant.decorationElementKind
+    #expect(BezierSectionVariant(decorationElementKind: kind) == variant)
+  }
+
+  @Test("variant마다 decoration elementKind가 유일하다")
+  func decorationElementKindsAreUnique() {
+    let kinds = BezierSectionVariant.allCases.map(\.decorationElementKind)
+    #expect(Set(kinds).count == kinds.count)
+  }
+
+  @Test("알 수 없는 elementKind는 variant로 해석되지 않는다")
+  func unknownElementKindReturnsNil() {
+    #expect(BezierSectionVariant(decorationElementKind: "unknown") == nil)
+  }
+}
+
+// MARK: - LabelColor 해석
+
+@Suite("BezierSectionLabelColor 색 토큰")
+struct BezierSectionLabelColorTests {
+  @Test("neutralDark → textNeutral, neutralLight → textNeutralLighter")
+  func labelColorTokens() {
+    #expect(BezierSectionLabelColor.neutralDark.textColor == .textNeutral)
+    #expect(BezierSectionLabelColor.neutralLight.textColor == .textNeutralLighter)
+  }
+}
+
+// MARK: - 정적 컨테이너 구조
+
+@Suite("BezierSection 정적 컨테이너", .serialized)
+@MainActor
+struct BezierSectionContainerTests {
+  @Test("card는 행 사이에 divider를 인터리브한다")
+  func cardInterleavesDividers() {
+    let section = BezierSection(variant: .card, items: Self.makeItems(3))
+
+    #expect(Self.allDividers(in: section).count == 2)
+  }
+
+  @Test("solid는 divider를 넣지 않는다")
+  func solidHasNoDividers() {
+    let section = BezierSection(variant: .solid, items: Self.makeItems(3))
+
+    #expect(Self.allDividers(in: section).isEmpty)
+  }
+
+  @Test("setItems를 다시 호출해도 divider 개수가 일관된다")
+  func setItemsRebuildsDividers() {
+    let section = BezierSection(variant: .card, items: Self.makeItems(3))
+    section.setItems(Self.makeItems(5))
+
+    #expect(section.items.count == 5)
+    #expect(Self.allDividers(in: section).count == 4)
+  }
+
+  @Test("variant를 바꾸면 divider가 재구성된다")
+  func variantChangeRebuildsDividers() {
+    let section = BezierSection(variant: .card, items: Self.makeItems(3))
+    section.variant = .solid
+
+    #expect(Self.allDividers(in: section).isEmpty)
+
+    section.variant = .card
+    #expect(Self.allDividers(in: section).count == 2)
+  }
+
+  @Test("addItem은 divider를 유지하며 행을 추가한다")
+  func addItemAppendsRow() {
+    let section = BezierSection(variant: .card, items: Self.makeItems(2))
+    section.addItem(UIView())
+
+    #expect(section.items.count == 3)
+    #expect(Self.allDividers(in: section).count == 2)
+  }
+
+  @Test("labelText가 nil이면 label이 숨는다")
+  func nilLabelTextHidesLabel() throws {
+    let section = BezierSection(variant: .solid, items: Self.makeItems(1))
+
+    let label = try #require(Self.sectionLabel(in: section))
+    #expect(label.isHidden)
+
+    section.labelText = "태그"
+    #expect(label.isHidden == false)
+
+    section.labelText = nil
+    #expect(label.isHidden)
+  }
+
+  // MARK: - Helpers
+
+  private static func makeItems(_ count: Int) -> [UIView] {
+    (0..<count).map { _ in UIView() }
+  }
+
+  private static func sectionLabel(in view: UIView) -> BezierSectionLabel? {
+    for subview in view.subviews {
+      if let label = subview as? BezierSectionLabel { return label }
+      if let found = self.sectionLabel(in: subview) { return found }
+    }
+    return nil
+  }
+
+  private static func allDividers(in view: UIView) -> [BezierSectionRowDivider] {
+    var result: [BezierSectionRowDivider] = []
+    for subview in view.subviews {
+      if let divider = subview as? BezierSectionRowDivider { result.append(divider) }
+      result.append(contentsOf: self.allDividers(in: subview))
+    }
+    return result
+  }
+}


### PR DESCRIPTION



## MOB-6455

https://linear.app/channel/issue/MOB-6455

V3 Section 컴포넌트 패밀리(Section / SectionLabel / SectionItem)를 UIKit + SwiftUI로 구현합니다.

## 구현 내용

### Section — `BezierSection` / `SUBezierSection` / `BezierSectionLayout`

- variant `solid` / `card` — 배경(`surface`)·테두리(`borderNeutral` 1pt)·radius 16·행간 divider를 `BezierSectionVariant.Appearance` 한곳에서 해석
- `labelText`(nil = 미표시)로 SectionLabel 표시, `labelColor` neutralDark / neutralLight
- UIKit 동적 리스트: UICollectionViewCompositionalLayout 전용 `BezierSectionLayout`
  - 섹션 chrome은 variant별 elementKind background decoration 1장, 행간 divider는 list separator (`UICollectionViewListCell` 전제)
  - `register(in:)` 필수 호출 계약, label은 32pt boundary header + decoration top inset으로 겹침 상쇄
- UIKit 정적 컨테이너: `BezierSection` (UIStackView 기반) — divider 인터리브, 다크모드 시 `layer.borderColor` CGColor 재주입
- SwiftUI: `SUBezierSection` 데이터 주도 init 4종 (ForEach 동형, ScrollView + LazyVStack 내 사용)

### SectionLabel — `BezierSectionLabel` / `SUBezierSectionLabel`

- 최소 높이 32 / 좌우 패딩 10 / radius 8 / leading 슬롯 20×20 (gap 8) / trailing 슬롯 높이 20 (gap 4)
- 타이포 `textMedium(weight: .bold)`, 1줄 ellipsis

### SectionItem — `BezierSectionItem` / `SUBezierSectionItem`

- size small / medium / large (minHeight 40/48/52 · 상하 패딩 6/8/6 · leading 24/24/36 · custom leading 20/20/36)
- leading none / icon / avatar / custom — custom은 description·centerSlot 강제 숨김 (Figma 구조와 동일)
- accessory 7종: navigation / outlink / select / multiselect / display / toggle / custom — 전부 비인터랙티브 표시자 (행 전체가 단일 탭 타겟)
- description: small·medium은 de-nest (leading 존재 시 인덴트 34), large는 nested (gap 2)
- 좌우 패딩 10은 아이템이 소유 — Section의 좌우 인셋은 0 (pressed 배경이 카드 테두리까지 차오르는 Figma 구조 유지)
- press 피드백: pressed 배경 `fillNeutralLighter` + 콘텐츠 0.97 축소·release 오버슈트 복귀 — internal 유틸 `BezierPressFeedback`으로 추출 (public 승격 + BaseItem 마이그레이션: MOB-6471)
- toggle 표시자는 Switch(`1095:19`) 실측값(50×28 · radius 14 · thumb 24 · 그림자 (0,2)/blur4/25%)으로 자체 렌더 — BezierSwitch 도입 시 교체 대상

## Spec 검증

figma-component-spec 3단계 사이클로 검증했습니다 (Figma = SSOT):

- Phase 1: Figma 실측 기반 `SPEC.md` 작성 (Section `4990:10604` / SectionLabel `1856:32` / SectionItem `4762:196`)
- Phase 2: Properties / Layout / Color / Typography / Asset / Spec Noise / Implementation Reference 7종 병렬 검증 전부 통과
- Phase 3: UIKit·SwiftUI Implementation Validator로 구현–SPEC 일치 확인
- Figma에 없는 구현 결정(BaseItem 미재사용 사유, leading 아이콘 색 heavy 고정, trigger enum 스코프 제외, press scale 적용 등)은 각 `SPEC.md` §8에 협의 사항으로 분리 기록

## 스크린샷

### Section / SectionLabel

| card (SwiftUI) | card (UIKit) | solid (SwiftUI) | solid (UIKit) |
|---|---|---|---|
| <img src="https://github.com/user-attachments/assets/b418592e-7be9-4677-be04-fc791f57fee1" width="220" alt="01-section-card-swiftui" /> | <img src="https://github.com/user-attachments/assets/c97176e4-0ad7-4d85-bf3f-1a94a0178bbb" width="220" alt="02-section-card-uikit" /> | <img src="https://github.com/user-attachments/assets/da45b8a4-a651-47d5-bbed-d97a751a20ec" width="220" alt="04-section-solid-swiftui" /> | <img src="https://github.com/user-attachments/assets/3bf0a34f-30ba-4d2e-9f35-685c7d9145cc" width="220" alt="05-section-solid-uikit" /> |

| hasLabel off | labelColor neutralLight | dark (SwiftUI) | dark (UIKit) |
|---|---|---|---|
| <img src="https://github.com/user-attachments/assets/52b4cc61-9882-4dc2-b777-803f61693934" width="220" alt="06-section-solid-nolabel" /> | <img src="https://github.com/user-attachments/assets/18af6f67-37fc-423e-b11f-dc87d2c1c320" width="220" alt="07-section-solid-labelcolor-neutrallight" /> | <img src="https://github.com/user-attachments/assets/07f79ecb-e3e0-4dd1-aa2b-89f37370861d" width="220" alt="08-section-card-dark" /> | <img src="https://github.com/user-attachments/assets/8d9ff89c-5db0-46e2-8808-dff2b6c78ef2" width="220" alt="09-section-card-dark-uikit" /> |

### SectionItem

| 기본 (medium·icon·navigation) | UIKit | medium + description (de-nest 34) | large + description (nested) |
|---|---|---|---|
| <img src="https://github.com/user-attachments/assets/0196b5bc-07b8-4cf2-b189-3c29ce889223" width="220" alt="10-sectionitem-default" /> | <img src="https://github.com/user-attachments/assets/5999f95b-25cd-46af-a986-c34fd167f029" width="220" alt="11-sectionitem-uikit" /> | <img src="https://github.com/user-attachments/assets/12c7b17a-b5a1-4a5b-8898-cfc3a1f458f5" width="220" alt="12-sectionitem-medium-description" /> | <img src="https://github.com/user-attachments/assets/004c0a9f-9b67-4114-99f5-1b4956b4f61e" width="220" alt="13-sectionitem-large-description-nested" /> |

| small | avatar | custom leading (description 자동 숨김) | accessory select |
|---|---|---|---|
| <img src="https://github.com/user-attachments/assets/9983c35b-264d-41a2-afd3-0062ef27a9d8" width="220" alt="14-sectionitem-small-description" /> | <img src="https://github.com/user-attachments/assets/0a2076d8-f5e9-407d-8594-4152de60f92d" width="220" alt="15-sectionitem-avatar" /> | <img src="https://github.com/user-attachments/assets/9edddae8-2c0a-4097-a4d5-4dac1861e9f8" width="220" alt="16-sectionitem-custom-leading" /> | <img src="https://github.com/user-attachments/assets/8c9db9c2-fb34-4e77-a1ac-8fc11f19e0a0" width="220" alt="17-sectionitem-accessory-select" /> |

| multiselect | toggle on | toggle off | destructive |
|---|---|---|---|
| <img src="https://github.com/user-attachments/assets/ae15818f-31e2-41f4-bc9b-9d59f9b0b86c" width="220" alt="18-sectionitem-accessory-multiselect" /> | <img src="https://github.com/user-attachments/assets/dd155d8b-2767-4ff3-bd0b-514c718ab87c" width="220" alt="19-sectionitem-accessory-toggle-on" /> | <img src="https://github.com/user-attachments/assets/fcfde383-04c6-4bb1-93f2-798fcbe87c6b" width="220" alt="20-sectionitem-accessory-toggle-off" /> | <img src="https://github.com/user-attachments/assets/bef6c73d-d6f7-40b9-9379-b29eb46bac06" width="220" alt="21-sectionitem-destructive" /> |

| disabled | dark | press 중 (0.97 scale + pressed bg) |
|---|---|---|
| <img src="https://github.com/user-attachments/assets/7f3e624f-b645-4f46-909f-48fee295f882" width="220" alt="22-sectionitem-disabled" /> | <img src="https://github.com/user-attachments/assets/df7b46fb-1fc6-422f-9ab4-f86ec4f95183" width="220" alt="23-sectionitem-dark" /> | <img src="https://github.com/user-attachments/assets/03dc4ff3-22b4-4722-b926-8ce0f0ef13cb" width="220" alt="24-sectionitem-press-feedback" /> |

## 테스트

- `BezierSectionTests` + `BezierSectionItemTests` — `xcodebuild test` 통과
- Examples 카탈로그 (Section / SectionItem) 추가, 시뮬레이터 라이트·다크 모드 시각 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

- **새 기능**
  - UIKit 및 SwiftUI용 Section, Section Label, Section Item 컴포넌트를 추가했습니다.
  - 솔리드/카드 스타일, 라벨 표시, 항목 구분선, leading 및 다양한 액세서리(선택/멀티셀렉트/토글/커스텀 등), 설명·비활성·파괴적 상태와 선택/눌림 피드백을 지원합니다.
  - 예제 카탈로그에 Section/Section Item 데모를 추가했습니다.

- **문서**
  - Section 및 Section Item의 디자인·레이아웃 사양을 문서화했습니다.

- **테스트**
  - 스타일/레이아웃/상태 변경 및 상호작용 동작을 검증하는 테스트를 추가했습니다.

- **기타**
  - 예제 Swift 패키지 참조 설정을 정리했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->