### PR TITLE
[MOB-6337] BezierSwitch 컴포넌트 구현 (UIKit + SwiftUI)

### DIFF
--- a/Examples/BezierExamples/BezierExamples/App/CatalogRegistry.swift
+++ b/Examples/BezierExamples/BezierExamples/App/CatalogRegistry.swift
@@ -130,6 +130,12 @@ enum CatalogRegistry {
       section: .v3Components,
       destination: AnyView(OverlayCatalog())
     ),
+    CatalogItem(
+      id: "switch",
+      title: "Switch",
+      section: .v3Components,
+      destination: AnyView(SwitchCatalog())
+    ),
     // MARK: - Legacy Components
     CatalogItem(
       id: "legacy-button",

--- a/Examples/BezierExamples/BezierExamples/Components/SwitchCatalog.swift
+++ b/Examples/BezierExamples/BezierExamples/Components/SwitchCatalog.swift
@@ -1,0 +1,120 @@
+import SwiftUI
+import UIKit
+import BezierSwift
+
+struct SwitchCatalog: View {
+  @State private var isOn: Bool = false
+  @State private var hasError: Bool = false
+  @State private var isEnabled: Bool = true
+
+  var body: some View {
+    CatalogScreen(title: "Switch") {
+      self.controls
+      CatalogSection(.swiftUI) { self.swiftUIPreview }
+      CatalogSection(.uiKit) { self.uiKitPreview }
+      Text("Matrix (isOn × state)")
+        .font(.system(size: 13, weight: .semibold))
+        .foregroundStyle(.secondary)
+        .textCase(.uppercase)
+      CatalogSection(.swiftUI) { self.swiftUIMatrix }
+      CatalogSection(.uiKit) { self.uiKitMatrix }
+    }
+  }
+
+  private var controls: some View {
+    VStack(alignment: .leading, spacing: 10) {
+      Toggle("On", isOn: self.$isOn).font(.callout)
+      Toggle("Has Error", isOn: self.$hasError).font(.callout)
+      Toggle("Enabled", isOn: self.$isEnabled).font(.callout)
+    }
+  }
+
+  private var swiftUIPreview: some View {
+    HStack {
+      Spacer()
+      SUBezierSwitch(isOn: self.$isOn, hasError: self.hasError)
+        .disabled(!self.isEnabled)
+      Spacer()
+    }
+    .padding(.vertical, 8)
+  }
+
+  private var uiKitPreview: some View {
+    HStack {
+      Spacer()
+      UIKitWrap(
+        {
+          let bezierSwitch = BezierSwitch()
+          bezierSwitch.addAction(
+            UIAction { [weak bezierSwitch] _ in
+              guard let bezierSwitch else { return }
+              self.isOn = bezierSwitch.isOn
+            },
+            for: .valueChanged
+          )
+          return bezierSwitch
+        },
+        update: { (bezierSwitch: BezierSwitch) in
+          bezierSwitch.setOn(self.isOn, animated: true)
+          bezierSwitch.hasError = self.hasError
+          bezierSwitch.isEnabled = self.isEnabled
+        }
+      )
+      .fixedSize()
+      Spacer()
+    }
+    .padding(.vertical, 8)
+  }
+
+  private var swiftUIMatrix: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      self.matrixRow(title: "default") { isOn in
+        SUBezierSwitch(isOn: .constant(isOn))
+      }
+      self.matrixRow(title: "disabled") { isOn in
+        SUBezierSwitch(isOn: .constant(isOn))
+          .disabled(true)
+      }
+      self.matrixRow(title: "hasError") { isOn in
+        SUBezierSwitch(isOn: .constant(isOn), hasError: true)
+      }
+    }
+  }
+
+  private var uiKitMatrix: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      self.matrixRow(title: "default") { isOn in
+        UIKitWrap({ BezierSwitch(isOn: isOn) })
+          .fixedSize()
+      }
+      self.matrixRow(title: "disabled") { isOn in
+        UIKitWrap(
+          {
+            let bezierSwitch = BezierSwitch(isOn: isOn)
+            bezierSwitch.isEnabled = false
+            return bezierSwitch
+          }
+        )
+        .fixedSize()
+      }
+      self.matrixRow(title: "hasError") { isOn in
+        UIKitWrap({ BezierSwitch(isOn: isOn, hasError: true) })
+          .fixedSize()
+      }
+    }
+  }
+
+  private func matrixRow(
+    title: String,
+    @ViewBuilder content: @escaping (Bool) -> some View
+  ) -> some View {
+    VStack(alignment: .leading, spacing: 6) {
+      Text(title).font(.caption2).foregroundStyle(.secondary)
+      HStack(spacing: 12) {
+        content(false)
+        content(true)
+        Spacer(minLength: 0)
+      }
+    }
+  }
+}

