### PR TITLE
[MOB-6473] V3 컴포넌트 public API doc comment 추가 (consumer 사용 가이드)

### DIFF
--- a/Sources/BezierSwift/MasterComponent/BezierAvatar/BezierAvatar.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierAvatar/BezierAvatar.swift
@@ -5,6 +5,7 @@
 
 import UIKit
 
+/// 사용자·대상을 나타내는 아바타 (UIKit). 이미지·크기·테두리·접속 상태 표식을 조합한다. SwiftUI에서는 `SUBezierAvatar`를 사용한다.
 public final class BezierAvatar: UIView, BezierComponentable {
   // MARK: - BezierComponentable
 
@@ -15,22 +16,27 @@ public final class BezierAvatar: UIView, BezierComponentable {
 
   // MARK: - Public Properties
 
+  /// 아바타에 표시할 이미지. 없으면 빈 영역으로 렌더된다.
   public var image: UIImage? {
     didSet { self.imageView.image = self.image }
   }
 
+  /// 아바타 크기. 기본값은 `.size24`다.
   public var size: BezierAvatarSize = .size24 {
     didSet { if oldValue != self.size { self.refreshLayout() } }
   }
 
+  /// 테두리 표시 여부. 기본값은 `false`다.
   public var showBorder: Bool = false {
     didSet { if oldValue != self.showBorder { self.refreshAppearance() } }
   }
 
+  /// 겹쳐 표시할 접속 상태 표식. `nil`이면 표식을 그리지 않는다.
   public var statusType: BezierStatusType? {
     didSet { self.refreshStatusOverlay() }
   }
 
+  /// 활성 여부. `false`면 흐리게(opacity `0.4`) 표시된다. 기본값은 `true`다.
   public var isEnabled: Bool = true {
     didSet { self.alpha = self.isEnabled ? 1.0 : BezierAvatarConstant.disabledOpacity }
   }
@@ -69,6 +75,7 @@ public final class BezierAvatar: UIView, BezierComponentable {
 
   // MARK: - Init
 
+  /// 이미지·크기·테두리·상태 표식을 지정해 아바타를 만든다. 모든 인자는 기본값이 있어 필요한 것만 넘기면 된다.
   public init(
     image: UIImage? = nil,
     size: BezierAvatarSize = .size24,

--- a/Sources/BezierSwift/MasterComponent/BezierAvatar/BezierAvatarSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierAvatar/BezierAvatarSpec.swift
@@ -7,17 +7,29 @@ import CoreGraphics
 
 // MARK: - Avatar Size
 
+/// 아바타의 지름 크기. Figma `Avatar` 컴포넌트의 `size` 프로퍼티에 대응 (Figma 값 `"20"` = `.size20`, bare 숫자에 `size` prefix가 붙은 형태). Figma엔 `60`이 있으나 Swift엔 없고, `.size16`·`.size160`은 모바일 parity로 추가된 값이다.
 public enum BezierAvatarSize: String, CaseIterable {
+  /// 초소형. 모바일 전용 예외 크기다.
   case size16
+  /// 드롭다운·칩·인라인 식별자에 쓴다.
   case size20
+  /// 대화 목록·발신자·알림에 쓰는 기본 크기다.
   case size24
+  /// 사이드바 팀원 목록에 쓴다.
   case size30
+  /// 담당자 배지·대화 헤더에 쓴다.
   case size36
+  /// 고객정보 패널 상단에 쓴다.
   case size42
+  /// 프로필 카드 헤더에 쓴다.
   case size48
+  /// 설정 내 프로필·상세 모달에 쓴다. 목록 안에서는 쓰지 않는다.
   case size72
+  /// 모달 대형·온보딩에 쓴다. 목록 안에서는 쓰지 않는다.
   case size90
+  /// 계정 설정 대표 프로필에 쓴다. 목록 안에서는 쓰지 않는다.
   case size120
+  /// 최대 크기. 목록 안에서는 쓰지 않는다.
   case size160
 
   public var length: CGFloat {

--- a/Sources/BezierSwift/MasterComponent/BezierAvatar/BezierStatus.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierAvatar/BezierStatus.swift
@@ -5,6 +5,7 @@
 
 import UIKit
 
+/// 접속 상태를 나타내는 표식 (UIKit). 보통 `BezierAvatar`가 내부에서 사용하지만 단독으로도 쓸 수 있다. SwiftUI에서는 `SUBezierStatus`를 사용한다.
 public final class BezierStatus: UIView, BezierComponentable {
   // MARK: - BezierComponentable
 
@@ -15,10 +16,12 @@ public final class BezierStatus: UIView, BezierComponentable {
 
   // MARK: - Public Properties
 
+  /// 표시할 접속 상태 종류다.
   public var type: BezierStatusType {
     didSet { if oldValue != self.type { self.refreshContent() } }
   }
 
+  /// 표식 크기다.
   public var size: BezierStatusSize {
     didSet { if oldValue != self.size { self.refreshLayout() } }
   }
@@ -49,6 +52,7 @@ public final class BezierStatus: UIView, BezierComponentable {
 
   // MARK: - Init
 
+  /// 상태 종류와 크기를 지정해 표식을 만든다.
   public init(type: BezierStatusType, size: BezierStatusSize) {
     self.type = type
     self.size = size

--- a/Sources/BezierSwift/MasterComponent/BezierAvatar/BezierStatusSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierAvatar/BezierStatusSpec.swift
@@ -7,11 +7,17 @@ import CoreGraphics
 
 // MARK: - Status Type
 
+/// 아바타에 겹쳐 표시하는 접속 상태 표식. Figma `Avatar`의 status overlay에 대응.
 public enum BezierStatusType: String, CaseIterable {
+  /// 접속 중.
   case online
+  /// 미접속.
   case offline
+  /// 잠금·비활성 상태.
   case lock
+  /// 접속 중이나 방해 금지(Do Not Disturb).
   case onlineDnd
+  /// 미접속·방해 금지(Do Not Disturb).
   case offlineDnd
 
   /// 내부 원(_circle) fill. 아이콘 type에서는 아이콘 배경 역할.
@@ -46,11 +52,17 @@ public enum BezierStatusType: String, CaseIterable {
 
 // MARK: - Status Size
 
+/// status 표식의 크기. 겹치는 아바타 크기에 맞춰 고른다. Figma `Avatar`의 status overlay 크기에 대응.
 public enum BezierStatusSize: String, CaseIterable {
+  /// 소형 아바타(size20·24)에 맞는 status 크기다.
   case small
+  /// 중형 아바타(size30·36·42)에 맞는 status 크기다.
   case medium
+  /// size48 아바타에 맞는 status 크기다.
   case large
+  /// 대형 아바타(size72·90)에 맞는 status 크기다.
   case xlarge
+  /// 최대형 아바타(size120·160)에 맞는 status 크기다.
   case xxlarge
 
   public var containerLength: CGFloat {

--- a/Sources/BezierSwift/MasterComponent/BezierAvatar/SUBezierAvatar.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierAvatar/SUBezierAvatar.swift
@@ -5,6 +5,7 @@
 
 import SwiftUI
 
+/// 사용자·대상을 나타내는 아바타 (SwiftUI). 이미지·크기·테두리·접속 상태 표식을 조합한다. UIKit에서는 `BezierAvatar`를 사용한다.
 public struct SUBezierAvatar: View, Themeable {
   private let image: Image?
   private let size: BezierAvatarSize
@@ -14,6 +15,7 @@ public struct SUBezierAvatar: View, Themeable {
   @Environment(\.colorScheme) public var colorScheme
   @Environment(\.isEnabled) private var isEnabled
 
+  /// 이미지·크기·테두리·상태 표식을 지정해 아바타를 만든다. 모든 인자는 기본값이 있어 필요한 것만 넘기면 된다.
   public init(
     image: Image? = nil,
     size: BezierAvatarSize = .size24,

--- a/Sources/BezierSwift/MasterComponent/BezierAvatar/SUBezierStatus.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierAvatar/SUBezierStatus.swift
@@ -5,12 +5,14 @@
 
 import SwiftUI
 
+/// 접속 상태를 나타내는 표식 (SwiftUI). 보통 `SUBezierAvatar`가 내부에서 사용하지만 단독으로도 쓸 수 있다. UIKit에서는 `BezierStatus`를 사용한다.
 public struct SUBezierStatus: View, Themeable {
   private let type: BezierStatusType
   private let size: BezierStatusSize
 
   @Environment(\.colorScheme) public var colorScheme
 
+  /// 상태 종류와 크기를 지정해 표식을 만든다.
   public init(type: BezierStatusType, size: BezierStatusSize) {
     self.type = type
     self.size = size

--- a/Sources/BezierSwift/MasterComponent/BezierAvatarGroup/BezierAvatarGroup.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierAvatarGroup/BezierAvatarGroup.swift
@@ -5,6 +5,7 @@
 
 import UIKit
 
+/// 여러 아바타를 겹치거나 나란히 묶어 보여주는 그룹 (UIKit). 최대 3명까지 표시하고 초과분은 아이콘·카운트로 나타낸다. SwiftUI에서는 `SUBezierAvatarGroup`을 사용한다.
 public final class BezierAvatarGroup: UIView, BezierComponentable {
   // MARK: - BezierComponentable
 
@@ -15,14 +16,17 @@ public final class BezierAvatarGroup: UIView, BezierComponentable {
 
   // MARK: - Public Properties
 
+  /// 표시할 아바타 이미지 목록. 최대 3개까지 보이고 나머지는 초과 표식으로 접힌다.
   public var avatars: [UIImage?] = [] {
     didSet { self.refresh() }
   }
 
+  /// 아바타 크기. 기본값은 `.size20`이다.
   public var size: BezierAvatarGroupSize = .size20 {
     didSet { if oldValue != self.size { self.refresh() } }
   }
 
+  /// 초과 인원 표현 방식. 기본값은 `.icon`이다.
   public var ellipsisType: BezierAvatarGroupEllipsisType = .icon {
     didSet { if oldValue != self.ellipsisType { self.refresh() } }
   }
@@ -41,6 +45,7 @@ public final class BezierAvatarGroup: UIView, BezierComponentable {
 
   // MARK: - Init
 
+  /// 아바타 이미지 목록·크기·초과 표현·겹침 여부를 지정해 그룹을 만든다.
   public init(
     avatars: [UIImage?] = [],
     size: BezierAvatarGroupSize = .size20,

--- a/Sources/BezierSwift/MasterComponent/BezierAvatarGroup/BezierAvatarGroupSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierAvatarGroup/BezierAvatarGroupSpec.swift
@@ -8,15 +8,25 @@ import UIKit
 
 // MARK: - AvatarGroup Size
 
+/// 아바타 그룹의 아바타 크기. Figma `AvatarGroup` 컴포넌트의 `size` 프로퍼티에 대응 (Figma 값 `"20"` = `.size20`, 철자만 다르다).
 public enum BezierAvatarGroupSize: String, CaseIterable {
+  /// 인라인 보조(타이핑·AI 참조)에 쓴다.
   case size20
+  /// 리스트·카드의 독립 UI(담당자·팔로워)에 쓰는 기본 크기다.
   case size24
+  /// 중밀도 배치에 쓴다.
   case size30
+  /// 카드 헤더에 쓴다.
   case size36
+  /// 상세 패널에 쓴다.
   case size42
+  /// 프로필 미리보기에 쓴다.
   case size48
+  /// 팀 페이지에 쓴다.
   case size72
+  /// 히어로 영역에 쓴다.
   case size90
+  /// 풀사이즈로 쓴다.
   case size120
 
   public var avatarSize: BezierAvatarSize {
@@ -118,8 +128,11 @@ struct BezierAvatarGroupCountFont: Equatable {
 
 // MARK: - Ellipsis Type
 
+/// 최대 표시 인원을 넘는 초과분의 표현 방식. Figma `AvatarGroup` 컴포넌트의 `ellipsisType` 프로퍼티에 대응 (case 이름 = Figma 값).
 public enum BezierAvatarGroupEllipsisType: String, CaseIterable {
+  /// 초과 인원 수가 불필요하고 폭이 매우 좁을 때 쓴다. 기본값이다.
   case icon
+  /// "+N"으로 총 초과 인원 수가 중요할 때 쓴다.
   case count
 }
 

--- a/Sources/BezierSwift/MasterComponent/BezierAvatarGroup/SUBezierAvatarGroup.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierAvatarGroup/SUBezierAvatarGroup.swift
@@ -5,6 +5,7 @@
 
 import SwiftUI
 
+/// 여러 아바타를 겹치거나 나란히 묶어 보여주는 그룹 (SwiftUI). 최대 3명까지 표시하고 초과분은 아이콘·카운트로 나타낸다. UIKit에서는 `BezierAvatarGroup`을 사용한다.
 public struct SUBezierAvatarGroup: View, Themeable {
   private let avatars: [Image?]
   private let size: BezierAvatarGroupSize
@@ -13,6 +14,7 @@ public struct SUBezierAvatarGroup: View, Themeable {
 
   @Environment(\.colorScheme) public var colorScheme
 
+  /// 아바타 이미지 목록·크기·초과 표현·겹침 여부를 지정해 그룹을 만든다.
   public init(
     avatars: [Image?] = [],
     size: BezierAvatarGroupSize = .size20,

--- a/Sources/BezierSwift/MasterComponent/BezierBadge/BezierBadge.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBadge/BezierBadge.swift
@@ -5,6 +5,7 @@
 
 import UIKit
 
+/// 짧은 상태·속성을 색으로 구분해 보여주는 배지 컴포넌트 (UIKit). 서로 다른 성격의 값을 구분하는 용도이며, 동일 성격의 나열이나 dismiss 가능한 라벨에는 `BezierTag`를 쓴다. SwiftUI에서는 `SUBezierBadge`를 사용한다.
 public final class BezierBadge: UIView, BezierComponentable {
   // MARK: - BezierComponentable
 
@@ -15,18 +16,22 @@ public final class BezierBadge: UIView, BezierComponentable {
 
   // MARK: - Public Properties
 
+  /// 배지 크기. 기본값은 `.small`.
   public var size: BezierBadgeSize = .small {
     didSet { if oldValue != self.size { self.refreshLayout() } }
   }
 
+  /// 색상 변형. 기본값은 `.default`.
   public var variant: BezierBadgeVariant = .default {
     didSet { if oldValue != self.variant { self.refreshAppearance() } }
   }
 
+  /// 배지에 표시할 텍스트. `nil`이거나 비어 있으면 라벨을 숨긴다.
   public var label: String? {
     didSet { if oldValue != self.label { self.refreshContent() } }
   }
 
+  /// 텍스트 앞에 붙는 아이콘. template 렌더링되어 `variant` 색으로 tint된다. 기본값은 `nil`.
   public var leadingIcon: UIImage? {
     didSet { self.refreshContent() }
   }
@@ -69,6 +74,7 @@ public final class BezierBadge: UIView, BezierComponentable {
 
   // MARK: - Init
 
+  /// 크기·색상 변형을 지정해 배지를 만든다. 텍스트·아이콘은 생성 후 `label`·`leadingIcon` 프로퍼티로 설정한다.
   public init(
     size: BezierBadgeSize = .small,
     variant: BezierBadgeVariant = .default

--- a/Sources/BezierSwift/MasterComponent/BezierBadge/BezierBadgeSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBadge/BezierBadgeSpec.swift
@@ -6,10 +6,15 @@
 import CoreGraphics
 import UIKit
 
+/// 배지의 크기. Figma `Badge` 컴포넌트의 `size` 프로퍼티에 대응 (case 이름 = Figma 값).
 public enum BezierBadgeSize: String, CaseIterable {
+  /// 가장 조밀한 배치.
   case xsmall
+  /// 조밀한 배치.
   case small
+  /// 표준 밀도의 배치.
   case medium
+  /// 큰 맥락에서 존재감을 키운 배치.
   case large
 
   public var height: CGFloat {
@@ -82,20 +87,35 @@ public enum BezierBadgeSize: String, CaseIterable {
   public var verticalLineSpacing: CGFloat { self.lineSpacing / 2 }
 }
 
+/// 배지의 색상 변형. Figma `Badge` 컴포넌트의 `variant` 프로퍼티에 대응. 일부 case는 Figma 값과 이름이 다르니 case별 표기를 참고한다.
 public enum BezierBadgeVariant: String, CaseIterable {
+  /// 색상 의미가 없는 중립 기본값.
   case `default`
+  /// Figma `neutral-light`. 연한 배경 위에서 존재감을 낮춘 보조 배지.
   case monochromeLight
+  /// Figma `neutral-dark`. 어둡거나 이미지 위 배경에서 쓰는 배지.
   case monochromeDark
+  /// 정보성 표시(신규·Beta·추천).
   case blue
+  /// 팀 내 색상↔의미 약속이 있는 카테고리·속성 구분용. 약속 없이 색상만 다양화하지 않는다.
   case cobalt
+  /// 팀 내 색상↔의미 약속이 있는 카테고리·속성 구분용. 약속 없이 색상만 다양화하지 않는다.
   case teal
+  /// 완료·성공·활성 상태.
   case green
+  /// 팀 내 색상↔의미 약속이 있는 카테고리·속성 구분용. 약속 없이 색상만 다양화하지 않는다.
   case olive
+  /// 팀 내 색상↔의미 약속이 있는 카테고리·속성 구분용. 약속 없이 색상만 다양화하지 않는다.
   case pink
+  /// 팀 내 색상↔의미 약속이 있는 카테고리·속성 구분용. 약속 없이 색상만 다양화하지 않는다.
   case navy
+  /// 주의·검토가 필요하지만 위험은 아닌 상태.
   case yellow
+  /// 경고·중간 우선순위. `yellow`보다 강한 주의를 나타낸다.
   case orange
+  /// 위험·긴급·기한 초과. 남용하지 않는다.
   case red
+  /// 팀 내 색상↔의미 약속이 있는 카테고리·속성 구분용. 약속 없이 색상만 다양화하지 않는다.
   case purple
 }
 

--- a/Sources/BezierSwift/MasterComponent/BezierBadge/SUBezierBadge.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBadge/SUBezierBadge.swift
@@ -5,6 +5,7 @@
 
 import SwiftUI
 
+/// 짧은 상태·속성을 색으로 구분해 보여주는 배지 컴포넌트 (SwiftUI). 서로 다른 성격의 값을 구분하는 용도이며, 동일 성격의 나열이나 dismiss 가능한 라벨에는 `SUBezierTag`를 쓴다. UIKit에서는 `BezierBadge`를 사용한다.
 public struct SUBezierBadge: View, Themeable {
   private let size: BezierBadgeSize
   private let variant: BezierBadgeVariant
@@ -13,6 +14,7 @@ public struct SUBezierBadge: View, Themeable {
 
   @Environment(\.colorScheme) public var colorScheme
 
+  /// 크기·색상 변형과 함께 표시할 텍스트(`label`)·아이콘(`leadingIcon`)을 지정해 배지를 만든다.
   public init(
     size: BezierBadgeSize = .small,
     variant: BezierBadgeVariant = .default,

--- a/Sources/BezierSwift/MasterComponent/BezierBanner/BezierBanner.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBanner/BezierBanner.swift
@@ -5,6 +5,7 @@
 
 import UIKit
 
+/// 화면 흐름 안내용 인라인(Inner) 배너 컴포넌트 (UIKit). 콘텐츠 영역 안에 놓여 상황을 안내한다. SwiftUI에서는 `SUBezierBanner`를 사용한다.
 public final class BezierBanner: UIView, BezierComponentable {
   // MARK: - BezierComponentable
 
@@ -15,22 +16,27 @@ public final class BezierBanner: UIView, BezierComponentable {
 
   // MARK: - Public Properties
 
+  /// 배너의 색상 계열. 기본값 `.default`.
   public var variant: BezierBannerVariant = .default {
     didSet { if oldValue != self.variant { self.refreshAppearance() } }
   }
 
+  /// 좌측에 표시할 아이콘. 기본값 `nil`.
   public var leadingIcon: BezierIcon? {
     didSet { if oldValue != self.leadingIcon { self.refreshContent() } }
   }
 
+  /// 배너 제목(볼드). 기본값 `nil`.
   public var title: String? {
     didSet { if oldValue != self.title { self.refreshContent() } }
   }
 
+  /// 배너 본문 텍스트. 기본값은 빈 문자열.
   public var bannerDescription: String = "" {
     didSet { if oldValue != self.bannerDescription { self.refreshContent() } }
   }
 
+  /// 배너의 클릭(탭) 동작 영역. 기본값 `.none`.
   public var clickArea: BezierBannerClickArea = .none {
     didSet { self.refreshClickArea() }
   }
@@ -92,6 +98,7 @@ public final class BezierBanner: UIView, BezierComponentable {
 
   // MARK: - Init
 
+  /// 색상 계열·아이콘·제목·본문·클릭 영역을 지정해 배너를 생성한다.
   public init(
     variant: BezierBannerVariant = .default,
     leadingIcon: BezierIcon? = nil,

--- a/Sources/BezierSwift/MasterComponent/BezierBanner/BezierBannerSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBanner/BezierBannerSpec.swift
@@ -7,12 +7,19 @@ import CoreGraphics
 
 // MARK: - Variant
 
+/// 배너의 색상 계열(상황 톤). Figma `Banner` 컴포넌트의 `variant` 프로퍼티에 대응 (case 이름 = Figma 값). Figma에서는 variant별 기본 아이콘이 정해져 있으나, Swift에서는 `leadingIcon`으로 지정한다.
 public enum BezierBannerVariant: CaseIterable {
+  /// 중립 정보. 특별한 감정 톤이 필요 없는 일반 안내에 쓴다.
   case `default`
+  /// 일반 안내·추천 정보에 쓴다.
   case blue
+  /// 시스템 상태·진행 중 안내에 쓴다.
   case cobalt
+  /// 성공·완료를 알릴 때 쓴다.
   case green
+  /// 경고·주의가 필요할 때 쓴다.
   case orange
+  /// 오류·차단·위험을 알릴 때 쓴다.
   case red
 
   var backgroundColor: BCSemanticToken {
@@ -51,9 +58,13 @@ public enum BezierBannerVariant: CaseIterable {
 
 // MARK: - ClickArea
 
+/// 배너의 클릭(탭) 동작 영역. 선택에 따라 우측 trailing 아이콘도 함께 결정된다.
 public enum BezierBannerClickArea {
+  /// 클릭이 없는 정보 표시용. trailing 아이콘이 없다.
   case none
+  /// 배너 전체를 탭 영역으로 쓴다. trailing에 chevron 아이콘이 노출된다.
   case full(onClick: () -> Void)
+  /// 우측 액션 아이콘만 탭 영역으로 쓴다. trailing에 close 아이콘이 노출된다.
   case actionIcon(onClick: () -> Void)
 
   var trailingIcon: BezierIcon? {

--- a/Sources/BezierSwift/MasterComponent/BezierBanner/SUBezierBanner.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBanner/SUBezierBanner.swift
@@ -5,6 +5,7 @@
 
 import SwiftUI
 
+/// 화면 흐름 안내용 인라인(Inner) 배너 컴포넌트 (SwiftUI). 콘텐츠 영역 안에 놓여 상황을 안내한다. UIKit에서는 `BezierBanner`를 사용한다.
 public struct SUBezierBanner: View, Themeable {
   @Environment(\.colorScheme) public var colorScheme
 
@@ -14,6 +15,7 @@ public struct SUBezierBanner: View, Themeable {
   private let description: String
   private let clickArea: BezierBannerClickArea
 
+  /// 색상 계열·아이콘·제목·본문·클릭 영역을 지정해 배너를 생성한다.
   public init(
     variant: BezierBannerVariant = .default,
     leadingIcon: BezierIcon? = nil,

--- a/Sources/BezierSwift/MasterComponent/BezierBaseItem/BezierBaseItem.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBaseItem/BezierBaseItem.swift
@@ -5,6 +5,7 @@
 
 import UIKit
 
+/// leading·center·trailing 3영역으로 구성되는 리스트 행 아이템 (UIKit). 탭 가능한 행과 정적인 행을 모두 표현한다. SwiftUI에서는 `SUBezierBaseItem`을 사용한다.
 public final class BezierBaseItem: UIControl, BezierComponentable {
   // MARK: - BezierComponentable
 
@@ -15,30 +16,37 @@ public final class BezierBaseItem: UIControl, BezierComponentable {
 
   // MARK: - Public Properties
 
+  /// 행의 크기. 기본값 `.medium`.
   public var size: BezierBaseItemSize = .medium {
     didSet { if oldValue != self.size { self.refreshSize() } }
   }
 
+  /// center 영역에 표시하는 주 텍스트. 기본값은 빈 문자열이며, 비어 있으면 제목이 숨겨진다.
   public var title: String = "" {
     didSet { if oldValue != self.title { self.refreshText() } }
   }
 
+  /// title 아래에 표시하는 보조 설명. `size`가 `.small`이면 무시된다. 기본값 `nil`.
   public var itemDescription: String? {
     didSet { if oldValue != self.itemDescription { self.refreshText() } }
   }
 
+  /// 행을 탭했을 때 실행되는 클로저. 지정하면 press 피드백과 상호작용이 켜지고, `nil`이면 정적인 행이 된다. 기본값 `nil`.
   public var onTap: (() -> Void)? {
     didSet { self.refreshInteraction() }
   }
 
+  /// leading(앞) 영역에 넣는 뷰(Avatar·아이콘 등). `size`에 맞춰 정사각형으로 크기가 잡힌다. 기본값 `nil`.
   public var leadingContent: UIView? {
     didSet { self.updateSlot(container: self.leadingContainer, old: oldValue, new: self.leadingContent, fill: true) }
   }
 
+  /// title 우측에 붙이는 뷰(배지·보조 아이콘 등). 기본값 `nil`.
   public var centerSlot: UIView? {
     didSet { self.updateSlot(container: self.centerSlotContainer, old: oldValue, new: self.centerSlot, fill: true) }
   }
 
+  /// trailing(뒤) 영역에 넣는 뷰(chevron·토글 등). 기본값 `nil`.
   public var trailingContent: UIView? {
     didSet { self.updateSlot(container: self.trailingContainer, old: oldValue, new: self.trailingContent, fill: true) }
   }
@@ -123,6 +131,7 @@ public final class BezierBaseItem: UIControl, BezierComponentable {
 
   // MARK: - Init
 
+  /// 행의 텍스트·크기·탭 동작을 지정해 생성한다. leading·center·trailing 슬롯 뷰는 생성 후 각 프로퍼티로 주입한다.
   public init(
     size: BezierBaseItemSize = .medium,
     title: String,

--- a/Sources/BezierSwift/MasterComponent/BezierBaseItem/BezierBaseItemSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBaseItem/BezierBaseItemSpec.swift
@@ -7,9 +7,13 @@ import Foundation
 
 // MARK: - Size
 
+/// 행(row) 아이템의 크기. Figma `_BaseItem` 컴포넌트의 `size` 프로퍼티에 대응 (case 이름 = Figma 값).
 public enum BezierBaseItemSize: CaseIterable {
+  /// 항목을 더 촘촘히 많이 노출할 때 쓴다. 단 `description`을 지원하지 않으므로, 설명이 필요하면 `medium`을 쓴다.
   case small
+  /// 대부분의 리스트 행에 쓰는 기본값.
   case medium
+  /// `leadingContent`(Avatar 등)가 커져 더 큰 행 높이가 필요할 때만 쓴다.
   case large
 
   var minHeight: CGFloat {

--- a/Sources/BezierSwift/MasterComponent/BezierBaseItem/SUBezierBaseItem.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBaseItem/SUBezierBaseItem.swift
@@ -5,6 +5,7 @@
 
 import SwiftUI
 
+/// leading·center·trailing 3영역으로 구성되는 리스트 행 아이템 (SwiftUI). 세 영역의 뷰를 `@ViewBuilder`로 채운다. UIKit에서는 `BezierBaseItem`을 사용한다.
 public struct SUBezierBaseItem<Leading: View, CenterSlot: View, Trailing: View>: View, Themeable {
   @Environment(\.colorScheme) public var colorScheme
   @Environment(\.isEnabled) private var isEnabled
@@ -17,6 +18,7 @@ public struct SUBezierBaseItem<Leading: View, CenterSlot: View, Trailing: View>:
   private let centerSlot: CenterSlot
   private let trailing: Trailing
 
+  /// 텍스트·크기·탭 동작과 함께 leading·centerSlot·trailing 세 슬롯 뷰를 지정해 생성한다. `description`은 `size`가 `.small`이면 무시되고, `onTap`이 `nil`이면 정적인 행이 된다.
   public init(
     size: BezierBaseItemSize = .medium,
     title: String,
@@ -112,6 +114,7 @@ public struct SUBezierBaseItem<Leading: View, CenterSlot: View, Trailing: View>:
 // MARK: - Convenience init (centerSlot 생략)
 
 extension SUBezierBaseItem where CenterSlot == EmptyView {
+  /// centerSlot을 생략하고 leading·trailing만으로 생성하는 편의 이니셜라이저.
   public init(
     size: BezierBaseItemSize = .medium,
     title: String,

--- a/Sources/BezierSwift/MasterComponent/BezierButton/BezierButton.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierButton/BezierButton.swift
@@ -5,6 +5,8 @@
 
 import UIKit
 
+/// Bezier 디자인 시스템 V3 버튼 (UIKit). `size`·`variant`·`semantic` 세 축으로 형태를 지정하고,
+/// 아이콘과 로딩 상태를 지원한다. SwiftUI에서는 `SUBezierButton`을 사용한다.
 public final class BezierButton: UIControl, BezierComponentable {
   // MARK: - BezierComponentable
 
@@ -15,30 +17,37 @@ public final class BezierButton: UIControl, BezierComponentable {
 
   // MARK: - Public Properties
 
+  /// 버튼 크기. 기본값 `.medium`.
   public var size: BezierButtonSize = .medium {
     didSet { if oldValue != self.size { self.refreshLayout() } }
   }
 
+  /// 시각적 강조도. 기본값 `.filled`.
   public var variant: BezierButtonVariant = .filled {
     didSet { if oldValue != self.variant { self.refreshAppearance() } }
   }
 
+  /// 의미론적 색상 역할. 기본값 `.primary`.
   public var semantic: BezierButtonSemantic = .primary {
     didSet { if oldValue != self.semantic { self.refreshAppearance() } }
   }
 
+  /// 버튼 라벨. `nil`이거나 빈 문자열이면 텍스트를 숨긴다.
   public var title: String? {
     didSet { if oldValue != self.title { self.refreshContent() } }
   }
 
+  /// 라벨 왼쪽에 표시되는 아이콘. `nil`이면 숨긴다.
   public var leadingIcon: UIImage? {
     didSet { self.refreshContent() }
   }
 
+  /// 라벨 오른쪽에 표시되는 아이콘. `nil`이면 숨긴다.
   public var trailingIcon: UIImage? {
     didSet { self.refreshContent() }
   }
 
+  /// `true`면 스피너를 표시하고 콘텐츠를 숨기며 탭을 차단한다. 비동기 작업 트리거 시 사용.
   public var isLoading: Bool = false {
     didSet { if oldValue != self.isLoading { self.refreshLoading() } }
   }
@@ -103,6 +112,8 @@ public final class BezierButton: UIControl, BezierComponentable {
 
   // MARK: - Init
 
+  /// 버튼을 생성한다. 콘텐츠(`title`·`leadingIcon`·`trailingIcon`)와 상태(`isLoading` 등)는
+  /// 생성 후 property로 설정한다.
   public init(
     size: BezierButtonSize = .medium,
     variant: BezierButtonVariant = .filled,

--- a/Sources/BezierSwift/MasterComponent/BezierButton/BezierButtonSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierButton/BezierButtonSpec.swift
@@ -5,11 +5,17 @@
 
 import UIKit
 
+/// 버튼의 크기. Figma `Button` 컴포넌트의 `size` 프로퍼티에 대응 (case 이름 = Figma 값). 놓이는 맥락의 밀도에 따라 고른다.
 public enum BezierButtonSize: String, CaseIterable {
+  /// 테이블 행·필터 칩 옆 등 가장 조밀한 맥락.
   case xsmall
+  /// 툴바·인라인 컨트롤 등 조밀한 맥락.
   case small
+  /// 폼 제출·모달 하단·헤더 등 표준 액션. 대부분의 기본값.
   case medium
+  /// Empty state CTA·온보딩 등 큰 진입점.
   case large
+  /// 가장 큰 강조가 필요한 대형 진입점.
   case xlarge
 
   public var height: CGFloat {
@@ -94,15 +100,23 @@ public enum BezierButtonSize: String, CaseIterable {
   public var fontWeight: BTFontWeight { .bold }
 }
 
+/// 버튼의 시각적 강조도. Figma `Button` 컴포넌트의 `variant` 프로퍼티에 대응 (case 이름 = Figma 값).
 public enum BezierButtonVariant: String, CaseIterable {
+  /// 화면에서 가장 중요한 단일 액션(저장·확인·제출). 한 화면에 하나만 둔다.
   case filled
+  /// 주 액션과 함께 두는 보조 액션(취소·나중에)이나 행 내 인라인 액션(편집·복제).
   case outlined
+  /// 흐름을 방해하지 않는 최저 강조 액션(필터 초기화·도움말)이나 그룹의 세 번째 옵션.
   case ghost
 }
 
+/// 버튼의 의미론적 색상 역할. Figma `Button` 컴포넌트의 `semantic` 프로퍼티에 대응 (case 이름 = Figma 값).
 public enum BezierButtonSemantic: String, CaseIterable {
+  /// 강조가 필요한 주 액션. 최고 위계.
   case primary
+  /// 중립·보조 조작. 낮은 대비의 보조 위계.
   case secondary
+  /// 되돌릴 수 없는 파괴적 액션(삭제·연결 끊기). 확인 모달과 함께 쓴다.
   case destructive
 }
 

--- a/Sources/BezierSwift/MasterComponent/BezierButton/SPEC.md
+++ b/Sources/BezierSwift/MasterComponent/BezierButton/SPEC.md
@@ -141,3 +141,13 @@ size 별 raw 값:
 - 크기 축소(§7 크기 표)는 label 색 스피너가 발생시키는 시선 강탈을 완화하기 위한 후속 조정이다.
 
 > Spinner 색은 GitHub design-team `Button-spec.md §6`(v1.1, "Spinner 색 = 라벨 텍스트 색" 원칙)과 일치한다. 크기(§7 크기 표)는 MOB-5322에서 확정한 값을 유지한다.
+
+## 8. 매핑되는 코드 심볼
+
+| 정의 | 파일 |
+|---|---|
+| UIKit 구현 | `BezierButton.swift` (`UIControl`, `BezierComponentable`) |
+| SwiftUI 구현 | `SUBezierButton.swift` (`View`, `Themeable`) |
+| size / variant / semantic 정의 | `BezierButtonSpec.swift` (`BezierButtonSize`, `BezierButtonVariant`, `BezierButtonSemantic`, `BezierButtonConstant`) |
+
+> 코드 측에 본 spec의 SSOT(Figma)와 어긋나는 정의가 존재한다면, 그것은 코드 측의 정리 대상이며 spec에 반영하지 않는다.

--- a/Sources/BezierSwift/MasterComponent/BezierButton/SUBezierButton.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierButton/SUBezierButton.swift
@@ -5,6 +5,8 @@
 
 import SwiftUI
 
+/// Bezier 디자인 시스템 V3 버튼 (SwiftUI). `size`·`variant`·`semantic` 세 축으로 형태를 지정하고,
+/// 아이콘과 로딩 상태를 지원한다. UIKit에서는 `BezierButton`을 사용한다.
 public struct SUBezierButton: View, Themeable {
   private let size: BezierButtonSize
   private let variant: BezierButtonVariant
@@ -19,6 +21,8 @@ public struct SUBezierButton: View, Themeable {
   @Environment(\.isEnabled) private var isEnabled
   @Environment(\.colorScheme) public var colorScheme
 
+  /// V3 버튼을 생성한다. `size`·`variant`·`semantic`은 필수이고, 콘텐츠(`title`·`leadingIcon`·`trailingIcon`)와
+  /// `isLoading`은 선택이다. `action`은 탭 시 실행된다.
   public init(
     size: BezierButtonSize,
     variant: BezierButtonVariant,

--- a/Sources/BezierSwift/MasterComponent/BezierButton/SUBezierButton.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierButton/SUBezierButton.swift
@@ -22,7 +22,7 @@ public struct SUBezierButton: View, Themeable {
   @Environment(\.colorScheme) public var colorScheme
 
   /// V3 버튼을 생성한다. `size`·`variant`·`semantic`은 필수이고, 콘텐츠(`title`·`leadingIcon`·`trailingIcon`)와
-  /// `isLoading`은 선택이다. `action`은 탭 시 실행된다.
+  /// `isLoading`은 선택이다. `action`은 탭 시 실행되며, `isLoading`이 `true`인 동안에는 실행되지 않는다.
   public init(
     size: BezierButtonSize,
     variant: BezierButtonVariant,

--- a/Sources/BezierSwift/MasterComponent/BezierConfirmModal/BezierConfirmModal+Presentation.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierConfirmModal/BezierConfirmModal+Presentation.swift
@@ -6,6 +6,7 @@
 import UIKit
 
 extension BezierModalViewController {
+  /// 확인 모달을 카드로 감싸 dim 배경과 함께 띄울 수 있는 컨트롤러를 만든다. 각 버튼 액션은 탭 시 모달을 먼저 닫은 뒤 핸들러를 실행한다.
   public static func confirm(
     title: String,
     description: String? = nil,

--- a/Sources/BezierSwift/MasterComponent/BezierConfirmModal/BezierConfirmModal.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierConfirmModal/BezierConfirmModal.swift
@@ -5,6 +5,7 @@
 
 import UIKit
 
+/// 되돌릴 수 없거나 영향이 큰 액션 실행 전 확인을 받는 모달 (UIKit). 제목·설명·버튼으로 구성되며, 표시는 `BezierModalViewController.confirm(...)`을 사용한다. SwiftUI에서는 `SUBezierConfirmModal`을 사용한다.
 public final class BezierConfirmModal: UIView, BezierComponentable {
   // MARK: - BezierComponentable
 
@@ -21,17 +22,22 @@ public final class BezierConfirmModal: UIView, BezierComponentable {
 
   // MARK: - Public Properties
 
+  /// 모달 상단에 표시하는 제목.
   public var title: String {
     didSet { self.refreshAppearance() }
   }
 
   // UIView.description(NSObject)과의 충돌을 피하기 위한 명명
+  /// 제목 아래 표시하는 설명 텍스트. `nil`이면 숨겨진다.
   public var descriptionText: String? {
     didSet { self.refreshAppearance() }
   }
 
+  /// 주 액션(확인) 버튼. `type`에 따라 강조 색이 결정된다.
   public let confirmButton: BezierButton
+  /// 취소 버튼. `cancelAction`을 지정하지 않으면 `nil`이다.
   public let cancelButton: BezierButton?
+  /// 세로 배치에서 쓰는 세 번째 대체 액션 버튼. `.vertical(altAction:)`에 액션을 넘겼을 때만 존재한다.
   public let altButton: BezierButton?
 
   // MARK: - Subviews
@@ -45,6 +51,7 @@ public final class BezierConfirmModal: UIView, BezierComponentable {
 
   // MARK: - Init
 
+  /// 제목·설명·버튼 구성으로 확인 모달을 생성한다. `type`으로 확인 버튼의 강조를, `buttonLayout`으로 버튼 배치를 정하며, `cancelAction`이 `nil`이면 확인 단일 버튼이 된다.
   public init(
     title: String,
     description: String? = nil,

--- a/Sources/BezierSwift/MasterComponent/BezierConfirmModal/BezierConfirmModalSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierConfirmModal/BezierConfirmModalSpec.swift
@@ -5,20 +5,28 @@
 
 import UIKit
 
+/// 확인 모달의 버튼 하나를 나타내는 액션. 버튼 제목과 탭 시 실행할 핸들러를 담는다.
 public struct BezierConfirmModalAction {
+  /// 버튼에 표시할 제목.
   public let title: String
+  /// 버튼을 탭했을 때 실행되는 클로저.
   public let handler: () -> Void
 
+  /// 제목과 핸들러로 액션을 생성한다. 핸들러 기본값은 아무 동작도 하지 않는 빈 클로저다.
   public init(title: String, handler: @escaping () -> Void = {}) {
     self.title = title
     self.handler = handler
   }
 }
 
+/// 확인 모달의 시맨틱 프리셋. Figma `ConfirmModal`에는 color/style variant가 없어 이 값은 Figma variant가 아니라 코드 측 시맨틱 프리셋이며, 확인 버튼의 강조 색을 결정한다.
 public enum BezierConfirmModalType {
+  /// 일반 확인. 확인 버튼이 primary로 강조된다.
   case `default`
+  /// 되돌릴 수 없는 파괴적 확인(삭제 등). 확인 버튼이 destructive로 강조된다.
   case destructive
 
+  /// 이 타입에 대응하는 확인 버튼의 시맨틱 색.
   public var confirmButtonSemantic: BezierButtonSemantic {
     switch self {
     case .default: return .primary
@@ -28,8 +36,11 @@ public enum BezierConfirmModalType {
 }
 
 // horizontal + altAction 조합은 SPEC 금지 규칙이라 타입 구조로 배제한다
+/// 확인 모달의 버튼 배치 방식. Figma `ConfirmModal`의 버튼 레이아웃 규칙(showCancel 조합)에 대응한다.
 public enum BezierConfirmModalButtonLayout {
+  /// 세로 배치. 세 번째 대체 액션(`altAction`)이 필요할 때 쓴다. 취소 없이 대체 액션만 두는 조합은 무효다.
   case vertical(altAction: BezierConfirmModalAction?)
+  /// 기본 가로 배치. 주 액션과 취소 두 버튼을 나란히 둘 때 쓴다.
   case horizontal
 }
 

--- a/Sources/BezierSwift/MasterComponent/BezierConfirmModal/SUBezierConfirmModal+Presentation.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierConfirmModal/SUBezierConfirmModal+Presentation.swift
@@ -7,6 +7,7 @@ import SwiftUI
 import UIKit
 
 extension View {
+  /// 이 뷰 위에 `SUBezierConfirmModal`을 dim 배경과 함께 띄우는 modifier. `isPresented` 바인딩으로 표시·해제를 제어한다.
   public func bezierConfirmModal(
     isPresented: Binding<Bool>,
     title: String,
@@ -30,6 +31,7 @@ extension View {
     )
   }
 
+  /// 커스텀 콘텐츠를 추가로 담아 `SUBezierConfirmModal`을 띄우는 modifier 오버로드.
   public func bezierConfirmModal<CustomContent: View>(
     isPresented: Binding<Bool>,
     title: String,

--- a/Sources/BezierSwift/MasterComponent/BezierConfirmModal/SUBezierConfirmModal.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierConfirmModal/SUBezierConfirmModal.swift
@@ -5,6 +5,7 @@
 
 import SwiftUI
 
+/// 되돌릴 수 없거나 영향이 큰 액션 실행 전 확인을 받는 모달 (SwiftUI). 제목·설명·버튼으로 구성된다. UIKit에서는 `BezierConfirmModal`을 사용한다.
 public struct SUBezierConfirmModal<CustomContent: View>: View {
   private let title: String
   private let description: String?
@@ -14,6 +15,7 @@ public struct SUBezierConfirmModal<CustomContent: View>: View {
   private let cancelAction: BezierConfirmModalAction?
   private let customContent: CustomContent?
 
+  /// 제목·설명·버튼 구성과 함께 추가 커스텀 콘텐츠를 `@ViewBuilder`로 받아 확인 모달을 생성한다.
   public init(
     title: String,
     description: String? = nil,
@@ -135,6 +137,7 @@ public struct SUBezierConfirmModal<CustomContent: View>: View {
 }
 
 extension SUBezierConfirmModal where CustomContent == EmptyView {
+  /// 커스텀 콘텐츠 없이 제목·설명·버튼만으로 확인 모달을 생성하는 편의 이니셜라이저.
   public init(
     title: String,
     description: String? = nil,

--- a/Sources/BezierSwift/MasterComponent/BezierDivider/BezierDivider.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierDivider/BezierDivider.swift
@@ -5,6 +5,7 @@
 
 import UIKit
 
+/// 콘텐츠를 구분하는 가로 구분선 (UIKit). Figma `Divider`의 `orientation` 중 가로(horizontal)만 지원하며 세로(vertical)는 제공하지 않는다. SwiftUI에서는 `SUBezierDivider`를 사용한다.
 public final class BezierDivider: UIView, BezierComponentable {
   // MARK: - BezierComponentable
 
@@ -15,10 +16,12 @@ public final class BezierDivider: UIView, BezierComponentable {
 
   // MARK: - Public Properties
 
+  /// 좌우 끝의 여백 적용 여부. Figma `Divider`의 `sideIndent` BOOLEAN 프로퍼티에 대응. 기본값 `true`.
   public var sideIndent: Bool = true {
     didSet { if oldValue != self.sideIndent { self.refreshLayout() } }
   }
 
+  /// 선 위아래(상하) 여백 적용 여부. Figma `Divider`의 `parallelIndent` BOOLEAN 프로퍼티에 대응. 기본값 `true`.
   public var parallelIndent: Bool = true {
     didSet { if oldValue != self.parallelIndent { self.refreshLayout() } }
   }
@@ -34,6 +37,7 @@ public final class BezierDivider: UIView, BezierComponentable {
 
   // MARK: - Init
 
+  /// 좌우(`sideIndent`)·상하(`parallelIndent`) 여백 적용 여부를 지정해 생성한다. 두 값 모두 기본 `true`다.
   public init(sideIndent: Bool = true, parallelIndent: Bool = true) {
     self.sideIndent = sideIndent
     self.parallelIndent = parallelIndent

--- a/Sources/BezierSwift/MasterComponent/BezierDivider/SUBezierDivider.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierDivider/SUBezierDivider.swift
@@ -5,12 +5,14 @@
 
 import SwiftUI
 
+/// 콘텐츠를 구분하는 가로 구분선 (SwiftUI). Figma `Divider`의 `orientation` 중 가로(horizontal)만 지원하며 세로(vertical)는 제공하지 않는다. UIKit에서는 `BezierDivider`를 사용한다.
 public struct SUBezierDivider: View, Themeable {
   private let sideIndent: Bool
   private let parallelIndent: Bool
 
   @Environment(\.colorScheme) public var colorScheme
 
+  /// 좌우(`sideIndent`)·상하(`parallelIndent`) 여백 적용 여부를 지정해 생성한다. 각각 Figma `Divider`의 동명 BOOLEAN 프로퍼티에 대응하며 기본 `true`다.
   public init(sideIndent: Bool = true, parallelIndent: Bool = true) {
     self.sideIndent = sideIndent
     self.parallelIndent = parallelIndent

--- a/Sources/BezierSwift/MasterComponent/BezierFloatingBanner/BezierFloatingBanner.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierFloatingBanner/BezierFloatingBanner.swift
@@ -5,7 +5,7 @@
 
 import UIKit
 
-/// 화면 위에 떠 있는 플로팅 배너 (UIKit). `surfaceHighest`(흰색) 배경과 그림자(elevation)로 다른 콘텐츠 위에 부유하는 스낵바형 지속 메시지를 표현한다. 체험판 만료·긴급 공지처럼 강하게 부각할 상태 안내에 쓴다. 화면 내 고정 인라인 배너는 `BezierBanner`, 자동 소멸하는 즉각 피드백은 `BezierToast`를 쓴다. SwiftUI에서는 `SUBezierFloatingBanner`를 사용한다.
+/// 화면 위에 떠 있는 플로팅 배너 (UIKit). `surfaceHighest` 배경과 그림자(elevation)로 다른 콘텐츠 위에 부유하는 스낵바형 지속 메시지를 표현한다. 체험판 만료·긴급 공지처럼 강하게 부각할 상태 안내에 쓴다. 화면 내 고정 인라인 배너는 `BezierBanner`, 자동 소멸하는 즉각 피드백은 `BezierToast`를 쓴다. SwiftUI에서는 `SUBezierFloatingBanner`를 사용한다.
 public final class BezierFloatingBanner: UIView, BezierComponentable {
   // MARK: - BezierComponentable
 

--- a/Sources/BezierSwift/MasterComponent/BezierFloatingBanner/BezierFloatingBanner.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierFloatingBanner/BezierFloatingBanner.swift
@@ -5,6 +5,7 @@
 
 import UIKit
 
+/// 화면 위에 떠 있는 플로팅 배너 (UIKit). `surfaceHighest`(흰색) 배경과 그림자(elevation)로 다른 콘텐츠 위에 부유하는 스낵바형 지속 메시지를 표현한다. 체험판 만료·긴급 공지처럼 강하게 부각할 상태 안내에 쓴다. 화면 내 고정 인라인 배너는 `BezierBanner`, 자동 소멸하는 즉각 피드백은 `BezierToast`를 쓴다. SwiftUI에서는 `SUBezierFloatingBanner`를 사용한다.
 public final class BezierFloatingBanner: UIView, BezierComponentable {
   // MARK: - BezierComponentable
 
@@ -15,22 +16,27 @@ public final class BezierFloatingBanner: UIView, BezierComponentable {
 
   // MARK: - Public Properties
 
+  /// 좌측에 표시할 아이콘. `nil`이면 아이콘 영역을 숨긴다 (기본값 `nil`).
   public var leadingIcon: BezierIcon? {
     didSet { if oldValue != self.leadingIcon { self.refreshContent() } }
   }
 
+  /// leading 아이콘의 tint 색. 아이콘 색으로 상태(성공·경고 등) 의미를 암시한다 (기본값 `iconNeutral`).
   public var leadingIconColor: BCSemanticToken = BezierFloatingBannerConstant.defaultLeadingIconColor {
     didSet { if oldValue != self.leadingIconColor { self.refreshAppearance() } }
   }
 
+  /// 본문 위에 굵게 표시하는 제목. Figma Floating 타입에는 없는 코드 전용 확장이며 `nil`이면 숨긴다 (기본값 `nil`).
   public var title: String? {
     didSet { if oldValue != self.title { self.refreshContent() } }
   }
 
+  /// 배너 본문 텍스트. init의 `description` 파라미터로 주입되는 필수 메시지다.
   public var bannerDescription: String = "" {
     didSet { if oldValue != self.bannerDescription { self.refreshContent() } }
   }
 
+  /// 배너의 탭 동작(none/full/actionIcon) (기본값 `.none`).
   public var clickArea: BezierFloatingBannerClickArea = .none {
     didSet { self.refreshClickArea() }
   }
@@ -92,6 +98,7 @@ public final class BezierFloatingBanner: UIView, BezierComponentable {
 
   // MARK: - Init
 
+  /// leading 아이콘·제목·본문·탭 동작을 지정해 배너를 만든다. `description`만 필수이며 나머지는 선택이다.
   public init(
     leadingIcon: BezierIcon? = nil,
     leadingIconColor: BCSemanticToken = BezierFloatingBannerConstant.defaultLeadingIconColor,

--- a/Sources/BezierSwift/MasterComponent/BezierFloatingBanner/BezierFloatingBannerSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierFloatingBanner/BezierFloatingBannerSpec.swift
@@ -7,9 +7,13 @@ import CoreGraphics
 
 // MARK: - ClickArea
 
+/// 플로팅 배너의 탭 동작. 코드 전용 축으로, Figma `Banner`(Type=Floating)의 `close` 불리언과 Android `onClick` 패턴을 하나의 enum으로 합친 것이다 (Figma에 단일 대응 프로퍼티는 없다).
 public enum BezierFloatingBannerClickArea {
+  /// 탭 상호작용이 없는 순수 안내 배너. trailing 아이콘도 표시하지 않는다.
   case none
+  /// 배너 전체를 탭 영역으로 만들고 우측에 `chevronSmallRight`를 표시한다. 배너를 눌러 상세로 이동시킬 때 쓴다 (Android `onClick` 패턴).
   case full(onClick: () -> Void)
+  /// 우측에 닫기용 `cancelSmall` 아이콘만 탭 가능하게 둔다. 사용자가 배너를 닫게 할 때 쓴다 (Figma `close=true`).
   case actionIcon(onClick: () -> Void)
 
   var trailingIcon: BezierIcon? {

--- a/Sources/BezierSwift/MasterComponent/BezierFloatingBanner/SUBezierFloatingBanner.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierFloatingBanner/SUBezierFloatingBanner.swift
@@ -5,6 +5,7 @@
 
 import SwiftUI
 
+/// 화면 위에 떠 있는 플로팅 배너 (SwiftUI). `surfaceHighest` 배경과 그림자로 콘텐츠 위에 부유하는 스낵바형 지속 메시지를 표현한다. 긴급·강조 상태 안내에 쓰며, 화면 내 고정 인라인 배너는 `SUBezierBanner`, 자동 소멸하는 즉각 피드백은 `SUBezierToast`를 쓴다. UIKit에서는 `BezierFloatingBanner`를 사용한다.
 public struct SUBezierFloatingBanner: View, Themeable {
   @Environment(\.colorScheme) public var colorScheme
 
@@ -14,6 +15,7 @@ public struct SUBezierFloatingBanner: View, Themeable {
   private let description: String
   private let clickArea: BezierFloatingBannerClickArea
 
+  /// leading 아이콘·제목·본문·탭 동작을 지정해 배너를 만든다. `description`만 필수이며 나머지는 선택이다.
   public init(
     leadingIcon: BezierIcon? = nil,
     leadingIconColor: BCSemanticToken = BezierFloatingBannerConstant.defaultLeadingIconColor,

--- a/Sources/BezierSwift/MasterComponent/BezierIconButton/BezierIconButton.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierIconButton/BezierIconButton.swift
@@ -5,6 +5,7 @@
 
 import UIKit
 
+/// 아이콘 전용 버튼 컴포넌트 (UIKit). 텍스트 없이 아이콘 하나로 액션을 표현한다. SwiftUI에서는 `SUBezierIconButton`을 사용한다.
 public final class BezierIconButton: UIControl, BezierComponentable {
   // MARK: - BezierComponentable
 
@@ -15,22 +16,27 @@ public final class BezierIconButton: UIControl, BezierComponentable {
 
   // MARK: - Public Properties
 
+  /// 버튼 크기. 기본값은 `.medium`.
   public var size: BezierIconButtonSize = .medium {
     didSet { if oldValue != self.size { self.refreshLayout() } }
   }
 
+  /// 시각적 강조도. 기본값은 `.ghost`.
   public var variant: BezierIconButtonVariant = .ghost {
     didSet { if oldValue != self.variant { self.refreshAppearance() } }
   }
 
+  /// 의미론적 위계. 기본값은 `.secondary`.
   public var semantic: BezierIconButtonSemantic = .secondary {
     didSet { if oldValue != self.semantic { self.refreshAppearance() } }
   }
 
+  /// 버튼에 표시할 아이콘. template 렌더링되어 `variant`·`semantic`에 따른 tint가 적용된다.
   public var icon: UIImage? {
     didSet { self.refreshContent() }
   }
 
+  /// 로딩 스피너 표시 여부. `true`면 아이콘 대신 스피너가 나오고 탭 액션이 차단된다. 기본값은 `false`.
   public var isLoading: Bool = false {
     didSet { if oldValue != self.isLoading { self.refreshLoading() } }
   }
@@ -72,6 +78,7 @@ public final class BezierIconButton: UIControl, BezierComponentable {
 
   // MARK: - Init
 
+  /// 크기·강조도·위계를 지정해 아이콘 버튼을 만든다. 아이콘은 생성 후 `icon` 프로퍼티로 설정한다. 기본 조합은 `ghost`×`secondary`.
   public init(
     size: BezierIconButtonSize = .medium,
     variant: BezierIconButtonVariant = .ghost,

--- a/Sources/BezierSwift/MasterComponent/BezierIconButton/BezierIconButtonSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierIconButton/BezierIconButtonSpec.swift
@@ -5,10 +5,15 @@
 
 import CoreGraphics
 
+/// 아이콘 버튼의 크기. Figma `IconButton` 컴포넌트의 `size` 프로퍼티에 대응 (case 이름 = Figma 값). `BezierButton`과 동일한 밀도 기준을 따른다.
 public enum BezierIconButtonSize: String, CaseIterable {
+  /// 좁은 인라인·툴바에서 가장 조밀하게 놓는 크기.
   case xsmall
+  /// 좁은 인라인·툴바에 놓는 조밀한 크기.
   case small
+  /// 표준 크기. 대부분의 맥락에서 기본으로 쓴다.
   case medium
+  /// 큰 진입점이나 강조가 필요한 단독 액션에 쓰는 크기.
   case large
 
   public var length: CGFloat {
@@ -43,15 +48,23 @@ public enum BezierIconButtonSize: String, CaseIterable {
   }
 }
 
+/// 아이콘 버튼의 시각적 강조도. Figma `IconButton` 컴포넌트의 `variant` 프로퍼티에 대응 (case 이름 = Figma 값).
 public enum BezierIconButtonVariant: String, CaseIterable {
+  /// 화면당 하나만 두는 강조된 아이콘 액션.
   case filled
+  /// `filled` 옆에 두는 보조 액션이나 행 내 인라인 액션.
   case outlined
+  /// 기본값. 툴바나 저강조 맥락의 아이콘 액션.
   case ghost
 }
 
+/// 아이콘 버튼의 의미론적 위계. Figma `IconButton` 컴포넌트의 `semantic` 프로퍼티에 대응 (case 이름 = Figma 값).
 public enum BezierIconButtonSemantic: String, CaseIterable {
+  /// 화면에서 최상위 위계를 갖는 아이콘 액션.
   case primary
+  /// 기본값. 닫기·더보기·편집·뒤로 등 일반적인 아이콘 액션.
   case secondary
+  /// 삭제·연결 해제 등 파괴적인 아이콘 액션.
   case destructive
 }
 

--- a/Sources/BezierSwift/MasterComponent/BezierIconButton/SUBezierIconButton.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierIconButton/SUBezierIconButton.swift
@@ -18,7 +18,7 @@ public struct SUBezierIconButton: View, Themeable {
   @Environment(\.isEnabled) private var isEnabled
   @Environment(\.colorScheme) public var colorScheme
 
-  /// 크기·강조도·위계와 아이콘, 탭 시 실행할 `action`을 지정해 아이콘 버튼을 만든다. `isActive`는 toggle ON 상태를, `isLoading`은 스피너 표시를 제어한다. 기본 조합은 `ghost`×`secondary`.
+  /// 크기·강조도·위계와 아이콘, 탭 시 실행할 `action`을 지정해 아이콘 버튼을 만든다. `isActive`는 toggle ON(선택) 상태를, `isLoading`은 스피너 표시 여부를 지정한다. 기본 조합은 `ghost`×`secondary`.
   public init(
     size: BezierIconButtonSize = .medium,
     variant: BezierIconButtonVariant = .ghost,

--- a/Sources/BezierSwift/MasterComponent/BezierIconButton/SUBezierIconButton.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierIconButton/SUBezierIconButton.swift
@@ -5,6 +5,7 @@
 
 import SwiftUI
 
+/// 아이콘 전용 버튼 컴포넌트 (SwiftUI). 텍스트 없이 아이콘 하나로 액션을 표현한다. UIKit에서는 `BezierIconButton`을 사용한다.
 public struct SUBezierIconButton: View, Themeable {
   private let size: BezierIconButtonSize
   private let variant: BezierIconButtonVariant
@@ -17,6 +18,7 @@ public struct SUBezierIconButton: View, Themeable {
   @Environment(\.isEnabled) private var isEnabled
   @Environment(\.colorScheme) public var colorScheme
 
+  /// 크기·강조도·위계와 아이콘, 탭 시 실행할 `action`을 지정해 아이콘 버튼을 만든다. `isActive`는 toggle ON 상태를, `isLoading`은 스피너 표시를 제어한다. 기본 조합은 `ghost`×`secondary`.
   public init(
     size: BezierIconButtonSize = .medium,
     variant: BezierIconButtonVariant = .ghost,

--- a/Sources/BezierSwift/MasterComponent/BezierModal/BezierModal.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierModal/BezierModal.swift
@@ -5,6 +5,7 @@
 
 import UIKit
 
+/// 현재 맥락을 유지한 채 집중 작업(설정·폼·정보 확인)을 담는 모달 카드 (UIKit). 단순 확인 흐름은 `BezierConfirmModal`을 쓴다. Figma의 `size`(420/540 등 너비 프리셋)는 Figma 전용이라 코드에는 prop이 없고, 컨테이너에서 너비를 직접 지정한다. SwiftUI에서는 `SUBezierModal`을 사용한다.
 public final class BezierModal: UIView, BezierComponentable {
   // 프레젠테이션 확장 제약(BezierModalPresentationConstant)이 이 값을 기준으로 +1 우선순위를 계산한다
   static let widthConstraintPriority: UILayoutPriority = .defaultHigh
@@ -18,6 +19,7 @@ public final class BezierModal: UIView, BezierComponentable {
 
   // MARK: - Public Properties
 
+  /// 모달 카드 안쪽에 콘텐츠를 담는 컨테이너. 이 뷰에 서브뷰를 추가해 모달 본문을 구성한다.
   public let contentView = UIView()
 
   // MARK: - Subviews
@@ -26,6 +28,7 @@ public final class BezierModal: UIView, BezierComponentable {
 
   // MARK: - Init
 
+  /// 빈 모달 카드를 생성한다. 선택 옵션이 없어 인자를 받지 않으며, 본문은 `contentView`에 직접 구성한다.
   public init() {
     super.init(frame: .zero)
     self.setUp()

--- a/Sources/BezierSwift/MasterComponent/BezierModal/BezierModalViewController.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierModal/BezierModalViewController.swift
@@ -15,6 +15,7 @@ enum BezierModalPresentationConstant {
   static let widthExpansionPriority = UILayoutPriority(BezierModal.widthConstraintPriority.rawValue + 1)
 }
 
+/// `BezierModal` 카드를 화면 중앙에 dim 배경과 함께 띄우는 프레젠테이션 컨트롤러. `present(_:animated:)`로 표시한다.
 public final class BezierModalViewController: UIViewController, BezierComponentable {
   // MARK: - BezierComponentable
 
@@ -25,6 +26,7 @@ public final class BezierModalViewController: UIViewController, BezierComponenta
 
   // MARK: - Public Properties
 
+  /// 화면에 띄우는 모달 뷰. `BezierModal` 또는 그 카드를 감싼 뷰가 들어간다.
   public let modalView: UIView
 
   // MARK: - Subviews
@@ -33,6 +35,7 @@ public final class BezierModalViewController: UIViewController, BezierComponenta
 
   // MARK: - Init
 
+  /// 이미 구성된 모달 뷰를 그대로 받아 표시하는 이니셜라이저. dim 배경·중앙 정렬·crossDissolve 전환이 함께 설정된다.
   public init(modalView: UIView) {
     self.modalView = modalView
     super.init(nibName: nil, bundle: nil)
@@ -40,6 +43,7 @@ public final class BezierModalViewController: UIViewController, BezierComponenta
     self.modalTransitionStyle = .crossDissolve
   }
 
+  /// 임의의 콘텐츠 뷰를 기본 `BezierModal` 카드로 감싸 표시하는 편의 이니셜라이저.
   public convenience init(contentView: UIView) {
     let modal = BezierModal()
     contentView.translatesAutoresizingMaskIntoConstraints = false

--- a/Sources/BezierSwift/MasterComponent/BezierModal/SUBezierModal+Presentation.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierModal/SUBezierModal+Presentation.swift
@@ -7,6 +7,7 @@ import SwiftUI
 import UIKit
 
 extension View {
+  /// 이 뷰 위에 `SUBezierModal` 카드를 dim 배경과 함께 띄우는 modifier. `isPresented` 바인딩으로 표시·해제를 제어하고, `onDismiss`로 닫힘 시점을 후처리한다.
   public func bezierModal<ModalContent: View>(
     isPresented: Binding<Bool>,
     onDismiss: (() -> Void)? = nil,

--- a/Sources/BezierSwift/MasterComponent/BezierModal/SUBezierModal.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierModal/SUBezierModal.swift
@@ -5,11 +5,13 @@
 
 import SwiftUI
 
+/// 현재 맥락을 유지한 채 집중 작업(설정·폼·정보 확인)을 담는 모달 카드 (SwiftUI). 단순 확인 흐름은 `SUBezierConfirmModal`을 쓴다. Figma의 `size`(420/540 등 너비 프리셋)는 Figma 전용이라 코드에는 prop이 없고, 컨테이너에서 너비를 직접 지정한다. UIKit에서는 `BezierModal`을 사용한다.
 public struct SUBezierModal<Content: View>: View, Themeable {
   @Environment(\.colorScheme) public var colorScheme
 
   private let content: Content
 
+  /// 모달 카드에 담을 본문을 `@ViewBuilder`로 받아 생성한다.
   public init(@ViewBuilder content: () -> Content) {
     self.content = content()
   }

--- a/Sources/BezierSwift/MasterComponent/BezierSection/BezierSection.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierSection/BezierSection.swift
@@ -5,6 +5,7 @@
 
 import UIKit
 
+/// 관련 리스트 항목을 의미 단위로 묶는 섹션 컨테이너 (UIKit). 헤더(`BezierSectionLabel`) + 행 목록으로 구성되며 행에는 `BezierSectionItem`을 넣는다. 정적 소수 항목용이며, 항목이 많은 동적 리스트는 `BezierSectionLayout`(컴포지셔널 레이아웃)을 쓴다. SwiftUI에서는 `SUBezierSection`을 사용한다.
 public final class BezierSection: UIView, BezierComponentable {
   // MARK: - BezierComponentable
 
@@ -21,26 +22,32 @@ public final class BezierSection: UIView, BezierComponentable {
 
   // MARK: - Public Properties
 
+  /// 섹션 스타일(solid/card) (기본값 `.solid`).
   public var variant: BezierSectionVariant = .solid {
     didSet { if oldValue != self.variant { self.refreshVariant() } }
   }
 
+  /// 헤더 라벨 텍스트. `nil`이면 헤더를 숨긴다 (기본값 `nil`).
   public var labelText: String? {
     didSet { if oldValue != self.labelText { self.refreshLabel() } }
   }
 
+  /// 헤더 라벨 색(neutralDark/neutralLight) (기본값 `.neutralDark`).
   public var labelColor: BezierSectionLabelColor = .neutralDark {
     didSet { if oldValue != self.labelColor { self.sectionLabel.color = self.labelColor } }
   }
 
+  /// 헤더 라벨 좌측 슬롯에 넣을 20×20 뷰(아이콘 등). `nil`이면 비운다.
   public var labelLeadingContent: UIView? {
     didSet { self.sectionLabel.leadingContent = self.labelLeadingContent }
   }
 
+  /// 헤더 라벨 우측 슬롯에 넣을 액션 뷰(높이 20). `nil`이면 비운다.
   public var labelTrailingContent: UIView? {
     didSet { self.sectionLabel.trailingContent = self.labelTrailingContent }
   }
 
+  /// 현재 표시 중인 행 뷰 배열. 읽기 전용이며 `setItems(_:)`/`addItem(_:)`으로 변경한다.
   public private(set) var items: [UIView] = []
 
   // MARK: - Subviews
@@ -76,6 +83,7 @@ public final class BezierSection: UIView, BezierComponentable {
 
   // MARK: - Init
 
+  /// variant·헤더 텍스트/색·초기 행 배열로 섹션을 만든다. 행은 이후 `setItems(_:)`/`addItem(_:)`으로 교체·추가할 수 있다.
   public init(
     variant: BezierSectionVariant = .solid,
     labelText: String? = nil,
@@ -126,11 +134,13 @@ public final class BezierSection: UIView, BezierComponentable {
 
   // MARK: - Items
 
+  /// 행 배열을 통째로 교체하고 divider를 다시 그린다.
   public func setItems(_ items: [UIView]) {
     self.items = items
     self.rebuildRows()
   }
 
+  /// 행을 끝에 하나 추가하고 divider를 다시 그린다.
   public func addItem(_ item: UIView) {
     self.items.append(item)
     self.rebuildRows()

--- a/Sources/BezierSwift/MasterComponent/BezierSection/BezierSectionLabel.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierSection/BezierSectionLabel.swift
@@ -5,6 +5,7 @@
 
 import UIKit
 
+/// 섹션 헤더 bar (UIKit). 선택적 좌측 아이콘 · 텍스트 · 우측 액션 슬롯을 담는 `BezierSection` 전용 헤더다. 단독으로 쓰지 말고 항상 `BezierSection`의 헤더로 사용한다. SwiftUI에서는 `SUBezierSectionLabel`을 사용한다.
 public final class BezierSectionLabel: UIView, BezierComponentable {
   // MARK: - BezierComponentable
 
@@ -15,18 +16,22 @@ public final class BezierSectionLabel: UIView, BezierComponentable {
 
   // MARK: - Public Properties
 
+  /// 헤더 텍스트. 빈 문자열이면 텍스트를 숨긴다 (기본값 `""`).
   public var text: String = "" {
     didSet { if oldValue != self.text { self.refreshText() } }
   }
 
+  /// 라벨 색(neutralDark/neutralLight) (기본값 `.neutralDark`).
   public var color: BezierSectionLabelColor = .neutralDark {
     didSet { if oldValue != self.color { self.refreshText() } }
   }
 
+  /// 좌측 20×20 슬롯 뷰(아이콘 등). `nil`이면 비운다.
   public var leadingContent: UIView? {
     didSet { self.updateSlot(container: self.leadingContainer, old: oldValue, new: self.leadingContent) }
   }
 
+  /// 우측 슬롯 뷰(높이 20, 우측 정렬 액션). `nil`이면 비운다.
   public var trailingContent: UIView? {
     didSet { self.updateSlot(container: self.trailingContainer, old: oldValue, new: self.trailingContent) }
   }
@@ -64,6 +69,7 @@ public final class BezierSectionLabel: UIView, BezierComponentable {
 
   // MARK: - Init
 
+  /// 라벨 텍스트와 색으로 헤더를 만든다. 좌우 슬롯은 생성 후 `leadingContent`/`trailingContent`로 채운다.
   public init(text: String, color: BezierSectionLabelColor = .neutralDark) {
     self.text = text
     self.color = color

--- a/Sources/BezierSwift/MasterComponent/BezierSection/BezierSectionLayout.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierSection/BezierSectionLayout.swift
@@ -57,9 +57,12 @@ enum BezierSectionDecorationKind: CaseIterable {
 
 // MARK: - Layout Builder
 
+/// `UICollectionViewCompositionalLayout`로 항목이 많은 동적 섹션 리스트를 구성하기 위한 헬퍼 (UIKit 전용, Figma에 대응 없음). 섹션 배경·테두리·radius는 background decoration view로, 헤더(`BezierSectionLabel`)는 boundary supplementary로, 행 간 divider는 list separator로 그린다. 정적 소수 항목에는 `BezierSection`을 사용한다.
 public enum BezierSectionLayout {
+  /// 헤더(SectionLabel) boundary supplementary의 elementKind 문자열. 소비자가 supplementary 등록·dequeue에 쓴다.
   public static let labelElementKind = "BezierSectionLayout.label"
 
+  /// 섹션 배경 decoration view 4종(variant × componentTheme)을 레이아웃에 등록한다. 레이아웃 생성 직후 반드시 호출해야 decoration dequeue 크래시를 막는다.
   public static func register(in layout: UICollectionViewCompositionalLayout) {
     for kind in BezierSectionDecorationKind.allCases {
       layout.register(
@@ -69,6 +72,7 @@ public enum BezierSectionLayout {
     }
   }
 
+  /// variant·행 수·헤더 표시 여부·테마에 맞는 `NSCollectionLayoutSection`을 만든다. `numberOfItems`는 마지막 행의 bottom separator를 숨겨 divider 수를 (행 수 − 1)로 맞추는 데 쓴다.
   public static func makeSection(
     variant: BezierSectionVariant,
     numberOfItems: Int,
@@ -158,6 +162,7 @@ public enum BezierSectionLayout {
 
 // MARK: - Background Decoration View
 
+/// 컴포지셔널 레이아웃에서 섹션 배경(카드 chrome — 배경색·테두리·radius)을 그리는 decoration view (UIKit 내부용). `BezierSectionLayout`이 dequeue하며 소비자가 직접 생성할 필요는 없다.
 public final class BezierSectionBackgroundView: UICollectionReusableView, BezierComponentable {
   // MARK: - BezierComponentable
 
@@ -227,7 +232,9 @@ public final class BezierSectionBackgroundView: UICollectionReusableView, Bezier
 
 // MARK: - Label Reusable View
 
+/// 컴포지셔널 레이아웃 헤더에 `BezierSectionLabel`을 얹는 supplementary view. configure 시점에 `sectionLabel`을 설정해 헤더 내용을 채운다.
 public final class BezierSectionLabelReusableView: UICollectionReusableView {
+  /// 헤더로 표시되는 `BezierSectionLabel` 인스턴스. 텍스트·색·슬롯·componentTheme를 여기서 설정한다.
   public let sectionLabel = BezierSectionLabel(text: "")
 
   public override init(frame: CGRect) {

--- a/Sources/BezierSwift/MasterComponent/BezierSection/BezierSectionSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierSection/BezierSectionSpec.swift
@@ -7,15 +7,21 @@ import CoreGraphics
 
 // MARK: - Variant
 
+/// 섹션의 시각 스타일. Figma `Section` 컴포넌트의 `variant` 프로퍼티에 대응 (case 이름 = Figma 값). 배경·테두리·radius·행 간 divider 유무를 결정한다.
 public enum BezierSectionVariant: CaseIterable {
+  /// 배경·테두리·divider 없는 투명 섹션. 화면 배경 위에 그대로 얹는 기본 리스트에 쓴다.
   case solid
+  /// `surface` 배경 + 1pt `borderNeutral` 테두리 + radius 16 카드. 행 사이에 divider가 들어간다. 리스트를 카드로 감싸 구분할 때 쓴다.
   case card
 }
 
 // MARK: - Label Color
 
+/// 섹션 라벨 텍스트 색. Figma `Internal/SectionLabel`의 `color` 프로퍼티에 대응 (Figma 값 `neutral-dark`/`neutral-light` = 코드 `neutralDark`/`neutralLight`).
 public enum BezierSectionLabelColor: CaseIterable {
+  /// 진한 라벨(`textNeutral`). 일반 섹션 헤더의 기본값이다.
   case neutralDark
+  /// 연한 라벨(`textNeutralLighter`). 오버레이/시트 내부 등 약하게 표기할 때 쓴다.
   case neutralLight
 
   var textColor: BCSemanticToken {

--- a/Sources/BezierSwift/MasterComponent/BezierSection/SUBezierSection.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierSection/SUBezierSection.swift
@@ -5,6 +5,7 @@
 
 import SwiftUI
 
+/// 관련 행을 의미 단위로 묶는 섹션 컨테이너 (SwiftUI). 데이터 컬렉션을 받아 헤더(`SUBezierSectionLabel`) + 행 목록을 그리며 행에는 `SUBezierSectionItem`을 넣는다. `ScrollView`+`LazyVStack` 안에서 쓴다. UIKit에서는 `BezierSection`(정적) 또는 `BezierSectionLayout`(동적)을 사용한다.
 public struct SUBezierSection<Data: RandomAccessCollection, ID: Hashable, Row: View, LabelTrailing: View>: View, Themeable {
   @Environment(\.colorScheme) public var colorScheme
 
@@ -16,6 +17,7 @@ public struct SUBezierSection<Data: RandomAccessCollection, ID: Hashable, Row: V
   private let labelTrailing: LabelTrailing
   private let rowContent: (Data.Element) -> Row
 
+  /// 데이터 컬렉션·식별 keyPath·variant·헤더로 섹션을 만든다. `rowContent`로 각 원소의 행 뷰를, `labelTrailing`으로 헤더 우측 액션을 구성한다.
   public init(
     _ data: Data,
     id: KeyPath<Data.Element, ID>,
@@ -127,6 +129,7 @@ public struct SUBezierSection<Data: RandomAccessCollection, ID: Hashable, Row: V
 // MARK: - Convenience init
 
 extension SUBezierSection where LabelTrailing == EmptyView {
+  /// 헤더 우측 액션 없이 만드는 편의 이니셜라이저.
   public init(
     _ data: Data,
     id: KeyPath<Data.Element, ID>,
@@ -148,6 +151,7 @@ extension SUBezierSection where LabelTrailing == EmptyView {
 }
 
 extension SUBezierSection where Data.Element: Identifiable, ID == Data.Element.ID {
+  /// 원소가 `Identifiable`일 때 `id` keyPath를 생략하는 편의 이니셜라이저.
   public init(
     _ data: Data,
     variant: BezierSectionVariant = .solid,
@@ -169,6 +173,7 @@ extension SUBezierSection where Data.Element: Identifiable, ID == Data.Element.I
 }
 
 extension SUBezierSection where Data.Element: Identifiable, ID == Data.Element.ID, LabelTrailing == EmptyView {
+  /// 원소가 `Identifiable`이고 헤더 우측 액션이 없을 때 쓰는 편의 이니셜라이저.
   public init(
     _ data: Data,
     variant: BezierSectionVariant = .solid,

--- a/Sources/BezierSwift/MasterComponent/BezierSection/SUBezierSectionLabel.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierSection/SUBezierSectionLabel.swift
@@ -5,6 +5,7 @@
 
 import SwiftUI
 
+/// 섹션 헤더 bar (SwiftUI). 선택적 좌측 슬롯 · 텍스트 · 우측 슬롯을 담는 `SUBezierSection` 전용 헤더다. 단독으로 쓰지 말고 섹션 헤더로 사용한다. UIKit에서는 `BezierSectionLabel`을 사용한다.
 public struct SUBezierSectionLabel<Leading: View, Trailing: View>: View, Themeable {
   @Environment(\.colorScheme) public var colorScheme
 
@@ -13,6 +14,7 @@ public struct SUBezierSectionLabel<Leading: View, Trailing: View>: View, Themeab
   private let leading: Leading
   private let trailing: Trailing
 
+  /// 라벨 텍스트·색과 좌우 슬롯 빌더로 헤더를 만든다.
   public init(
     _ text: String,
     color: BezierSectionLabelColor = .neutralDark,
@@ -73,6 +75,7 @@ public struct SUBezierSectionLabel<Leading: View, Trailing: View>: View, Themeab
 // MARK: - Convenience init
 
 extension SUBezierSectionLabel where Leading == EmptyView {
+  /// 좌측 슬롯 없이 텍스트·우측 슬롯만으로 만드는 편의 이니셜라이저.
   public init(
     _ text: String,
     color: BezierSectionLabelColor = .neutralDark,
@@ -83,6 +86,7 @@ extension SUBezierSectionLabel where Leading == EmptyView {
 }
 
 extension SUBezierSectionLabel where Leading == EmptyView, Trailing == EmptyView {
+  /// 텍스트(와 색)만으로 만드는 편의 이니셜라이저.
   public init(_ text: String, color: BezierSectionLabelColor = .neutralDark) {
     self.init(text, color: color, leading: { EmptyView() }, trailing: { EmptyView() })
   }

--- a/Sources/BezierSwift/MasterComponent/BezierSectionItem/BezierSectionItem.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierSectionItem/BezierSectionItem.swift
@@ -5,6 +5,7 @@
 
 import UIKit
 
+/// `BezierSection` 안에 넣는 리스트 행 아이템 (UIKit). leading(아이콘/아바타/커스텀) · 텍스트 · description · centerSlot · 우측 accessory로 구성되며 탭·pressed·disabled 상호작용을 지원한다. 섹션 밖 독립 리스트 행에는 `BezierBaseItem`을 쓴다. SwiftUI에서는 `SUBezierSectionItem`을 사용한다.
 public final class BezierSectionItem: UIControl, BezierComponentable {
   // MARK: - BezierComponentable
 
@@ -18,18 +19,22 @@ public final class BezierSectionItem: UIControl, BezierComponentable {
 
   // MARK: - Public Properties
 
+  /// 행 크기(small/medium/large) (기본값 `.medium`).
   public var size: BezierSectionItemSize = .medium {
     didSet { if oldValue != self.size { self.refreshSize() } }
   }
 
+  /// 행 본문(label) 텍스트 (기본값 `""`).
   public var content: String = "" {
     didSet { if oldValue != self.content { self.refreshText() } }
   }
 
+  /// 본문 아래 보조 설명. `nil`/빈 문자열이면 숨긴다. `large`는 nested, 그 외는 행 아래 de-nest로 배치한다.
   public var itemDescription: String? {
     didSet { if oldValue != self.itemDescription { self.refreshDescription() } }
   }
 
+  /// leading 콘텐츠 유형(none/icon/avatar/custom) (기본값 `.none`).
   public var leading: BezierSectionItemLeading<UIView> = .none {
     didSet {
       self.refreshLeading()
@@ -37,6 +42,7 @@ public final class BezierSectionItem: UIControl, BezierComponentable {
     }
   }
 
+  /// label 우측에 인라인으로 붙는 슬롯 뷰(높이 24). custom leading에서는 지원하지 않는다.
   public var centerSlot: UIView? {
     didSet {
       self.updateSlot(container: self.centerSlotContainer, old: oldValue, new: self.centerSlot)
@@ -44,6 +50,7 @@ public final class BezierSectionItem: UIControl, BezierComponentable {
     }
   }
 
+  /// custom leading일 때 label 대신 중앙을 채우는 자유 콘텐츠 뷰.
   public var customCenterContent: UIView? {
     didSet {
       self.updateSlot(container: self.customCenterContainer, old: oldValue, new: self.customCenterContent)
@@ -51,14 +58,17 @@ public final class BezierSectionItem: UIControl, BezierComponentable {
     }
   }
 
+  /// 우측 accessory(navigation/toggle 등). `nil`이면 숨긴다.
   public var accessory: BezierSectionItemAccessory<UIView>? {
     didSet { self.accessoryView.apply(self.accessory) }
   }
 
+  /// 삭제 등 파괴적 액션 표시. `true`면 leading 아이콘·본문을 red 색으로 그린다 (기본값 `false`).
   public var isDestructive: Bool = false {
     didSet { if oldValue != self.isDestructive { self.refreshAppearance() } }
   }
 
+  /// 행 탭 핸들러. `nil`이면 비인터랙티브(pressed 없음)가 된다.
   public var onTap: (() -> Void)? {
     didSet { self.refreshInteraction() }
   }
@@ -166,6 +176,7 @@ public final class BezierSectionItem: UIControl, BezierComponentable {
 
   // MARK: - Init
 
+  /// size·본문 텍스트·description·탭 핸들러로 행을 만든다. leading·accessory 등 나머지 구성은 생성 후 프로퍼티로 지정한다.
   public init(
     size: BezierSectionItemSize = .medium,
     content: String,

--- a/Sources/BezierSwift/MasterComponent/BezierSectionItem/BezierSectionItemSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierSectionItem/BezierSectionItemSpec.swift
@@ -7,9 +7,13 @@ import CoreGraphics
 
 // MARK: - Size
 
+/// 섹션 아이템의 크기. Figma `Internal/SectionItem`의 `size` 프로퍼티에 대응 (case 이름 = Figma 값). 행 높이·leading 크기·description 배치 구조를 결정한다.
 public enum BezierSectionItemSize: CaseIterable {
+  /// 최소 높이 40, leading 24×24. 조밀한 리스트에 쓴다.
   case small
+  /// 최소 높이 48, leading 24×24. 대부분의 섹션 행에 쓰는 기본값이다.
   case medium
+  /// 최소 높이 52, leading 36×36. description을 label 아래 nested로 배치한다. 아바타·설명이 함께 있는 행에 쓴다.
   case large
 
   var minHeight: CGFloat {
@@ -49,10 +53,15 @@ public enum BezierSectionItemSize: CaseIterable {
 
 // MARK: - Leading
 
+/// 섹션 아이템의 leading(좌측) 콘텐츠 유형. Figma `Internal/SectionItem`의 `leadingType` 프로퍼티에 대응 (case 이름 = Figma 값). `Content`는 avatar/custom 슬롯에 넣을 뷰 타입이다.
 public enum BezierSectionItemLeading<Content> {
+  /// leading 없이 텍스트만 시작하는 행.
   case none
+  /// `BezierIcon` 자산을 leading 아이콘으로 표시한다.
   case icon(BezierIcon)
+  /// 아바타 뷰를 leading에 배치한다 (Figma는 Avatar 인스턴스).
   case avatar(Content)
+  /// 임의의 뷰를 leading에 배치하는 자유 구조. 이때 label·description·centerSlot 대신 `customCenterContent`로 중앙을 채운다.
   case custom(Content)
 
   var isCustom: Bool {
@@ -72,13 +81,21 @@ public enum BezierSectionItemLeading<Content> {
 
 // MARK: - Accessory
 
+/// 섹션 아이템 우측 accessory 유형. Figma `Internal/SectionItemAccessory`의 `type` 프로퍼티에 대응 (case 이름 = Figma 값). 모두 탭 불가한 상태 표시자다 (단일 탭 타겟 불변식).
 public enum BezierSectionItemAccessory<Content> {
+  /// `chevronSmallRight` 아이콘. 다음 화면으로 이동하는 행에 쓴다.
   case navigation
+  /// `arrowRightUpSmall` 아이콘. 외부 링크로 나가는 행에 쓴다.
   case outlink
+  /// 선택된 값 텍스트 + `chevronUpdown`. 단일 선택 값을 보여줄 때 쓴다.
   case select(value: String)
+  /// 값들을 콤마로 이어 붙인 텍스트 + `chevronUpdown`. 다중 선택 값을 보여줄 때 쓴다.
   case multiselect(values: [String])
+  /// 값 텍스트만 표시한다. 편집 없이 현재 값만 보여줄 때 쓴다.
   case display(value: String)
+  /// 켜짐/꺼짐 상태를 나타내는 비인터랙티브 토글 표시자.
   case toggle(isOn: Bool)
+  /// 임의의 뷰를 accessory로 배치한다 (포커서블 컨트롤 금지).
   case custom(Content)
 }
 

--- a/Sources/BezierSwift/MasterComponent/BezierSectionItem/SUBezierSectionItem.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierSectionItem/SUBezierSectionItem.swift
@@ -5,6 +5,7 @@
 
 import SwiftUI
 
+/// `SUBezierSection` 안에 넣는 리스트 행 아이템 (SwiftUI). leading · 텍스트 · description · centerSlot · 우측 accessory로 구성되며 탭·pressed·disabled를 지원한다. 섹션 밖 독립 리스트 행에는 `SUBezierBaseItem`을 쓴다. UIKit에서는 `BezierSectionItem`을 사용한다.
 public struct SUBezierSectionItem<CenterSlot: View>: View, Themeable {
   @Environment(\.colorScheme) public var colorScheme
   @Environment(\.isEnabled) private var isEnabled
@@ -19,6 +20,7 @@ public struct SUBezierSectionItem<CenterSlot: View>: View, Themeable {
   private let onTap: (() -> Void)?
   private let centerSlot: CenterSlot
 
+  /// size·본문·description·leading·accessory·탭 핸들러와 `centerSlot` 빌더로 행을 만든다.
   public init(
     size: BezierSectionItemSize = .medium,
     content: String,
@@ -168,6 +170,7 @@ public struct SUBezierSectionItem<CenterSlot: View>: View, Themeable {
 // MARK: - Convenience init (centerSlot 생략)
 
 extension SUBezierSectionItem where CenterSlot == EmptyView {
+  /// centerSlot 없이 만드는 편의 이니셜라이저.
   public init(
     size: BezierSectionItemSize = .medium,
     content: String,

--- a/Sources/BezierSwift/MasterComponent/BezierSpinner/BezierSpinner.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierSpinner/BezierSpinner.swift
@@ -5,6 +5,7 @@
 
 import UIKit
 
+/// 비동기 로딩 대기를 나타내는 회전 스피너 (UIKit). 무한 회전 애니메이션으로 처리 중임을 표시한다. SwiftUI에서는 `SUBezierSpinner`를 사용한다.
 public final class BezierSpinner: UIView, BezierComponentable {
   private enum Metric {
     static let arcStartAngle: CGFloat = .pi * 3 / 4
@@ -21,6 +22,7 @@ public final class BezierSpinner: UIView, BezierComponentable {
 
   // MARK: - Public Properties
 
+  /// 스피너 크기. 기본값은 `.size12`다.
   public var size: BezierSpinnerSize = .size12 {
     didSet { if oldValue != self.size { self.refreshLayout() } }
   }
@@ -42,6 +44,7 @@ public final class BezierSpinner: UIView, BezierComponentable {
 
   // MARK: - Init
 
+  /// 크기를 지정해 스피너를 만든다. 기본값은 `.size12`다.
   public init(size: BezierSpinnerSize = .size12) {
     self.size = size
     super.init(frame: .zero)

--- a/Sources/BezierSwift/MasterComponent/BezierSpinner/BezierSpinnerSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierSpinner/BezierSpinnerSpec.swift
@@ -7,14 +7,23 @@ import Foundation
 
 // MARK: - Spinner Size
 
+/// 스피너의 지름 크기. Figma `Spinner` 컴포넌트의 `size` 프로퍼티에 대응 (Figma 값 `"12"` = `.size12`). 담기는 맥락(버튼 내부·인라인·전체 화면 로딩)에 맞춰 고른다. Figma 모바일 스펙 확정 전이라 참고용이다(신뢰도 낮음).
 public enum BezierSpinnerSize: String, CaseIterable {
+  /// 최소 크기. 버튼 내부·인라인에 쓴다.
   case size12
+  /// 버튼 내부·인라인에 쓴다.
   case size16
+  /// 인라인·소형 영역에 쓴다.
   case size20
+  /// 중형 영역에 쓴다.
   case size24
+  /// 중형 영역에 쓴다.
   case size30
+  /// 대형 영역에 쓴다.
   case size36
+  /// 대형 영역에 쓴다.
   case size42
+  /// 최대 크기. 전체 화면·대형 영역에 쓴다.
   case size48
 
   public var length: CGFloat {

--- a/Sources/BezierSwift/MasterComponent/BezierSpinner/SUBezierSpinner.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierSpinner/SUBezierSpinner.swift
@@ -5,6 +5,7 @@
 
 import SwiftUI
 
+/// 비동기 로딩 대기를 나타내는 회전 스피너 (SwiftUI). 무한 회전 애니메이션으로 처리 중임을 표시한다. UIKit에서는 `BezierSpinner`를 사용한다.
 public struct SUBezierSpinner: View, Themeable {
   private let size: BezierSpinnerSize
   private let fillColorOverride: Color?
@@ -12,6 +13,7 @@ public struct SUBezierSpinner: View, Themeable {
   @Environment(\.colorScheme) public var colorScheme
   @State private var isRotating = false
 
+  /// 크기를 지정해 스피너를 만든다. 기본값은 `.size12`다.
   public init(size: BezierSpinnerSize = .size12) {
     self.size = size
     self.fillColorOverride = nil

--- a/Sources/BezierSwift/MasterComponent/BezierTag/BezierTag.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierTag/BezierTag.swift
@@ -5,6 +5,7 @@
 
 import UIKit
 
+/// 카테고리 라벨링용 태그 컴포넌트 (UIKit). 상태·시맨틱 표현은 `BezierBadge`를 쓴다. SwiftUI에서는 `SUBezierTag`를 사용한다.
 public final class BezierTag: UIView, BezierComponentable {
   // MARK: - BezierComponentable
 
@@ -15,14 +16,17 @@ public final class BezierTag: UIView, BezierComponentable {
 
   // MARK: - Public Properties
 
+  /// 태그의 크기. 기본값 `.small`.
   public var size: BezierTagSize = .small {
     didSet { if oldValue != self.size { self.refreshLayout() } }
   }
 
+  /// 태그의 색상 계열. 기본값 `.default`.
   public var variant: BezierTagVariant = .default {
     didSet { if oldValue != self.variant { self.refreshAppearance() } }
   }
 
+  /// 태그에 표시할 텍스트. 기본값 `nil`.
   public var label: String? {
     didSet { if oldValue != self.label { self.refreshContent() } }
   }
@@ -78,6 +82,7 @@ public final class BezierTag: UIView, BezierComponentable {
 
   // MARK: - Init
 
+  /// 크기와 색상 계열을 지정해 태그를 생성한다. 라벨과 close 아이콘은 프로퍼티로 설정한다.
   public init(
     size: BezierTagSize = .small,
     variant: BezierTagVariant = .default

--- a/Sources/BezierSwift/MasterComponent/BezierTag/BezierTagSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierTag/BezierTagSpec.swift
@@ -6,10 +6,15 @@
 import CoreGraphics
 import UIKit
 
+/// 태그의 크기(밀도). Figma `Tag` 컴포넌트의 `size` 프로퍼티에 대응 (case 이름 = Figma 값).
 public enum BezierTagSize: String, CaseIterable {
+  /// 밀도가 가장 높은 조밀한 크기. 좁은 공간이나 인라인 라벨에 쓴다.
   case xsmall
+  /// 기본 밀도. 목록·폼 등 일반적인 상황에 쓴다.
   case small
+  /// 본문 텍스트와 함께 놓아 가독성을 높일 때 쓴다.
   case medium
+  /// 가장 큰 밀도. 강조가 필요하거나 넉넉한 영역에 쓴다.
   case large
 
   public var height: CGFloat {
@@ -79,18 +84,31 @@ public enum BezierTagSize: String, CaseIterable {
   public var verticalLineSpacing: CGFloat { self.lineSpacing / 2 }
 }
 
+/// 태그의 색상 계열. Figma `Tag` 컴포넌트의 `variant` 프로퍼티에 대응 (case 이름 = Figma 값). Figma의 `monochrome-light`/`monochrome-dark`는 Swift Tag에서 제공하지 않는다.
 public enum BezierTagVariant: String, CaseIterable {
+  /// 색상 약속이 없는 중립 기본.
   case `default`
+  /// 팀 내 색상↔의미 약속이 있는 카테고리 구분용. 상태·시맨틱 강조는 `BezierBadge`를 쓴다.
   case red
+  /// 팀 내 색상↔의미 약속이 있는 카테고리 구분용. 상태·시맨틱 강조는 `BezierBadge`를 쓴다.
   case orange
+  /// 팀 내 색상↔의미 약속이 있는 카테고리 구분용. 상태·시맨틱 강조는 `BezierBadge`를 쓴다.
   case yellow
+  /// 팀 내 색상↔의미 약속이 있는 카테고리 구분용. 상태·시맨틱 강조는 `BezierBadge`를 쓴다.
   case olive
+  /// 팀 내 색상↔의미 약속이 있는 카테고리 구분용. 상태·시맨틱 강조는 `BezierBadge`를 쓴다.
   case green
+  /// 팀 내 색상↔의미 약속이 있는 카테고리 구분용. 상태·시맨틱 강조는 `BezierBadge`를 쓴다.
   case cobalt
+  /// 팀 내 색상↔의미 약속이 있는 카테고리 구분용. 상태·시맨틱 강조는 `BezierBadge`를 쓴다.
   case purple
+  /// 팀 내 색상↔의미 약속이 있는 카테고리 구분용. 상태·시맨틱 강조는 `BezierBadge`를 쓴다.
   case pink
+  /// 팀 내 색상↔의미 약속이 있는 카테고리 구분용. 상태·시맨틱 강조는 `BezierBadge`를 쓴다.
   case navy
+  /// 팀 내 색상↔의미 약속이 있는 카테고리 구분용. 상태·시맨틱 강조는 `BezierBadge`를 쓴다.
   case blue
+  /// 팀 내 색상↔의미 약속이 있는 카테고리 구분용. 상태·시맨틱 강조는 `BezierBadge`를 쓴다.
   case teal
 }
 

--- a/Sources/BezierSwift/MasterComponent/BezierTag/SUBezierTag.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierTag/SUBezierTag.swift
@@ -5,6 +5,7 @@
 
 import SwiftUI
 
+/// 카테고리 라벨링용 태그 컴포넌트 (SwiftUI). 상태·시맨틱 표현은 `BezierBadge`를 쓴다. UIKit에서는 `BezierTag`를 사용한다.
 public struct SUBezierTag: View, Themeable {
   private let size: BezierTagSize
   private let variant: BezierTagVariant
@@ -14,6 +15,7 @@ public struct SUBezierTag: View, Themeable {
 
   @Environment(\.colorScheme) public var colorScheme
 
+  /// 크기·색상 계열·라벨과 삭제 콜백을 지정해 태그를 생성한다. `onDelete`가 있으면 trailing에 close 아이콘이 노출된다.
   public init(
     size: BezierTagSize = .small,
     variant: BezierTagVariant = .default,

--- a/Sources/BezierSwift/MasterComponent/BezierToast/BezierToast.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierToast/BezierToast.swift
@@ -5,6 +5,7 @@
 
 import UIKit
 
+/// 짧은 비차단 알림 토스트 컴포넌트 (UIKit/UIView). 확인이 꼭 필요한 오류·영구 메시지는 `BezierBanner`를 쓴다. SwiftUI에서는 `View.bezierToast(param:)` modifier를 사용한다.
 public final class BezierToast: UIView, BezierComponentable {
   // MARK: - BezierComponentable
 
@@ -16,6 +17,7 @@ public final class BezierToast: UIView, BezierComponentable {
 
   // MARK: - Public Properties
 
+  /// 토스트의 표시 유형. 기본값 `.info`.
   public var preset: BezierToastPreset = .info {
     didSet {
       if oldValue != self.preset {
@@ -25,6 +27,7 @@ public final class BezierToast: UIView, BezierComponentable {
     }
   }
 
+  /// 토스트에 표시할 텍스트. 기본값 `nil`.
   public var title: String? {
     didSet { if oldValue != self.title { self.refreshContent() } }
   }
@@ -65,6 +68,7 @@ public final class BezierToast: UIView, BezierComponentable {
 
   // MARK: - Init
 
+  /// 표시 유형과 텍스트를 지정해 토스트를 생성한다.
   public init(preset: BezierToastPreset = .info, title: String? = nil) {
     self.preset = preset
     self.title = title

--- a/Sources/BezierSwift/MasterComponent/BezierToast/BezierToastSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierToast/BezierToastSpec.swift
@@ -5,9 +5,13 @@
 
 import CoreGraphics
 
+/// 토스트의 표시 유형. Figma `Toast` 컴포넌트의 `preset` 프로퍼티에 대응(Figma `default` ↔ `.info`). Figma의 `warning`은 Swift에서 제공하지 않는다. Figma mobile 스펙 확정 전이라 매핑은 참고용이다.
 public enum BezierToastPreset: String, CaseIterable {
+  /// 저장·삭제 등 액션 완료 결과를 알린다. 3초 후 자동 해제된다.
   case success
+  /// 액션 실패 결과를 알린다.
   case error
+  /// Figma `default`. 아이콘 없는 중립 알림에 쓴다.
   case info
 
   /// preset별 leading 아이콘. `info`는 아이콘 없음(nil).


### PR DESCRIPTION
## 배경

BezierSwift V3 컴포넌트를 사용하는 consumer(ch-desk-ios 등) 관점의 사용 가이드가 부족했다. 두 사용 시나리오 — (1) 디자인 시안이 있을 때 Figma↔코드 매핑, (2) 디자인이 없을 때 컴포넌트/속성 선택 판단 — 모두 필요한데, 재료(team-design spec의 Selection Rules, SPEC.md 코드 심볼 매핑)는 있으나 consumer 손이 닿는 코드 옆(public API doc comment)으로 옮기는 레이어가 비어 있었다.

## 변경

16개 V3 컴포넌트의 선택 축 enum·타입·init·주요 property에 consumer용 doc comment(`///`)를 추가했다.

- **관점1(매핑)**: enum 선언부에 `Figma {Component} 컴포넌트의 {property} 프로퍼티` 대응 명시
- **관점2(판단)**: case별 team-design spec §2 Selection Rules 기반 "언제 쓰는지"
- **이름/구현 갭 명시**: Badge `neutral-*`→`monochrome*`, Tag monochrome 미제공, Toast `default`→`.info`·warning 미제공, Avatar `"20"`→`.size20`·`60` 미제공, Divider 세로 미지원, Modal size는 Figma 전용 프리셋, ConfirmModal Type은 코드 시맨틱 프리셋, FloatingBanner는 Banner의 `Type=Floating` variant, Section* 다수는 코드 전용 인프라
- BezierButton SPEC.md에 누락된 "매핑되는 코드 심볼" 섹션 보강

대상 16개: Button, IconButton, Badge, Tag, Banner, FloatingBanner, Toast, Avatar(+Status), AvatarGroup, Spinner, BaseItem, Divider, Modal, ConfirmModal, Section, SectionItem. (Dialog·Legacy*는 레거시로 제외)

## 검증

- **순수 doc comment 변경** — 추가 343줄 전부 `///`, 기존 코드 변경 0 (`git diff`로 확인)
- SourceKit-LSP hover로 Xcode·비-Xcode 에디터(VSCode·Cursor 등)·AI 에이전트 모두에서 노출 확인

## 참고

원천 SSOT: channel-io/team-design `bezier-v3/components/{Comp}-spec.md` (§2 Selection Rules, §4 Variants).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 아바타 상태 표식, 아바타 그룹, 배지, 버튼, 아이콘 버튼, 태그, 섹션 아이템의 추가 크기 옵션을 지원합니다.
  - 배너와 플로팅 배너에 액션 아이콘 클릭 영역과 새로운 색상 옵션이 추가되었습니다.
  - 버튼과 아이콘 버튼에 위험 동작용 스타일이 추가되었습니다.
  - 섹션 라벨의 밝은 중립 색상과 토스트 정보 유형을 지원합니다.

- **문서화**
  - 주요 UIKit·SwiftUI 컴포넌트와 옵션에 대한 한국어 사용 설명이 보강되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->