### PR TITLE
[MOB-6352] BezierOverlay 컴포넌트 구현 (UIKit + SwiftUI)

### DIFF
--- a/Examples/BezierExamples/BezierExamples/App/CatalogRegistry.swift
+++ b/Examples/BezierExamples/BezierExamples/App/CatalogRegistry.swift
@@ -124,6 +124,12 @@ enum CatalogRegistry {
       section: .v3Components,
       destination: AnyView(FloatingBannerCatalog())
     ),
+    CatalogItem(
+      id: "overlay",
+      title: "Overlay",
+      section: .v3Components,
+      destination: AnyView(OverlayCatalog())
+    ),
     // MARK: - Legacy Components
     CatalogItem(
       id: "legacy-button",

--- a/Examples/BezierExamples/BezierExamples/Components/OverlayCatalog.swift
+++ b/Examples/BezierExamples/BezierExamples/Components/OverlayCatalog.swift
@@ -1,0 +1,129 @@
+import SwiftUI
+import UIKit
+import BezierSwift
+
+struct OverlayCatalog: View {
+  enum ContentKind: String, CaseIterable, Identifiable {
+    case menu, freeText, empty
+    var id: String { self.rawValue }
+  }
+
+  @State private var contentKind: ContentKind = .menu
+
+  var body: some View {
+    CatalogScreen(title: "Overlay") {
+      self.controls
+      CatalogSection(.swiftUI) { self.swiftUIPreview }
+      CatalogSection(.uiKit) { self.uiKitPreview }
+    }
+  }
+
+  private var controls: some View {
+    Picker("content", selection: self.$contentKind) {
+      ForEach(ContentKind.allCases) { kind in
+        Text(kind.rawValue).tag(kind)
+      }
+    }
+    .pickerStyle(.segmented)
+    .font(.caption)
+  }
+
+  private var swiftUIPreview: some View {
+    SUBezierOverlay {
+      switch self.contentKind {
+      case .menu:
+        VStack(alignment: .leading, spacing: 0) {
+          ForEach(Self.menuTitles, id: \.self) { title in
+            SUBezierBaseItem(
+              title: title,
+              onTap: {},
+              leading: { EmptyView() },
+              trailing: { EmptyView() }
+            )
+          }
+        }
+      case .freeText:
+        Text("자유 구성 콘텐츠입니다. Overlay는 내부 구조를 강제하지 않는 escape hatch 컨테이너입니다.")
+          .font(.caption)
+          .padding(8)
+      case .empty:
+        EmptyView()
+      }
+    }
+    .padding(24)
+    .frame(maxWidth: .infinity)
+    .background(Color(uiColor: .secondarySystemBackground))
+  }
+
+  private var uiKitPreview: some View {
+    OverlayUIKitRepresentable(contentKind: self.contentKind)
+      .padding(24)
+      .frame(maxWidth: .infinity)
+      .background(Color(uiColor: .secondarySystemBackground))
+  }
+
+  static let menuTitles = ["이름 변경", "복제", "삭제"]
+}
+
+private struct OverlayUIKitRepresentable: UIViewRepresentable {
+  let contentKind: OverlayCatalog.ContentKind
+
+  final class Coordinator {
+    var renderedKind: OverlayCatalog.ContentKind?
+  }
+
+  func makeCoordinator() -> Coordinator { Coordinator() }
+
+  // BezierOverlay는 240pt 고정 폭(content hug)이라 wrapper에서 center로 배치한다.
+  func makeUIView(context: Context) -> UIView {
+    let wrapper = UIView()
+    let overlay = BezierOverlay()
+    overlay.translatesAutoresizingMaskIntoConstraints = false
+    wrapper.addSubview(overlay)
+    NSLayoutConstraint.activate([
+      overlay.topAnchor.constraint(equalTo: wrapper.topAnchor),
+      overlay.bottomAnchor.constraint(equalTo: wrapper.bottomAnchor),
+      overlay.centerXAnchor.constraint(equalTo: wrapper.centerXAnchor),
+    ])
+    return wrapper
+  }
+
+  func updateUIView(_ wrapper: UIView, context: Context) {
+    guard let overlay = wrapper.subviews.compactMap({ $0 as? BezierOverlay }).first else { return }
+    guard context.coordinator.renderedKind != self.contentKind else { return }
+    context.coordinator.renderedKind = self.contentKind
+    overlay.content = self.makeContent()
+  }
+
+  func sizeThatFits(_ proposal: ProposedViewSize, uiView: UIView, context: Context) -> CGSize? {
+    let fitting = uiView.systemLayoutSizeFitting(
+      CGSize(width: BezierOverlayConstant.width, height: UIView.layoutFittingCompressedSize.height),
+      withHorizontalFittingPriority: .fittingSizeLevel,
+      verticalFittingPriority: .fittingSizeLevel
+    )
+    return CGSize(width: proposal.width ?? fitting.width, height: fitting.height)
+  }
+
+  private func makeContent() -> UIView? {
+    switch self.contentKind {
+    case .menu:
+      let stackView = UIStackView()
+      stackView.axis = .vertical
+      stackView.alignment = .fill
+      stackView.distribution = .fill
+      stackView.spacing = 0
+      OverlayCatalog.menuTitles.forEach { title in
+        stackView.addArrangedSubview(BezierBaseItem(title: title, onTap: {}))
+      }
+      return stackView
+    case .freeText:
+      let label = UILabel()
+      label.text = "자유 구성 콘텐츠입니다. Overlay는 내부 구조를 강제하지 않는 escape hatch 컨테이너입니다."
+      label.font = .preferredFont(forTextStyle: .caption1)
+      label.numberOfLines = 0
+      return label
+    case .empty:
+      return nil
+    }
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierOverlay/BezierOverlay.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierOverlay/BezierOverlay.swift
@@ -1,0 +1,110 @@
+//
+//  BezierOverlay.swift
+//  BezierSwift
+//
+
+import UIKit
+
+/// floating UI를 직접 구성할 때 쓰는 범용 오버레이 컨테이너 (UIKit). `surfaceHighest` 배경·32pt 라운드·elevation 그림자를 가진 240pt 고정 폭 카드로, `content` 슬롯에 임의 뷰를 담는다. 자식 구조가 정해진 목적형 오버레이(드롭다운 목록 등)로 표현할 수 없는 floating UI에만 쓰며, 열림/닫힘·위치 계산(backdrop 없는 앵커형 팝오버 배치)은 사용처 책임이다. SwiftUI에서는 `SUBezierOverlay`를 사용한다.
+public final class BezierOverlay: UIView, BezierComponentable {
+  // MARK: - BezierComponentable
+
+  public var colorTheme: BezierColorTheme { .systemBezierColorTheme() }
+  public var componentTheme: BezierComponentTheme = .normal {
+    didSet { self.refreshAppearance() }
+  }
+
+  // MARK: - Public Properties
+
+  /// content 슬롯에 담을 뷰. 교체 시 이전 뷰는 제거되며 `nil`이면 슬롯을 비운다 (기본값 `nil`). 슬롯 폭은 220pt(= 240 − 10×2)로 고정되고 높이는 콘텐츠에 맞게 늘어난다.
+  public var content: UIView? {
+    didSet {
+      guard oldValue !== self.content else { return }
+      oldValue?.removeFromSuperview()
+      if let content = self.content {
+        self.attachContent(content)
+      }
+    }
+  }
+
+  // MARK: - Init
+
+  /// content 슬롯 뷰를 지정해 오버레이를 만든다.
+  public init(content: UIView? = nil) {
+    self.content = content
+    super.init(frame: .zero)
+    self.setUp()
+  }
+
+  public required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    self.setUp()
+  }
+
+  // MARK: - Setup
+
+  private func setUp() {
+    self.translatesAutoresizingMaskIntoConstraints = false
+    self.layer.cornerRadius = BezierOverlayConstant.cornerRadius
+    // elevation 그림자를 렌더하려면 masksToBounds = false. 배경은 layer.cornerRadius로 둥글게 유지된다.
+    self.layer.masksToBounds = false
+    self.insetsLayoutMarginsFromSafeArea = false
+
+    self.directionalLayoutMargins = NSDirectionalEdgeInsets(
+      top: BezierOverlayConstant.padding,
+      leading: BezierOverlayConstant.padding,
+      bottom: BezierOverlayConstant.padding,
+      trailing: BezierOverlayConstant.padding
+    )
+    NSLayoutConstraint.activate([
+      self.widthAnchor.constraint(equalToConstant: BezierOverlayConstant.width),
+      self.heightAnchor.constraint(greaterThanOrEqualToConstant: BezierOverlayConstant.padding * 2),
+    ])
+
+    if let content = self.content {
+      self.attachContent(content)
+    }
+    self.refreshAppearance()
+  }
+
+  private func attachContent(_ content: UIView) {
+    content.translatesAutoresizingMaskIntoConstraints = false
+    self.addSubview(content)
+    let margins = self.layoutMarginsGuide
+    NSLayoutConstraint.activate([
+      content.topAnchor.constraint(equalTo: margins.topAnchor),
+      content.leadingAnchor.constraint(equalTo: margins.leadingAnchor),
+      content.trailingAnchor.constraint(equalTo: margins.trailingAnchor),
+      content.bottomAnchor.constraint(equalTo: margins.bottomAnchor),
+    ])
+  }
+
+  // MARK: - Layout
+
+  public override func layoutSubviews() {
+    super.layoutSubviews()
+    self.layer.shadowPath = UIBezierPath(
+      roundedRect: self.bounds,
+      cornerRadius: BezierOverlayConstant.cornerRadius
+    ).cgPath
+  }
+
+  // MARK: - Trait
+
+  public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    self.refreshAppearance()
+  }
+
+  // MARK: - Refresh
+
+  private func refreshAppearance() {
+    self.backgroundColor = BezierOverlayConstant.backgroundColor.palette(self)
+
+    let elevation = BezierOverlayConstant.elevation.rawValue
+    self.layer.shadowColor = elevation.semanticColor.palette(self).cgColor
+    self.layer.shadowOffset = CGSize(width: elevation.x, height: elevation.y)
+    self.layer.shadowRadius = elevation.blur
+    self.layer.shadowOpacity = 1
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierOverlay/BezierOverlay.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierOverlay/BezierOverlay.swift
@@ -83,9 +83,12 @@ public final class BezierOverlay: UIView, BezierComponentable {
 
   public override func layoutSubviews() {
     super.layoutSubviews()
+    // cornerRadius(32)가 높이/2를 넘으면 CALayer·UIBezierPath가 렌즈형 아티팩트를 그리므로 절반까지로 클램프한다 (Figma 렌더 동작과 동일).
+    let cornerRadius = min(BezierOverlayConstant.cornerRadius, self.bounds.height / 2)
+    self.layer.cornerRadius = cornerRadius
     self.layer.shadowPath = UIBezierPath(
       roundedRect: self.bounds,
-      cornerRadius: BezierOverlayConstant.cornerRadius
+      cornerRadius: cornerRadius
     ).cgPath
   }
 

--- a/Sources/BezierSwift/MasterComponent/BezierOverlay/BezierOverlaySpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierOverlay/BezierOverlaySpec.swift
@@ -1,0 +1,15 @@
+//
+//  BezierOverlaySpec.swift
+//  BezierSwift
+//
+
+import CoreGraphics
+
+public enum BezierOverlayConstant {
+  public static let width: CGFloat = 240
+  public static let padding: CGFloat = 10
+  public static let cornerRadius: CGFloat = 32
+  public static let elevation: BezierElevation = .mEv3
+
+  static let backgroundColor: BCSemanticToken = .surfaceHighest
+}

--- a/Sources/BezierSwift/MasterComponent/BezierOverlay/SPEC.md
+++ b/Sources/BezierSwift/MasterComponent/BezierOverlay/SPEC.md
@@ -1,0 +1,83 @@
+# BezierOverlay SPEC
+
+> **SSOT**: [Figma · Mobile-Components / overlay (5078:2253)](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=5078-2253) (canvas `Overlay` = 5078:2181)
+> **Design spec doc**: [team-design / bezier-v3 / components / Overlay-spec.md](https://github.com/channel-io/team-design/blob/main/bezier-v3/components/Overlay-spec.md) · [BaseOverlay.md §Mobile 임베딩 패턴](https://github.com/channel-io/team-design/blob/main/bezier-v3/components/BaseOverlay.md) (보조 참조 — 값 충돌 시 Figma 파일 우선)
+
+DropdownMenu·Select·MultiSelect 등 목적형 오버레이로 표현할 수 없는 floating UI를 구성하는 범용 레이아웃 컨테이너(escape hatch) (Figma component description 1행).
+
+## 1. Component Properties
+
+| Property | 값 | 비고 |
+|---|---|---|
+| **content** | SLOT (`5215:13008`) | 내부 콘텐츠 영역. 자식 구조는 사용처가 자유롭게 정의 |
+
+variant / state / boolean 축 없음 — 단일 스타일 정적 컨테이너.
+
+총 instance: 1개 (`overlay` = `5078:2253`)
+
+## 2. Layout Spec
+
+| Part | 값 |
+|---|---|
+| container 폭 | `240pt` FIXED |
+| container 높이 | auto (HUG — 콘텐츠 기반. 마스터 실측 164pt) |
+| padding | `10pt` (상하좌우 균일) |
+| gap | `0pt` |
+| corner radius | `32pt` (`radius/32`) |
+| content SLOT | 폭 `220pt` (= 240 − 10×2) — 마스터 실측 220×144pt (144pt는 placeholder 높이) |
+| clipsContent | 없음 (루트 프레임 overflow clip 미적용) |
+
+## 3. 컬러 토큰
+
+| 영역 | Token | Figma Variable | Raw |
+|---|---|---|---|
+| container 배경 | `surfaceHighest` | `color/surface/highest` | `#FFFFFF` |
+| shadow 색 | `elevationLarge` | `color/elevation/large` | `#00000038` |
+
+## 4. Typography
+
+이 컴포넌트에 텍스트 없음.
+
+## 5. State 별 시각 동작
+
+Figma CS에 state variant 축 없음 (정적 컨테이너).
+
+## 6. Elevation
+
+| Effect Style | 구성 |
+|---|---|
+| `Elevation/Mobile/3` | DROP_SHADOW · color `color/elevation/large` · offset (0, `elevation/4` = 4) · blur `elevation/20` = 20 · spread 0 (단일 레이어) |
+
+## 7. 디자이너 가이드라인 (Figma component description 인용)
+
+- DropdownMenu·Select·MultiSelect 등 목적형 오버레이로 표현할 수 없는 floating UI를 구성하는 범용 레이아웃 컨테이너(escape hatch). Mobile Select/MultiSelect의 container=overlay variant가 backdrop 없는 앵커형 팝오버로 옵션 목록을 표시할 때 이 셸을 내장한다.
+- width: content SLOT에 맞춰 HUG, min 160 / max 280px 클램프
+  - (실측 불일치: 현재 노드는 폭 `240pt` FIXED · SLOT `220pt` 고정 — description의 width 항목만 노드 실측과 어긋난다. 판정은 §9-5 참조)
+- max-height: 고정값 없음 — 뷰포트·트리거 위치·세이프 에어리어 기준 동적 fit, 초과 시 내부 스크롤 (코드 구현 참고용, Figma 레이어로 표현 불가)
+- position: 기본 bottom-start, 트리거와 8px 간격, 화면 밖이면 flip, 가장자리 마진 16px (코드 구현 참고용)
+- backdrop 없음 · 외부 탭 시 닫힘 · 드래그 딜미스 없음 (BottomSheet와 구분)
+- 드롭다운 선택 목록에는 DropdownMenu·Select·MultiSelect를 직접 사용한다.
+
+## 8. 매핑되는 코드 심볼
+
+| 정의 | 파일 |
+|---|---|
+| UIKit 구현 | `BezierOverlay.swift` |
+| SwiftUI 구현 | `SUBezierOverlay.swift` |
+| 상수 정의 | `BezierOverlaySpec.swift` |
+
+## 9. Figma 외 · 협의 사항 (구현 결정)
+
+Figma에 없는 구현 아키텍처 결정은 아래에 분리 표기한다. SSOT 값이 아니다.
+
+1. **스코프 = 시각 셸 + content 슬롯**. §7의 position(bottom-start·8pt 간격·flip·가장자리 16pt)·외부 탭 닫힘·max-height 동적 fit은 description이 "코드 구현 참고용, Figma 레이어로 표현 불가"로 명시한 프레젠테이션 거동이며, 열림/닫힘·포지셔닝 로직은 사용처 책임(Overlay-spec §7)이므로 본 컴포넌트 스코프에서 제외한다. 후속 DropdownMenu/Select 패널이 이 셸을 조합해 프레젠테이션을 구성한다.
+2. **content 슬롯 API**: UIKit은 `content: UIView?` 프로퍼티(교체형 단일 슬롯), SwiftUI는 `@ViewBuilder content` — Figma의 단일 SLOT 구조에 대응.
+3. **Elevation은 기존 `BezierElevation.mEv3` 재사용** — 정의(semanticColor `.elevationLarge`, y 4, blur 20)가 Figma `Elevation/Mobile/3`과 동일.
+4. **폭 240pt는 내부 고정** — public resizing/width API를 노출하지 않는다 (배치는 컨테이너 책임 원칙).
+5. **description width 불일치 처리**: §7의 "HUG min160/max280" 항목은 노드 실측(FIXED 240pt · SLOT 220pt)과 어긋난다. 구현은 노드 실측을 따른다. (description이 stale하다는 근거는 외부 저장소 team-design Overlay-spec에서 확인한 사항으로, Figma 안에서는 검증 불가)
+
+## 10. Variant 매트릭스
+
+```
+overlay = 5078:2253  (총 1 — variant 축 없음)
+```

--- a/Sources/BezierSwift/MasterComponent/BezierOverlay/SPEC.md
+++ b/Sources/BezierSwift/MasterComponent/BezierOverlay/SPEC.md
@@ -75,6 +75,8 @@ Figma에 없는 구현 아키텍처 결정은 아래에 분리 표기한다. SSO
 3. **Elevation은 기존 `BezierElevation.mEv3` 재사용** — 정의(semanticColor `.elevationLarge`, y 4, blur 20)가 Figma `Elevation/Mobile/3`과 동일.
 4. **폭 240pt는 내부 고정** — public resizing/width API를 노출하지 않는다 (배치는 컨테이너 책임 원칙).
 5. **description width 불일치 처리**: §7의 "HUG min160/max280" 항목은 노드 실측(FIXED 240pt · SLOT 220pt)과 어긋난다. 구현은 노드 실측을 따른다. (description이 stale하다는 근거는 외부 저장소 team-design Overlay-spec에서 확인한 사항으로, Figma 안에서는 검증 불가)
+6. **cornerRadius 클램프**: 카드 높이가 64pt(= 32×2) 미만이면 radius를 높이/2로 클램프한다. CALayer·UIBezierPath·RoundedRectangle 모두 radius > 높이/2에서 렌즈형 아티팩트를 그리는 반면 Figma는 렌더 시 자동 클램프하므로, 클램프가 Figma 렌더 결과와 일치한다.
+7. **빈 슬롯 최소 높이**: content가 비어도 패딩 합(20pt) 높이의 카드를 유지한다 — Figma auto-layout 프레임이 자식 없이도 패딩을 유지하는 동작과 동일 (UIKit `heightAnchor ≥ 20`, SwiftUI는 VStack 래핑으로 EmptyView 소거 방지).
 
 ## 10. Variant 매트릭스
 

--- a/Sources/BezierSwift/MasterComponent/BezierOverlay/SUBezierOverlay.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierOverlay/SUBezierOverlay.swift
@@ -1,0 +1,66 @@
+//
+//  SUBezierOverlay.swift
+//  BezierSwift
+//
+
+import SwiftUI
+
+/// floating UI를 직접 구성할 때 쓰는 범용 오버레이 컨테이너 (SwiftUI). `surfaceHighest` 배경·32pt 라운드·elevation 그림자를 가진 240pt 고정 폭 카드로, `content`에 임의 뷰를 담는다. 자식 구조가 정해진 목적형 오버레이(드롭다운 목록 등)로 표현할 수 없는 floating UI에만 쓰며, 열림/닫힘·위치 계산(backdrop 없는 앵커형 팝오버 배치)은 사용처 책임이다. UIKit에서는 `BezierOverlay`를 사용한다.
+public struct SUBezierOverlay<Content: View>: View, Themeable {
+  @Environment(\.colorScheme) public var colorScheme
+
+  private let content: Content
+
+  /// content 슬롯 뷰를 지정해 오버레이를 만든다. 슬롯 폭은 220pt(= 240 − 10×2)로 고정되고 높이는 콘텐츠에 맞게 늘어난다.
+  public init(@ViewBuilder content: () -> Content) {
+    self.content = content()
+  }
+
+  public var body: some View {
+    self.content
+      .frame(maxWidth: .infinity, alignment: .topLeading)
+      .padding(BezierOverlayConstant.padding)
+      .frame(width: BezierOverlayConstant.width)
+      .background(
+        RoundedRectangle(cornerRadius: BezierOverlayConstant.cornerRadius)
+          .fill(self.palette(BezierOverlayConstant.backgroundColor))
+      )
+      .applyBezierElevation(BezierOverlayConstant.elevation)
+  }
+}
+
+struct SUBezierOverlay_Previews: PreviewProvider {
+  static var previews: some View {
+    VStack(spacing: 32) {
+      SUBezierOverlay {
+        VStack(alignment: .leading, spacing: 0) {
+          SUBezierBaseItem(
+            title: "이름 변경",
+            onTap: {},
+            leading: { EmptyView() },
+            trailing: { EmptyView() }
+          )
+          SUBezierBaseItem(
+            title: "복제",
+            onTap: {},
+            leading: { EmptyView() },
+            trailing: { EmptyView() }
+          )
+          SUBezierBaseItem(
+            title: "삭제",
+            onTap: {},
+            leading: { EmptyView() },
+            trailing: { EmptyView() }
+          )
+        }
+      }
+
+      SUBezierOverlay {
+        Text("자유 구성 콘텐츠")
+          .padding(8)
+      }
+    }
+    .padding()
+    .background(Color.gray.opacity(0.2))
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierOverlay/SUBezierOverlay.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierOverlay/SUBezierOverlay.swift
@@ -17,15 +17,21 @@ public struct SUBezierOverlay<Content: View>: View, Themeable {
   }
 
   public var body: some View {
-    self.content
+    // content가 EmptyView여도 카드가 그려지도록 실체가 있는 컨테이너(VStack)로 감싼다 (EmptyView는 모디파이어 체인 전체를 소거함).
+    VStack(alignment: .leading, spacing: 0) { self.content }
       .frame(maxWidth: .infinity, alignment: .topLeading)
       .padding(BezierOverlayConstant.padding)
       .frame(width: BezierOverlayConstant.width)
-      .background(
-        RoundedRectangle(cornerRadius: BezierOverlayConstant.cornerRadius)
-          .fill(self.palette(BezierOverlayConstant.backgroundColor))
-      )
+      .background(self.backgroundView)
       .applyBezierElevation(BezierOverlayConstant.elevation)
+  }
+
+  private var backgroundView: some View {
+    GeometryReader { geometry in
+      // cornerRadius(32)가 높이/2를 넘으면 RoundedRectangle이 렌즈형 아티팩트를 그리므로 절반까지로 클램프한다 (Figma 렌더 동작과 동일).
+      RoundedRectangle(cornerRadius: min(BezierOverlayConstant.cornerRadius, geometry.size.height / 2))
+        .fill(self.palette(BezierOverlayConstant.backgroundColor))
+    }
   }
 }
 

--- a/Tests/BezierSwiftTests/BezierOverlayLayoutTests.swift
+++ b/Tests/BezierSwiftTests/BezierOverlayLayoutTests.swift
@@ -41,6 +41,27 @@ struct BezierOverlayLayoutTests {
     #expect(overlay.frame.height == 20)
   }
 
+  @Test("높이가 64 미만이면 cornerRadius가 높이 절반으로 클램프된다")
+  func cornerRadiusClampsToHalfHeight() {
+    let overlay = BezierOverlay()
+
+    Self.layout(overlay)
+
+    #expect(overlay.layer.cornerRadius == 10)
+  }
+
+  @Test("높이가 64 이상이면 cornerRadius 32가 유지된다")
+  func cornerRadiusStaysAtSpecValue() {
+    let content = UIView()
+    content.translatesAutoresizingMaskIntoConstraints = false
+    content.heightAnchor.constraint(equalToConstant: 100).isActive = true
+    let overlay = BezierOverlay(content: content)
+
+    Self.layout(overlay)
+
+    #expect(overlay.layer.cornerRadius == 32)
+  }
+
   @Test("content 교체 시 이전 뷰가 제거된다")
   func replacingContentRemovesOldView() {
     let first = UIView()

--- a/Tests/BezierSwiftTests/BezierOverlayLayoutTests.swift
+++ b/Tests/BezierSwiftTests/BezierOverlayLayoutTests.swift
@@ -1,0 +1,81 @@
+import Testing
+import UIKit
+@testable import BezierSwift
+
+@Suite("BezierOverlay 상수")
+struct BezierOverlayConstantTests {
+  @Test("Figma 실측 수치와 일치한다")
+  func constantsMatchFigma() {
+    #expect(BezierOverlayConstant.width == 240)
+    #expect(BezierOverlayConstant.padding == 10)
+    #expect(BezierOverlayConstant.cornerRadius == 32)
+    #expect(BezierOverlayConstant.elevation == .mEv3)
+    #expect(BezierOverlayConstant.backgroundColor == .surfaceHighest)
+  }
+}
+
+@Suite("BezierOverlay 레이아웃", .serialized)
+@MainActor
+struct BezierOverlayLayoutTests {
+  @Test("고정 폭 240 안에서 content가 패딩 10을 두고 배치된다")
+  func contentIsInsetByPadding() {
+    let content = UIView()
+    content.translatesAutoresizingMaskIntoConstraints = false
+    content.heightAnchor.constraint(equalToConstant: 100).isActive = true
+    let overlay = BezierOverlay(content: content)
+
+    Self.layout(overlay)
+
+    #expect(overlay.frame.width == 240)
+    #expect(overlay.frame.height == 120)
+    #expect(content.frame == CGRect(x: 10, y: 10, width: 220, height: 100))
+  }
+
+  @Test("content가 nil이면 패딩만큼의 빈 카드가 된다")
+  func emptyContentKeepsPaddingHeight() {
+    let overlay = BezierOverlay()
+
+    Self.layout(overlay)
+
+    #expect(overlay.frame.width == 240)
+    #expect(overlay.frame.height == 20)
+  }
+
+  @Test("content 교체 시 이전 뷰가 제거된다")
+  func replacingContentRemovesOldView() {
+    let first = UIView()
+    let overlay = BezierOverlay(content: first)
+
+    let second = UIView()
+    overlay.content = second
+
+    #expect(first.superview == nil)
+    #expect(second.superview === overlay)
+
+    overlay.content = nil
+    #expect(second.superview == nil)
+  }
+
+  @Test("라운드 32에 그림자 렌더를 위한 masksToBounds가 꺼져 있다")
+  func layerConfiguration() {
+    let overlay = BezierOverlay()
+
+    #expect(overlay.layer.cornerRadius == 32)
+    #expect(overlay.layer.masksToBounds == false)
+  }
+
+  // MARK: - Helpers
+
+  private static func layout(_ overlay: BezierOverlay) {
+    let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 400, height: 400))
+    window.isHidden = false
+    let host = UIView(frame: window.bounds)
+    window.addSubview(host)
+    host.addSubview(overlay)
+    NSLayoutConstraint.activate([
+      overlay.topAnchor.constraint(equalTo: host.topAnchor),
+      overlay.leadingAnchor.constraint(equalTo: host.leadingAnchor),
+    ])
+    host.layoutIfNeeded()
+  }
+}


### PR DESCRIPTION
## MOB-6352

https://linear.app/channel/issue/MOB-6352

V3 Overlay 컴포넌트를 UIKit + SwiftUI로 구현합니다. DropdownMenu·Select 등 목적형 오버레이로 표현할 수 없는 floating UI를 담는 범용 레이아웃 컨테이너(escape hatch)이며, 후속 DropdownMenu(MOB-6355)/Select(MOB-6353) 패널이 이 셸을 조합해 사용할 예정입니다.

## 구현 내용

### Overlay — `BezierOverlay` / `SUBezierOverlay`

- 폭 **240pt 고정** · 높이 HUG · 패딩 10pt 균일 · radius **32pt** · 배경 `surfaceHighest` · 그림자 `Elevation/Mobile/3`(기존 `BezierElevation.mEv3` 재사용 — `elevationLarge`, offset (0,4), blur 20)
- content 슬롯 단일 축 (variant/state 축 없음) — 슬롯 폭 220pt(= 240 − 10×2), 높이는 콘텐츠 추종
  - UIKit: `content: UIView?` 교체형 슬롯 (할당 시 layoutMarginsGuide에 pin, 이전 뷰 제거). 빈 슬롯일 때 SwiftUI와 동일하게 240×20 빈 카드가 되도록 최소 높이(패딩 합) 제약 부여
  - SwiftUI: `@ViewBuilder content` — `frame(maxWidth:.infinity) → padding(10) → frame(width:240)` 체인으로 슬롯 220pt 성립. content가 `EmptyView`여도 카드가 소거되지 않도록 VStack으로 래핑
- **cornerRadius 클램프**: 카드 높이 < 64pt(= 32×2)이면 radius를 높이/2로 클램프 — CALayer/UIBezierPath/RoundedRectangle 모두 radius > 높이/2에서 렌즈형 아티팩트를 그리는 반면 Figma는 자동 클램프 (시뮬레이터 검증에서 발견·수정, SPEC.md §9-6)
- UIKit 다크모드: 배경·`layer.shadowColor`(CGColor)를 `traitCollectionDidChange`에서 재주입, `layer.shadowPath`는 `layoutSubviews`에서 갱신
- 그림자 렌더를 위해 `masksToBounds = false`, 콘텐츠 clip은 Figma와 동일하게 미적용
- 배치 원칙 준수: public resizing/width API 없음 (열림/닫힘·포지셔닝은 사용처 책임)
- public API에 consumer 가이드 doc comment 작성

### Examples

- `OverlayCatalog` 추가 (사이드바 V3 Components 그룹) — content 축(menu/freeText/empty) 세그먼트, SwiftUI/UIKit 프리뷰. UIKit representable은 Coordinator로 content 종류 변경 시에만 슬롯 재구성

## Spec 검증

figma-component-spec 3단계 사이클로 검증했습니다 (Figma = SSOT):

- Phase 1: Figma 실측 기반 `SPEC.md` 작성 (`overlay` 5078:2253, content SLOT 5215:13008)
- Phase 2: Properties / Layout / Color / Typography / Asset / Spec Noise / Implementation Reference 7종 병렬 검증 전부 통과
  - Figma component description의 "width HUG min160/max280" 항목은 노드 실측(FIXED 240 · SLOT 220)과 불일치 — 실측을 SSOT로 채택 (team-design Overlay-spec DL-104 재회귀와 정합, SPEC.md §7·§9-5 기록)
- Phase 3: UIKit·SwiftUI Implementation Validator로 구현–SPEC 일치 확인
- Figma에 없는 구현 결정(프레젠테이션 스코프 제외, content 슬롯 API 형태, mEv3 재사용, 폭 내부 고정, cornerRadius 클램프, 빈 슬롯 최소 높이)은 `SPEC.md` §9에 협의 사항으로 분리 기록

## 스크린샷

시뮬레이터(iPhone 16, iOS 18.6) 검증 캡처. 라이트/다크 × content 축 조합에서 SwiftUI/UIKit 렌더 일치 확인.

| 파일 | 내용 |
|---|---|
| `01-overlay-menu-light.png` | menu content (BaseItem 3행) — SwiftUI/UIKit, 라이트 |
| `02-overlay-freetext-light.png` | freeText content — SwiftUI/UIKit, 라이트 |
| `03-overlay-empty-light.png` | empty content — 240×20 빈 카드 (radius 클램프 적용), SwiftUI/UIKit |
| `04-overlay-menu-dark.png` | menu content — 다크 (`surfaceHighest` 자동 적응) |
| `05-overlay-freetext-dark.png` | freeText content — 다크 |

시뮬레이터 검증에서 발견·수정한 결함 2건:
1. SwiftUI `EmptyView` content 시 카드 자체가 렌더되지 않음 → VStack 래핑으로 수정
2. 높이 < 64pt에서 radius 32가 렌즈형 아티팩트 유발 (빈 카드 20pt, small 단일 행 60pt 등에서 재현) → radius 클램프로 수정

## 테스트

- `BezierOverlayLayoutTests` — 상수(Figma 실측 일치)·레이아웃(240 고정 폭/패딩 10/슬롯 220/빈 카드 20pt)·cornerRadius 클램프(높이 20 → 10, 높이 120 → 32)·content 교체·layer 구성, `xcodebuild test` 통과
- 패키지 clean build + test, Examples 앱 clean build 성공


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - UIKit과 SwiftUI에서 사용할 수 있는 `BezierOverlay` 오버레이 컴포넌트를 추가했습니다.
  - 콘텐츠를 자유롭게 삽입하거나 메뉴, 텍스트, 빈 상태로 표시할 수 있습니다.
  - 고정 너비, 자동 높이, 모서리 반경, 배경색 및 그림자 스타일을 지원합니다.
  - 카탈로그에 Overlay 예제를 추가해 다양한 표시 모드를 확인할 수 있습니다.

- **문서**
  - 오버레이의 레이아웃, 스타일 및 사용 지침을 문서화했습니다.

- **테스트**
  - 크기, 여백, 콘텐츠 교체, 모서리 반경 및 그림자 동작을 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->