--- a/Examples/BezierExamples/BezierExamples/Components/SwitchCatalog.swift
+++ b/Examples/BezierExamples/BezierExamples/Components/SwitchCatalog.swift
@@ -57,10 +57,11 @@ struct SwitchCatalog: View {
         update: { (bezierSwitch: BezierSwitch) in
           bezierSwitch.setOn(self.isOn, animated: true)
           bezierSwitch.hasError = self.hasError
-          bezierSwitch.isEnabled = self.isEnabled
         }
       )
       .fixedSize()
+      // SwiftUI가 environment isEnabled를 UIControl.isEnabled로 강제 동기화 — 직접 설정 대신 .disabled로 제어
+      .disabled(!self.isEnabled)
       Spacer()
     }
     .padding(.vertical, 8)
@@ -88,14 +89,10 @@ struct SwitchCatalog: View {
           .fixedSize()
       }
       self.matrixRow(title: "disabled") { isOn in
-        UIKitWrap(
-          {
-            let bezierSwitch = BezierSwitch(isOn: isOn)
-            bezierSwitch.isEnabled = false
-            return bezierSwitch
-          }
-        )
-        .fixedSize()
+        UIKitWrap({ BezierSwitch(isOn: isOn) })
+          .fixedSize()
+          // SwiftUI가 environment isEnabled를 UIControl.isEnabled로 강제 동기화 — 직접 설정 대신 .disabled로 제어
+          .disabled(true)
       }
       self.matrixRow(title: "hasError") { isOn in
         UIKitWrap({ BezierSwitch(isOn: isOn, hasError: true) })

--- a/Sources/BezierSwift/MasterComponent/BezierSwitch/BezierSwitch.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierSwitch/BezierSwitch.swift
@@ -1,0 +1,176 @@
+//
+//  BezierSwitch.swift
+//  BezierSwift
+//
+
+import UIKit
+
+/// ON/OFF 설정 토글 컴포넌트 (UIKit). 라벨 없이 `50×28pt` 단일 크기로 제공되며, 라벨과 배치는 컨테이너(행)가 소유한다. 값이 바뀌면 `.valueChanged` 이벤트를 보낸다. SwiftUI에서는 `SUBezierSwitch`를 사용한다.
+public final class BezierSwitch: UIControl, BezierComponentable {
+  // MARK: - BezierComponentable
+
+  public var colorTheme: BezierColorTheme { .systemBezierColorTheme() }
+  public var componentTheme: BezierComponentTheme = .normal {
+    didSet { self.refreshAppearance() }
+  }
+
+  // MARK: - Public Properties
+
+  /// 스위치 ON 여부. 직접 설정하면 애니메이션 없이 즉시 반영된다. 애니메이션이 필요하면 `setOn(_:animated:)`를 사용한다. 기본값은 `false`.
+  public var isOn: Bool = false {
+    didSet {
+      guard oldValue != self.isOn else { return }
+      self.refreshToggle(animated: self.isAnimatedChangeInProgress)
+    }
+  }
+
+  /// 오류 상태 표시 여부. Figma `hasError` 프로퍼티에 대응하며, `true`면 트랙 외곽에 warning ring이 나타난다. 기본값은 `false`.
+  public var hasError: Bool = false {
+    didSet {
+      guard oldValue != self.hasError else { return }
+      self.errorRingView.isHidden = !self.hasError
+    }
+  }
+
+  public override var isEnabled: Bool {
+    didSet {
+      guard oldValue != self.isEnabled else { return }
+      self.alpha = self.isEnabled ? 1 : BezierSwitchConstant.disabledOpacity
+    }
+  }
+
+  // MARK: - Private Properties
+
+  private var isAnimatedChangeInProgress = false
+
+  // MARK: - Subviews
+
+  private let thumbView = UIView()
+  private let errorRingView = UIView()
+  private var thumbLeadingConstraint: NSLayoutConstraint?
+
+  // MARK: - Init
+
+  /// ON 여부와 오류 표시 여부를 지정해 스위치를 만든다. 탭하면 값이 토글되고 `.valueChanged` 이벤트가 발송된다.
+  public init(isOn: Bool = false, hasError: Bool = false) {
+    self.isOn = isOn
+    self.hasError = hasError
+    super.init(frame: .zero)
+    self.setUp()
+  }
+
+  public required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    self.setUp()
+  }
+
+  // MARK: - Public Methods
+
+  /// ON 여부를 변경한다. `animated`가 `true`면 thumb 슬라이드·트랙 색 전환이 애니메이션되며, Reduce Motion 설정 시에는 즉시 전환된다.
+  public func setOn(_ isOn: Bool, animated: Bool) {
+    guard self.isOn != isOn else { return }
+    self.isAnimatedChangeInProgress = animated
+    self.isOn = isOn
+    self.isAnimatedChangeInProgress = false
+  }
+
+  // MARK: - Setup
+
+  private func setUp() {
+    self.translatesAutoresizingMaskIntoConstraints = false
+    self.layer.cornerRadius = BezierSwitchConstant.trackCornerRadius
+
+    self.thumbView.isUserInteractionEnabled = false
+    self.thumbView.translatesAutoresizingMaskIntoConstraints = false
+    self.thumbView.layer.cornerRadius = BezierSwitchConstant.thumbLength / 2
+    self.thumbView.layer.shadowColor = UIColor.black.cgColor
+    self.thumbView.layer.shadowOpacity = BezierSwitchConstant.thumbShadowOpacity
+    self.thumbView.layer.shadowOffset = BezierSwitchConstant.thumbShadowOffset
+    self.thumbView.layer.shadowRadius = BezierSwitchConstant.thumbShadowRadius
+
+    self.errorRingView.isUserInteractionEnabled = false
+    self.errorRingView.translatesAutoresizingMaskIntoConstraints = false
+    self.errorRingView.isHidden = !self.hasError
+    self.errorRingView.layer.cornerRadius = BezierSwitchConstant.errorRingCornerRadius
+    self.errorRingView.layer.borderWidth = BezierSwitchConstant.errorRingWidth
+
+    self.addSubview(self.errorRingView)
+    self.addSubview(self.thumbView)
+
+    let thumbLeading = self.thumbView.leadingAnchor.constraint(
+      equalTo: self.leadingAnchor,
+      constant: self.thumbLeadingOffset
+    )
+    self.thumbLeadingConstraint = thumbLeading
+
+    let ringSpacing = BezierSwitchConstant.errorRingSpacing
+    NSLayoutConstraint.activate([
+      self.widthAnchor.constraint(equalToConstant: BezierSwitchConstant.trackWidth),
+      self.heightAnchor.constraint(equalToConstant: BezierSwitchConstant.trackHeight),
+      thumbLeading,
+      self.thumbView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+      self.thumbView.widthAnchor.constraint(equalToConstant: BezierSwitchConstant.thumbLength),
+      self.thumbView.heightAnchor.constraint(equalToConstant: BezierSwitchConstant.thumbLength),
+      self.errorRingView.topAnchor.constraint(equalTo: self.topAnchor, constant: -ringSpacing),
+      self.errorRingView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: -ringSpacing),
+      self.errorRingView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: ringSpacing),
+      self.errorRingView.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: ringSpacing),
+    ])
+
+    self.addTarget(self, action: #selector(self.didTap), for: .touchUpInside)
+
+    self.refreshAppearance()
+  }
+
+  // MARK: - Trait
+
+  public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    self.refreshAppearance()
+  }
+
+  // MARK: - Refresh
+
+  private var thumbLeadingOffset: CGFloat {
+    self.isOn
+      ? BezierSwitchConstant.trackWidth
+        - BezierSwitchConstant.thumbInset
+        - BezierSwitchConstant.thumbLength
+      : BezierSwitchConstant.thumbInset
+  }
+
+  private func refreshToggle(animated: Bool) {
+    self.thumbLeadingConstraint?.constant = self.thumbLeadingOffset
+
+    guard animated, !UIAccessibility.isReduceMotionEnabled else {
+      self.refreshAppearance()
+      return
+    }
+
+    UIView.animate(
+      withDuration: BezierSwitchConstant.toggleAnimationDuration,
+      delay: 0,
+      options: [.curveEaseInOut, .beginFromCurrentState]
+    ) {
+      self.refreshAppearance()
+      self.layoutIfNeeded()
+    }
+  }
+
+  private func refreshAppearance() {
+    self.backgroundColor = (
+      self.isOn
+        ? BezierSwitchConstant.trackOnColor
+        : BezierSwitchConstant.trackOffColor
+    ).palette(self)
+    self.thumbView.backgroundColor = BezierSwitchConstant.thumbColor.palette(self)
+    self.errorRingView.layer.borderColor = BezierSwitchConstant.errorRingColor.palette(self).cgColor
+  }
+
+  // MARK: - Touch
+
+  @objc private func didTap() {
+    self.setOn(!self.isOn, animated: true)
+    self.sendActions(for: .valueChanged)
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierSwitch/BezierSwitchSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierSwitch/BezierSwitchSpec.swift
@@ -1,0 +1,30 @@
+//
+//  BezierSwitchSpec.swift
+//  BezierSwift
+//
+
+import Foundation
+
+enum BezierSwitchConstant {
+  static let trackWidth: CGFloat = 50
+  static let trackHeight: CGFloat = 28
+  static let trackCornerRadius: CGFloat = 14
+
+  static let thumbLength: CGFloat = 24
+  static let thumbInset: CGFloat = 2
+  static let thumbShadowOpacity: Float = 0.25
+  static let thumbShadowOffset = CGSize(width: 0, height: 2)
+  static let thumbShadowRadius: CGFloat = 2
+
+  static let errorRingSpacing: CGFloat = 3
+  static let errorRingWidth: CGFloat = 1.5
+  static let errorRingCornerRadius: CGFloat = (trackHeight + errorRingSpacing * 2) / 2
+
+  static let disabledOpacity: CGFloat = BOGlobalToken.disabled
+  static let toggleAnimationDuration: TimeInterval = 0.2
+
+  static let trackOffColor: BCSemanticToken = .fillNeutralHeavy
+  static let trackOnColor: BCSemanticToken = .fillNeutralHeaviest
+  static let thumbColor: BCSemanticToken = .iconInverseHeavier
+  static let errorRingColor: BCSemanticToken = .stateWarning
+}

--- a/Sources/BezierSwift/MasterComponent/BezierSwitch/SPEC.md
+++ b/Sources/BezierSwift/MasterComponent/BezierSwitch/SPEC.md
@@ -1,0 +1,101 @@
+# BezierSwitch SPEC
+
+> **SSOT**: [Figma · Mobile-Components / Switch (1095:19)](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=1095-19)
+> **Design spec doc**: [team-design / bezier-v3 / components / Switch-spec.md](https://github.com/channel-io/team-design/blob/main/bezier-v3/components/Switch-spec.md) (보조 참조 — 값 충돌 시 Figma 파일 우선)
+
+ON/OFF 설정 토글. 라벨 없음 — 라벨은 항상 외부(ListItem·행)가 소유 (Figma component description 1행).
+
+## 1. Component Properties
+
+| Property | 값 | 비고 |
+|---|---|---|
+| **checked** | `on` / `off` | thumb 위치·트랙 색 결정 |
+| **state** | `default` / `disabled` | disabled는 루트 opacity 처리 |
+| **hasError** | `false` / `true` | 트랙 외곽 warning ring 표시 |
+
+총 instance: 6개 — `checked(2) × state(2)`의 `hasError=false` 4개 + `checked(2) × state=default`의 `hasError=true` 2개. `state=disabled × hasError=true` 조합은 CS에 없음.
+
+크기 축 없음 (단일 사이즈). 텍스트 라벨 슬롯 없음.
+
+## 2. Layout Spec
+
+| Part | 값 | Figma Variable |
+|---|---|---|
+| 트랙 | `50×28pt`, radius `14pt` (pill) | `radius/14` |
+| thumb | `24×24pt` 원형, 트랙 인셋 `2pt` | — |
+| thumb 위치 | off: leading `2pt` / on: leading `24pt` (= 50 − 2 − 24) | — |
+| thumb 그림자 | offset `(0, 2)`, blur `4` (Gaussian stdDeviation `2`), black `25%` | — |
+| error ring (`_ring`) | 트랙 외곽 `3pt` 확장 프레임 `56×34pt`, stroke `1.5pt` (프레임 안쪽), pill radius | — |
+
+- thumb 그림자 실측 근거: Figma export SVG 필터 — `feOffset dy=2` + `feGaussianBlur stdDeviation=2` + alpha `0.25`.
+
+## 3. 컬러 토큰
+
+| 영역 | Token | Figma Variable | Raw |
+|---|---|---|---|
+| 트랙 (checked=off) | `fillNeutralHeavy` | `color/fill/neutral/heavy` | `#00000026` |
+| 트랙 (checked=on) | `fillNeutralHeaviest` | `color/fill/neutral/heaviest` | `#000000D9` |
+| thumb | `iconInverseHeavier` | `color/icon/inverse/heavier` | `#FFFFFF` |
+| error ring | `stateWarning` | `color/state/warning` | `#E67F2B` |
+| thumb 그림자 | — *(raw black 25%, SVG 필터 값)* | — | `#000000` 25% |
+
+| 효과 | 값 | Figma Variable |
+|---|---|---|
+| disabled opacity | `40%` → `0.4` | `opacity/disabled` |
+
+## 4. Typography
+
+이 컴포넌트에 텍스트 없음.
+
+## 5. State 별 시각 동작
+
+| State | 변경점 | 인터랙션 |
+|---|---|---|
+| `checked=off` | 트랙 `fillNeutralHeavy`, thumb 좌측 (leading 2pt) | 활성 |
+| `checked=on` | 트랙 `fillNeutralHeaviest`, thumb 우측 (leading 24pt) | 활성 |
+| `state=disabled` | 루트 opacity `0.4` | 비활성 (입력 차단) |
+| `hasError=true` | 트랙 외곽 `stateWarning` ring 표시 | 활성 (CS에는 `state=default` 조합만 존재) |
+
+pressed variant 없음 (CS에 press 시각 상태 미정의).
+
+## 6. 디자이너 가이드라인 (Figma 인용)
+
+Component description (Switch `1095:19`):
+
+- ON/OFF 설정 토글. 라벨 없음 — 라벨은 항상 외부(ListItem·행)가 소유. 모바일에서 단독 라벨 스위치는 쓰지 않음. 설정 리스트는 ListItem + 라벨리스 Switch 조합 사용. 즉시 반영 설정 전용(저장 버튼 없음). 폼 일괄 제출 ON/OFF는 Checkbox 사용.
+
+Canvas 디자이너 노트 (`5000:12406`):
+
+- "스위치는 거의 Item이나 FormField에 넣어서 쓸거라 라벨 안만들었어요"
+
+## 7. 매핑되는 코드 심볼
+
+| 정의 | 파일 |
+|---|---|
+| UIKit 구현 | `BezierSwitch.swift` |
+| SwiftUI 구현 | `SUBezierSwitch.swift` |
+| 상수 / 토큰 매핑 | `BezierSwitchSpec.swift` |
+
+## 8. Figma 외 · 협의 사항
+
+Figma에 없는 구현 결정은 아래에 분리 표기한다. SSOT 값이 아니다.
+
+1. **API 표면**: UIKit `BezierSwitch: UIControl` — `isOn` / `setOn(_:animated:)` / `hasError` / `isEnabled`, 값 변경 시 `.valueChanged` 이벤트 발송. SwiftUI `SUBezierSwitch(isOn: Binding<Bool>, hasError: Bool = false)` — disabled는 `.disabled()` 환경으로 제어.
+2. **라벨·배치는 컨테이너 책임**: size/label/full-width 류 public API 없음 (단일 사이즈 라벨리스 컴포넌트).
+3. **`disabled × hasError` 조합**: CS에 없음 — 구현은 두 효과를 중첩 적용 (ring 유지 + opacity 0.4).
+4. **thumb 슬라이드 애니메이션**: Mobile CS에 모션 정의 없음 — UIKit·SwiftUI 공통 easeInOut 0.2s (`UIView.animate` / `.easeInOut(duration:)`), 두 패러다임 시각 일치 목적. Reduce Motion 활성 시 애니메이션 생략(즉시 전환).
+5. **그림자 단위 변환**: Figma blur `4`는 CSS blur radius — `CALayer.shadowRadius` / SwiftUI `.shadow(radius:)`는 Gaussian stdDeviation 기준이므로 `2` 적용.
+6. **error ring 렌더**: UIKit은 별도 ring 뷰(`layer.border`, 트랙 밖 −3pt 확장) — CALayer border는 프레임 안쪽으로 그려져 CSS `border-box`와 동일. SwiftUI는 `Capsule().strokeBorder` overlay.
+
+## 9. Variant 매트릭스
+
+총 instance: **6개**
+
+```
+checked=on,  state=default,  hasError=false = 1095:7
+checked=off, state=default,  hasError=false = 1095:10
+checked=on,  state=disabled, hasError=false = 1095:13
+checked=off, state=disabled, hasError=false = 1095:16
+checked=off, state=default,  hasError=true  = 4864:251
+checked=on,  state=default,  hasError=true  = 4864:254
+```

--- a/Sources/BezierSwift/MasterComponent/BezierSwitch/SUBezierSwitch.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierSwitch/SUBezierSwitch.swift
@@ -59,6 +59,8 @@ public struct SUBezierSwitch: View, Themeable {
       )
     }
     .buttonStyle(SUBezierSwitchButtonStyle())
+    // compositingGroup 없이는 opacity가 per-view 곱으로 렌더돼 thumb 아래 트랙이 비침 — Figma·UIKit(그룹 opacity)과 동일한 flatten 강제
+    .compositingGroup()
     .opacity(self.isEnabled ? 1 : BezierSwitchConstant.disabledOpacity)
   }
 

--- a/Sources/BezierSwift/MasterComponent/BezierSwitch/SUBezierSwitch.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierSwitch/SUBezierSwitch.swift
@@ -1,0 +1,115 @@
+//
+//  SUBezierSwitch.swift
+//  BezierSwift
+//
+
+import SwiftUI
+
+/// ON/OFF 설정 토글 컴포넌트 (SwiftUI). 라벨 없이 `50×28pt` 단일 크기로 제공되며, 라벨과 배치는 컨테이너(행)가 소유한다. UIKit에서는 `BezierSwitch`를 사용한다.
+public struct SUBezierSwitch: View, Themeable {
+  @Binding private var isOn: Bool
+  private let hasError: Bool
+
+  @Environment(\.isEnabled) private var isEnabled
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @Environment(\.colorScheme) public var colorScheme
+
+  /// ON 상태 바인딩과 오류 표시 여부를 지정해 스위치를 만든다. `hasError`는 Figma `hasError` 프로퍼티에 대응하며 `true`면 트랙 외곽에 warning ring이 나타난다. 비활성화는 `.disabled(true)`로 제어한다.
+  public init(isOn: Binding<Bool>, hasError: Bool = false) {
+    self._isOn = isOn
+    self.hasError = hasError
+  }
+
+  public var body: some View {
+    Button(action: { self.isOn.toggle() }) {
+      ZStack(alignment: self.isOn ? .trailing : .leading) {
+        RoundedRectangle(cornerRadius: BezierSwitchConstant.trackCornerRadius)
+          .fill(
+            self.palette(
+              self.isOn
+                ? BezierSwitchConstant.trackOnColor
+                : BezierSwitchConstant.trackOffColor
+            )
+          )
+
+        Circle()
+          .fill(self.palette(BezierSwitchConstant.thumbColor))
+          .frame(
+            width: BezierSwitchConstant.thumbLength,
+            height: BezierSwitchConstant.thumbLength
+          )
+          .shadow(
+            color: Color.black.opacity(Double(BezierSwitchConstant.thumbShadowOpacity)),
+            radius: BezierSwitchConstant.thumbShadowRadius,
+            x: BezierSwitchConstant.thumbShadowOffset.width,
+            y: BezierSwitchConstant.thumbShadowOffset.height
+          )
+          .padding(BezierSwitchConstant.thumbInset)
+      }
+      .frame(
+        width: BezierSwitchConstant.trackWidth,
+        height: BezierSwitchConstant.trackHeight
+      )
+      .overlay(self.errorRing)
+      .animation(
+        self.reduceMotion
+          ? nil
+          : .easeInOut(duration: BezierSwitchConstant.toggleAnimationDuration),
+        value: self.isOn
+      )
+    }
+    .buttonStyle(SUBezierSwitchButtonStyle())
+    .opacity(self.isEnabled ? 1 : BezierSwitchConstant.disabledOpacity)
+  }
+
+  @ViewBuilder
+  private var errorRing: some View {
+    if self.hasError {
+      Capsule()
+        .strokeBorder(
+          self.palette(BezierSwitchConstant.errorRingColor),
+          lineWidth: BezierSwitchConstant.errorRingWidth
+        )
+        .padding(-BezierSwitchConstant.errorRingSpacing)
+    }
+  }
+}
+
+private struct SUBezierSwitchButtonStyle: ButtonStyle {
+  func makeBody(configuration: Configuration) -> some View {
+    configuration.label
+  }
+}
+
+struct SUBezierSwitch_Previews: PreviewProvider {
+  private struct Container: View {
+    @State private var isOn = true
+    @State private var isOff = false
+
+    var body: some View {
+      VStack(spacing: 16) {
+        HStack(spacing: 12) {
+          SUBezierSwitch(isOn: self.$isOff)
+          SUBezierSwitch(isOn: self.$isOn)
+        }
+
+        HStack(spacing: 12) {
+          SUBezierSwitch(isOn: self.$isOff)
+            .disabled(true)
+          SUBezierSwitch(isOn: self.$isOn)
+            .disabled(true)
+        }
+
+        HStack(spacing: 12) {
+          SUBezierSwitch(isOn: self.$isOff, hasError: true)
+          SUBezierSwitch(isOn: self.$isOn, hasError: true)
+        }
+      }
+      .padding()
+    }
+  }
+
+  static var previews: some View {
+    Container()
+  }
+}


### PR DESCRIPTION
## MOB-6337

https://linear.app/channel/issue/MOB-6337

V3 Switch 컴포넌트를 UIKit + SwiftUI로 구현합니다.

## 구현 내용

### Switch — `BezierSwitch` / `SUBezierSwitch`

- 라벨 없는 `50×28pt` 단일 크기 ON/OFF 토글 — 라벨·배치는 컨테이너(행)가 소유 (Figma component description·DL-083)
- 트랙: radius `14`(pill), off `fillNeutralHeavy` / on `fillNeutralHeaviest`
- thumb: `24pt` 원형 `iconInverseHeavier`, 인셋 `2pt`, 그림자 offset `(0,2)` · Figma blur `4`(= shadowRadius `2`) · black `25%` — Figma export SVG 필터 실측
- `hasError`: 트랙 외곽 `3pt` 확장 `stateWarning` ring (`1.5pt` stroke, pill) — UIKit은 별도 ring 뷰의 `layer.border`, SwiftUI는 `Capsule().strokeBorder`
- disabled: opacity `0.4` (`opacity/disabled`) + 입력 차단. SwiftUI는 `.compositingGroup()`으로 그룹 flatten 렌더를 강제해 Figma·UIKit(그룹 opacity)과 시각 일치
- 토글 애니메이션 easeInOut `0.2s`, Reduce Motion 시 즉시 전환
- UIKit: `UIControl` 기반 `isOn` / `setOn(_:animated:)` / `hasError`, 탭 시 자체 토글 + `.valueChanged` 발송, 다크모드 시 `traitCollectionDidChange`에서 토큰색·CGColor 재주입
- SwiftUI: `SUBezierSwitch(isOn: Binding<Bool>, hasError:)`, 비활성화는 `.disabled()` 환경
- pressed 시각 상태 없음 (Figma CS에 pressed variant 미정의)
- Examples 카탈로그(Switch) 추가 — 인터랙티브 토글 + isOn × default/disabled/hasError 매트릭스 (SwiftUI·UIKit)
  - UIKit 데모의 disabled 제어는 `.disabled()` modifier 사용 — SwiftUI가 environment `isEnabled`를 UIViewRepresentable 내 `UIControl.isEnabled`로 강제 동기화하므로 update/factory에서의 직접 설정은 무효화됨 (시뮬레이터 검증에서 발견)

## Spec 검증

figma-component-spec 3단계 사이클로 검증했습니다 (Figma = SSOT):

- Phase 1: Figma 실측 기반 `SPEC.md` 작성 (Switch `1095:19`, variant 6종 — checked on/off × state default/disabled + hasError on/off는 default만)
- Phase 2: Properties / Layout / Color / Typography / Asset / Spec Noise / Implementation Reference 7종 병렬 검증 전부 통과
- Phase 3: UIKit·SwiftUI Implementation Validator로 구현–SPEC 일치 확인
- Figma에 없는 구현 결정(API 표면, `disabled × hasError` 중첩 처리, 애니메이션 duration, 그림자 blur→shadowRadius 단위 변환, ring 렌더 방식)은 `SPEC.md` §8에 협의 사항으로 분리 기록
- develop의 `BezierSectionItem` toggle 표시자 실측값(50×28 · radius 14 · thumb 24 · 그림자 (0,2)/blur4/25% · 동일 토큰 3종)과 이번 Figma 실측이 완전 일치함을 확인

## 스크린샷

시뮬레이터(iPhone 16 · iOS 18.6) 검증 캡처 — `Screenshots-MOB-6337/` (라이트/다크 × on/off/disabled/hasError, SwiftUI·UIKit 동시 확인):

| # | 파일 | 내용 |
|---|---|---|
| 01 | `01-light-live-off-matrix.png` | 라이트 · 라이브 off + SwiftUI 매트릭스 (default/disabled/hasError × off/on) |
| 02 | `02-light-swiftui-tapped-on-sync.png` | SwiftUI 스위치 탭 → on 전환 + UIKit 프리뷰 동기화 (`.valueChanged` 양방향) |
| 03 | `03-light-live-haserror-on.png` | 라이트 · on + hasError ring (SwiftUI·UIKit) |
| 04 | `04-light-live-haserror-off.png` | 라이트 · off + hasError ring |
| 05 | `05-light-live-disabled-off.png` | 라이트 · disabled (opacity 0.4, SwiftUI·UIKit 동일 렌더) |
| 06 | `06-light-uikit-matrix.png` | 라이트 · UIKit 매트릭스 (default/disabled/hasError × off/on) |
| 07 | `07-dark-uikit-matrix.png` | 다크 · 매트릭스 — on 트랙 흰색·thumb 어두운 색 (`iconInverseHeavier` 다크 팔레트, `traitCollectionDidChange` 재주입 확인) |
| 08 | `08-dark-live-off.png` | 다크 · 라이브 off |

## 검증

- `BezierSwift` 스킴 + Examples 앱 clean build 통과 (iOS 시뮬레이터 destination)
- 시뮬레이터 실기 검증: 탭 토글 애니메이션, SwiftUI↔UIKit 양방향 동기화, 라이트/다크 전환 시 토큰 재주입, disabled 렌더의 SwiftUI·UIKit·Figma 3자 일치(픽셀 대조) 확인
- 검증 중 발견·수정: SwiftUI `.opacity`가 per-view 곱으로 렌더돼 disabled 시 thumb 아래 트랙이 비치는 문제 → `.compositingGroup()`으로 flatten 강제 (Figma·UIKit과 일치)

## 후속 과제

- `BezierSectionItem`의 toggle 표시자(`BezierSectionItemToggleView` / `SUBezierSectionItemToggleIndicator`)는 현재 Switch 실측값으로 자체 렌더 중 — `BezierSwitch` 도입에 따른 교체는 본 PR 스코프 밖으로, 별도 후속 작업으로 진행 (MOB-6471의 BezierPressFeedback public 승격 건과는 별개)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
