### PR TITLE
[MOB-6344] BezierCheckbox 컴포넌트 구현 (UIKit + SwiftUI)

### DIFF
--- a/Examples/BezierExamples/BezierExamples/App/CatalogRegistry.swift
+++ b/Examples/BezierExamples/BezierExamples/App/CatalogRegistry.swift
@@ -130,6 +130,12 @@ enum CatalogRegistry {
       section: .v3Components,
       destination: AnyView(OverlayCatalog())
     ),
+    CatalogItem(
+      id: "checkbox",
+      title: "Checkbox",
+      section: .v3Components,
+      destination: AnyView(CheckboxCatalog())
+    ),
     // MARK: - Legacy Components
     CatalogItem(
       id: "legacy-button",

--- a/Examples/BezierExamples/BezierExamples/Components/CheckboxCatalog.swift
+++ b/Examples/BezierExamples/BezierExamples/Components/CheckboxCatalog.swift
@@ -1,0 +1,131 @@
+import SwiftUI
+import UIKit
+import BezierSwift
+
+struct CheckboxCatalog: View {
+  @State private var hasError = false
+  @State private var isEnabled = true
+  @State private var firstChecked = false
+  @State private var secondChecked = true
+
+  var body: some View {
+    CatalogScreen(title: "Checkbox") {
+      self.controls
+      CatalogSection(.swiftUI) { self.swiftUIPreview }
+      CatalogSection(.uiKit) { self.uiKitPreview }
+    }
+  }
+
+  private var controls: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Toggle("hasError", isOn: self.$hasError)
+      Toggle("isEnabled", isOn: self.$isEnabled)
+    }
+    .font(.caption)
+  }
+
+  private var headerChecked: BezierCheckboxChecked {
+    switch (self.firstChecked, self.secondChecked) {
+    case (true, true): return .checked
+    case (false, false): return .unchecked
+    default: return .indeterminate
+    }
+  }
+
+  private var swiftUIPreview: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      SUBezierCheckbox(
+        label: "전체 선택",
+        checked: self.headerChecked,
+        hasError: self.hasError,
+        onCheckedChange: { newValue in
+          let isChecked = newValue == .checked
+          self.firstChecked = isChecked
+          self.secondChecked = isChecked
+        }
+      )
+      SUBezierCheckbox(
+        label: "마케팅 정보 수신 동의",
+        checked: self.firstChecked ? .checked : .unchecked,
+        hasError: self.hasError,
+        onCheckedChange: { self.firstChecked = $0 == .checked }
+      )
+      SUBezierCheckbox(
+        label: "이용약관 동의",
+        checked: self.secondChecked ? .checked : .unchecked,
+        hasError: self.hasError,
+        onCheckedChange: { self.secondChecked = $0 == .checked }
+      )
+    }
+    .disabled(!self.isEnabled)
+    .frame(maxWidth: .infinity, alignment: .leading)
+  }
+
+  private var uiKitPreview: some View {
+    CheckboxUIKitRepresentable(hasError: self.hasError, isEnabled: self.isEnabled)
+  }
+}
+
+private struct CheckboxUIKitRepresentable: UIViewRepresentable {
+  let hasError: Bool
+  let isEnabled: Bool
+
+  func makeUIView(context: Context) -> UIView {
+    let wrapper = UIView()
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    stackView.alignment = .leading
+    stackView.spacing = 0
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    wrapper.addSubview(stackView)
+    NSLayoutConstraint.activate([
+      stackView.leadingAnchor.constraint(equalTo: wrapper.leadingAnchor),
+      stackView.trailingAnchor.constraint(equalTo: wrapper.trailingAnchor),
+      stackView.topAnchor.constraint(equalTo: wrapper.topAnchor),
+      stackView.bottomAnchor.constraint(equalTo: wrapper.bottomAnchor),
+    ])
+
+    let header = BezierCheckbox(label: "전체 선택", checked: .indeterminate)
+    let first = BezierCheckbox(label: "마케팅 정보 수신 동의", checked: .unchecked)
+    let second = BezierCheckbox(label: "이용약관 동의", checked: .checked)
+
+    header.onCheckedChange = { [weak first, weak second] newValue in
+      let childChecked: BezierCheckboxChecked = newValue == .checked ? .checked : .unchecked
+      first?.checked = childChecked
+      second?.checked = childChecked
+    }
+    let syncHeader: (BezierCheckboxChecked) -> Void = { [weak header, weak first, weak second] _ in
+      guard let first, let second else { return }
+      switch (first.checked, second.checked) {
+      case (.checked, .checked): header?.checked = .checked
+      case (.unchecked, .unchecked): header?.checked = .unchecked
+      default: header?.checked = .indeterminate
+      }
+    }
+    first.onCheckedChange = syncHeader
+    second.onCheckedChange = syncHeader
+
+    stackView.addArrangedSubview(header)
+    stackView.addArrangedSubview(first)
+    stackView.addArrangedSubview(second)
+    return wrapper
+  }
+
+  func updateUIView(_ wrapper: UIView, context: Context) {
+    guard let stackView = wrapper.subviews.first as? UIStackView else { return }
+    for case let checkbox as BezierCheckbox in stackView.arrangedSubviews {
+      checkbox.hasError = self.hasError
+      checkbox.isEnabled = self.isEnabled
+    }
+  }
+
+  func sizeThatFits(_ proposal: ProposedViewSize, uiView: UIView, context: Context) -> CGSize? {
+    let width = proposal.width ?? 320
+    let fitting = uiView.systemLayoutSizeFitting(
+      CGSize(width: width, height: UIView.layoutFittingCompressedSize.height),
+      withHorizontalFittingPriority: .required,
+      verticalFittingPriority: .fittingSizeLevel
+    )
+    return CGSize(width: width, height: fitting.height)
+  }
+}

--- a/Examples/BezierExamples/BezierExamples/Components/CheckboxCatalog.swift
+++ b/Examples/BezierExamples/BezierExamples/Components/CheckboxCatalog.swift
@@ -62,13 +62,15 @@ struct CheckboxCatalog: View {
   }
 
   private var uiKitPreview: some View {
-    CheckboxUIKitRepresentable(hasError: self.hasError, isEnabled: self.isEnabled)
+    // UIViewRepresentable 안 UIControl.isEnabled는 SwiftUI가 environment로 강제 동기화하므로
+    // updateUIView 수동 주입 대신 .disabled()로 제어한다.
+    CheckboxUIKitRepresentable(hasError: self.hasError)
+      .disabled(!self.isEnabled)
   }
 }
 
 private struct CheckboxUIKitRepresentable: UIViewRepresentable {
   let hasError: Bool
-  let isEnabled: Bool
 
   func makeUIView(context: Context) -> UIView {
     let wrapper = UIView()
@@ -115,7 +117,9 @@ private struct CheckboxUIKitRepresentable: UIViewRepresentable {
     guard let stackView = wrapper.subviews.first as? UIStackView else { return }
     for case let checkbox as BezierCheckbox in stackView.arrangedSubviews {
       checkbox.hasError = self.hasError
-      checkbox.isEnabled = self.isEnabled
+      // root가 UIControl이 아니라 SwiftUI의 isEnabled 자동 동기화가 nested control까지 닿지 않음
+      // → environment 값을 직접 주입 (.disabled() modifier와 일관)
+      checkbox.isEnabled = context.environment.isEnabled
     }
   }
 

--- a/Sources/BezierSwift/MasterComponent/BezierCheckbox/BezierCheckbox.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierCheckbox/BezierCheckbox.swift
@@ -1,0 +1,215 @@
+//
+//  BezierCheckbox.swift
+//  BezierSwift
+//
+
+import UIKit
+
+/// 입력·동의용 체크박스 (UIKit). 라벨이 곧 체크 대상이므로 라벨 없이 쓰지 않는다. 폼 입력·약관 동의에 쓰고, 리스트 다중 선택에는 쓰지 않는다. 탭하면 `checked`가 전환되고 `onCheckedChange`로 통지한다. SwiftUI에서는 `SUBezierCheckbox`를 사용한다.
+public final class BezierCheckbox: UIControl, BezierComponentable {
+  // MARK: - BezierComponentable
+
+  public var colorTheme: BezierColorTheme { .systemBezierColorTheme() }
+  public var componentTheme: BezierComponentTheme = .normal {
+    didSet { self.refreshAppearance() }
+  }
+
+  // MARK: - Public Properties
+
+  /// 선택 상태 (기본값 `.unchecked`). 탭하면 `toggled` 값으로 전환된다.
+  public var checked: BezierCheckboxChecked = .unchecked {
+    didSet { if oldValue != self.checked { self.refreshAppearance() } }
+  }
+
+  /// 에러 상태 (기본값 `false`). `true`면 박스 둘레에 3pt 간격의 warning 링을 표시한다. disabled 상태에서는 링을 표시하지 않는다.
+  public var hasError: Bool = false {
+    didSet { if oldValue != self.hasError { self.refreshAppearance() } }
+  }
+
+  /// 체크 대상을 설명하는 라벨. 라벨이 곧 체크 대상이므로 비우지 않는다.
+  public var label: String = "" {
+    didSet { if oldValue != self.label { self.refreshText() } }
+  }
+
+  /// 탭으로 상태가 전환된 뒤 호출되는 클로저. 전환된 새 값이 전달된다. 기본값 `nil`.
+  public var onCheckedChange: ((BezierCheckboxChecked) -> Void)?
+
+  // MARK: - State
+
+  public override var isEnabled: Bool {
+    didSet { if oldValue != self.isEnabled { self.refreshEnabled() } }
+  }
+
+  // MARK: - Subviews
+
+  private let rootStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .horizontal
+    stackView.alignment = .center
+    stackView.distribution = .fill
+    stackView.spacing = BezierCheckboxConstant.contentSpacing
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    stackView.isUserInteractionEnabled = false
+    return stackView
+  }()
+
+  private let boxView: UIView = {
+    let view = UIView()
+    view.layer.cornerRadius = BezierCheckboxConstant.boxCornerRadius
+    view.clipsToBounds = false
+    return view
+  }()
+
+  private let iconImageView: UIImageView = {
+    let imageView = UIImageView()
+    imageView.contentMode = .scaleAspectFit
+    return imageView
+  }()
+
+  private let ringView: UIView = {
+    let view = UIView()
+    view.layer.cornerRadius = BezierCheckboxConstant.errorRingCornerRadius
+    view.layer.borderWidth = BezierCheckboxConstant.errorRingBorderWidth
+    view.isUserInteractionEnabled = false
+    return view
+  }()
+
+  private let titleLabel: UILabel = {
+    let label = UILabel()
+    label.numberOfLines = 0
+    return label
+  }()
+
+  // MARK: - Init
+
+  /// 라벨과 초기 선택 상태를 지정해 생성한다.
+  public init(
+    label: String,
+    checked: BezierCheckboxChecked = .unchecked,
+    hasError: Bool = false,
+    onCheckedChange: ((BezierCheckboxChecked) -> Void)? = nil
+  ) {
+    self.label = label
+    self.checked = checked
+    self.hasError = hasError
+    self.onCheckedChange = onCheckedChange
+    super.init(frame: .zero)
+    self.setUp()
+  }
+
+  public required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    self.setUp()
+  }
+
+  // MARK: - Setup
+
+  private func setUp() {
+    self.translatesAutoresizingMaskIntoConstraints = false
+    self.directionalLayoutMargins = NSDirectionalEdgeInsets(
+      top: BezierCheckboxConstant.verticalPadding,
+      leading: 0,
+      bottom: BezierCheckboxConstant.verticalPadding,
+      trailing: 0
+    )
+
+    self.boxView.translatesAutoresizingMaskIntoConstraints = false
+    self.iconImageView.translatesAutoresizingMaskIntoConstraints = false
+    self.ringView.translatesAutoresizingMaskIntoConstraints = false
+    self.boxView.addSubview(self.iconImageView)
+    self.boxView.addSubview(self.ringView)
+
+    self.rootStackView.addArrangedSubview(self.boxView)
+    self.rootStackView.addArrangedSubview(self.titleLabel)
+    self.addSubview(self.rootStackView)
+
+    let margins = self.layoutMarginsGuide
+    NSLayoutConstraint.activate([
+      self.rootStackView.topAnchor.constraint(equalTo: margins.topAnchor),
+      self.rootStackView.leadingAnchor.constraint(equalTo: margins.leadingAnchor),
+      self.rootStackView.trailingAnchor.constraint(equalTo: margins.trailingAnchor),
+      self.rootStackView.bottomAnchor.constraint(equalTo: margins.bottomAnchor),
+      self.heightAnchor.constraint(greaterThanOrEqualToConstant: BezierCheckboxConstant.minHeight),
+
+      self.boxView.widthAnchor.constraint(equalToConstant: BezierCheckboxConstant.boxLength),
+      self.boxView.heightAnchor.constraint(equalToConstant: BezierCheckboxConstant.boxLength),
+
+      self.iconImageView.centerXAnchor.constraint(equalTo: self.boxView.centerXAnchor),
+      self.iconImageView.centerYAnchor.constraint(equalTo: self.boxView.centerYAnchor),
+      self.iconImageView.widthAnchor.constraint(equalToConstant: BezierCheckboxConstant.iconLength),
+      self.iconImageView.heightAnchor.constraint(equalToConstant: BezierCheckboxConstant.iconLength),
+
+      self.ringView.centerXAnchor.constraint(equalTo: self.boxView.centerXAnchor),
+      self.ringView.centerYAnchor.constraint(equalTo: self.boxView.centerYAnchor),
+      self.ringView.widthAnchor.constraint(equalToConstant: BezierCheckboxConstant.errorRingLength),
+      self.ringView.heightAnchor.constraint(equalToConstant: BezierCheckboxConstant.errorRingLength),
+    ])
+
+    self.boxView.setContentHuggingPriority(.required, for: .horizontal)
+    self.boxView.setContentCompressionResistancePriority(.required, for: .horizontal)
+
+    self.addTarget(self, action: #selector(self.handleTap), for: .touchUpInside)
+
+    self.refreshText()
+    self.refreshEnabled()
+    self.refreshAppearance()
+  }
+
+  // MARK: - Trait
+
+  public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    self.refreshAppearance()
+  }
+
+  // MARK: - Refresh
+
+  private func refreshAppearance() {
+    switch self.checked {
+    case .unchecked:
+      let backgroundToken: BCSemanticToken = self.isEnabled
+        ? BezierCheckboxConstant.uncheckedBackgroundColor
+        : BezierCheckboxConstant.uncheckedDisabledBackgroundColor
+      self.boxView.backgroundColor = backgroundToken.palette(self)
+      self.boxView.layer.borderWidth = BezierCheckboxConstant.boxBorderWidth
+      self.boxView.layer.borderColor = BezierCheckboxConstant.uncheckedBorderColor.palette(self).cgColor
+      self.iconImageView.image = nil
+      self.iconImageView.isHidden = true
+    case .checked, .indeterminate:
+      self.boxView.backgroundColor = BezierCheckboxConstant.checkedBackgroundColor.palette(self)
+      self.boxView.layer.borderWidth = 0
+      let icon: BezierIcon = self.checked == .checked ? .checkBold : .hyphenBold
+      self.iconImageView.image = icon.uiImage
+      self.iconImageView.isHidden = false
+    }
+    self.iconImageView.tintColor = BezierCheckboxConstant.iconColor.palette(self)
+
+    // SPEC §7: disabled + hasError 조합은 Figma variant에 없어 disabled 시각을 우선하고 링을 숨긴다.
+    self.ringView.isHidden = !(self.hasError && self.isEnabled)
+    self.ringView.layer.borderColor = BezierCheckboxConstant.errorRingColor.palette(self).cgColor
+
+    self.refreshText()
+  }
+
+  private func refreshText() {
+    self.titleLabel.attributedText = BezierCheckboxConstant.labelTypography.attributedString(
+      self,
+      text: self.label,
+      semanticColorToken: BezierCheckboxConstant.labelColor,
+      alignment: .left,
+      lineBreakMode: .byWordWrapping
+    )
+  }
+
+  private func refreshEnabled() {
+    self.alpha = self.isEnabled ? 1 : BezierCheckboxConstant.disabledOpacity
+    self.refreshAppearance()
+  }
+
+  // MARK: - Action
+
+  @objc private func handleTap() {
+    self.checked = self.checked.toggled
+    self.onCheckedChange?(self.checked)
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierCheckbox/BezierCheckboxSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierCheckbox/BezierCheckboxSpec.swift
@@ -1,0 +1,55 @@
+//
+//  BezierCheckboxSpec.swift
+//  BezierSwift
+//
+
+import Foundation
+
+// MARK: - Checked
+
+/// 체크박스의 선택 상태. Figma `Checkbox` 컴포넌트의 `checked` 프로퍼티에 대응 (case 이름 = Figma 값).
+public enum BezierCheckboxChecked: CaseIterable {
+  /// 선택되지 않은 기본 상태. 빈 박스로 표시한다.
+  case unchecked
+  /// 선택된 상태. check 아이콘을 표시한다.
+  case checked
+  /// 하위 항목이 일부만 선택된 부분 선택 상태. 「전체 선택」 헤더 체크박스에만 쓴다. hyphen 아이콘을 표시한다.
+  case indeterminate
+
+  /// 탭했을 때 전환되는 다음 상태 (`unchecked` → `checked`, `checked` → `unchecked`, `indeterminate` → `checked`).
+  public var toggled: BezierCheckboxChecked {
+    switch self {
+    case .unchecked: return .checked
+    case .checked: return .unchecked
+    case .indeterminate: return .checked
+    }
+  }
+}
+
+// MARK: - Constant
+
+public enum BezierCheckboxConstant {
+  public static let boxLength: CGFloat = 22
+  public static let boxCornerRadius: CGFloat = 10
+  public static let boxBorderWidth: CGFloat = 2
+  public static let iconLength: CGFloat = 18
+  public static let contentSpacing: CGFloat = 8
+  public static let verticalPadding: CGFloat = 8
+  public static let minHeight: CGFloat = 40
+
+  static let errorRingLength: CGFloat = 28
+  static let errorRingBorderWidth: CGFloat = 1.5
+  static let errorRingCornerRadius: CGFloat = 13
+
+  static let disabledOpacity: CGFloat = BOGlobalToken.disabled
+
+  static let labelTypography: BTSemanticToken = .textXLarge(weight: .regular)
+
+  static let labelColor: BCSemanticToken = .textNeutral
+  static let uncheckedBackgroundColor: BCSemanticToken = .fillGreyLight
+  static let uncheckedDisabledBackgroundColor: BCSemanticToken = .fillNeutralHeavy
+  static let uncheckedBorderColor: BCSemanticToken = .borderNeutralHeavy
+  static let checkedBackgroundColor: BCSemanticToken = .fillNeutralHeaviest
+  static let iconColor: BCSemanticToken = .iconInverseHeavier
+  static let errorRingColor: BCSemanticToken = .stateWarning
+}

--- a/Sources/BezierSwift/MasterComponent/BezierCheckbox/SPEC.md
+++ b/Sources/BezierSwift/MasterComponent/BezierCheckbox/SPEC.md
@@ -48,7 +48,7 @@ Figma `Checkbox`(4838:126) property 정의 전수.
 
 ### Anatomy
 
-```
+```text
 Checkbox (H, items-center, gap 8, py 8, 높이 40)
   ├─ indicator (22×22, radius 10)
   │    ├─ _ring (28×28, radius 13, stroke 1.5)        [hasError=true 만]

--- a/Sources/BezierSwift/MasterComponent/BezierCheckbox/SPEC.md
+++ b/Sources/BezierSwift/MasterComponent/BezierCheckbox/SPEC.md
@@ -1,0 +1,126 @@
+# BezierCheckbox SPEC
+
+> **SSOT**: [Figma · Mobile-Components / Checkbox (4838:126)](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=4838-126)
+> **Design spec doc**: [team-design / bezier-v3 / components / Checkbox-spec.md](https://github.com/channel-io/team-design/blob/main/bezier-v3/components/Checkbox-spec.md) (보조 참조 — 값 충돌 시 Figma 파일 우선)
+>
+> 모든 수치/토큰은 Figma `Checkbox` 심볼 세트(4838:126)에 실재한다. §7 인터랙션은 Figma에 state variant가 없어 별도 협의 결정으로 분리 표기한다.
+
+## 1. Component Overview
+
+- **이름**: Checkbox
+- **설명**: 입력·동의용 체크박스. 라벨 필수 — 라벨이 곧 체크 대상.
+- **가이드라인** (Figma component description 인용):
+  - 폼 입력·약관 동의에 사용. 다중 선택(라벨 없는 리스트 선택)에는 쓰지 않음 — 그 경우 ListItem 선택 패턴 사용.
+  - circle·green·blue 미제공(웹 정렬). 입력/동의 전용 성격.
+  - `checked`: unchecked / checked / indeterminate(하위 항목 일부 선택 — 「전체 선택」 헤더 체크박스용, DL-089)
+  - `state`: default / disabled
+  - `hasError`: false / true (에러 시 3px gap 링, DES-18873)
+  - 터치 타깃(DL-094): 시각 박스는 22 유지, 터치 가능 영역(행 높이)은 40으로 확대(상하 8 패딩).
+
+## 2. Component Properties
+
+Figma `Checkbox`(4838:126) property 정의 전수.
+
+| Figma property key | Type | Default | 옵션 / 값 | 구현 매핑 |
+|---|---|---|---|---|
+| `checked` | VARIANT | unchecked | unchecked / checked / indeterminate | `BezierCheckboxChecked` |
+| `state` | VARIANT | default | default / disabled | `isEnabled` |
+| `hasError` | VARIANT | false | false / true | `hasError` |
+| `label` | TEXT | "Label" | 문자열 | `label` |
+
+총 instance: **9개** — `checked` 3종 × {default+hasError=false, default+hasError=true, disabled+hasError=false}. **disabled+hasError 조합 variant는 Figma에 없다** (에러 링은 default state에서만 정의).
+
+> 라벨 정책: 라벨 필수 — `hasLabel` boolean 없음, `label` TEXT 단독 제공 (Figma description "라벨 필수 — 라벨이 곧 체크 대상". DL-083 태그 출처는 design spec doc).
+
+## 3. Layout — Figma 실측
+
+단위 iOS `pt`. 심볼 세트 4838:126의 variant 실측 (각 variant 71×40).
+
+| 요소 | 값 |
+|---|---|
+| row | H 배치, box↔label gap **8**, 상하 padding **8**, 좌우 padding 0, 세로 중앙 정렬 |
+| row 높이 | **40** (= label line-height 24 + 상하 8) — 터치 타깃 (DL-094) |
+| box | **22×22**, corner radius **10** (`radius/10`) |
+| box border (unchecked) | **2** (inside stroke) |
+| check/hyphen 아이콘 | **18×18**, box 중앙 |
+| error ring (`_ring`) | **28×28**, box 중심 정렬(box 외곽에서 사방 **3** gap), stroke **1.5**, corner radius **13** |
+| label | HUG (row 폭 = 콘텐츠 폭) |
+
+### Anatomy
+
+```
+Checkbox (H, items-center, gap 8, py 8, 높이 40)
+  ├─ indicator (22×22, radius 10)
+  │    ├─ _ring (28×28, radius 13, stroke 1.5)        [hasError=true 만]
+  │    └─ icon/check-bold 또는 icon/hyphen-bold (18×18) [checked/indeterminate 만]
+  └─ label (text/xlarge, HUG)
+```
+
+## 4. Color 토큰 (Figma 사용처 기준)
+
+| 위치 | 조건 | Token (`BCSemanticToken`) | Figma Variable | Raw (light) |
+|---|---|---|---|---|
+| box 배경 | unchecked (default·hasError) | `.fillGreyLight` | `color/fill/grey/light` | `#fdfdfd` |
+| box border | unchecked 전 상태 (2pt) | `.borderNeutralHeavy` | `color/border/neutral/heavy` | `rgba(0,0,0,0.15)` |
+| box 배경 | unchecked + disabled | `.fillNeutralHeavy` | `color/fill/neutral/heavy` | `rgba(0,0,0,0.15)` |
+| box 배경 | checked / indeterminate (전 상태) | `.fillNeutralHeaviest` | `color/fill/neutral/heaviest` | `rgba(0,0,0,0.85)` |
+| check/hyphen 아이콘 | checked / indeterminate | `.iconInverseHeavier` | `color/icon/inverse/heavier` | `#ffffff` |
+| error ring | hasError=true (default state만) | `.stateWarning` | `color/state/warning` | `#e67f2b` |
+| label 텍스트 | 전 상태 | `.textNeutral` | `color/text/neutral` | `rgba(0,0,0,0.85)` |
+
+- **disabled**: 행 전체 opacity `opacity/disabled` = **0.4** + unchecked box 배경이 `fillGreyLight` → `fillNeutralHeavy`로 변경 (checked/indeterminate box 배경은 유지).
+- checked/indeterminate box는 border 없음.
+- hasError는 링 표시 외에 box/label 색을 바꾸지 않는다.
+
+## 5. Typography
+
+### Case A — Typography Token 사용 (전부 토큰)
+
+| 위치 | Token (`BTSemanticToken`) | Figma Style |
+|---|---|---|
+| label | `.textXLarge(weight: .regular)` | `Typography/text/xlarge` (Inter Regular, size 16, lineHeight 24, letterSpacing `text/letter-spacing/tight` −0.1) |
+
+### Case B — Custom Typography
+
+없음 (모든 텍스트가 토큰 사용).
+
+## 6. State 별 시각 동작 (Figma variant 전수)
+
+| checked | state | hasError | box 배경 | border | 아이콘 | ring | row opacity | 노드 |
+|---|---|---|---|---|---|---|---|---|
+| unchecked | default | false | fillGreyLight | 2 borderNeutralHeavy | — | — | 1 | 4833:122 |
+| checked | default | false | fillNeutralHeaviest | — | check-bold | — | 1 | 4833:125 |
+| indeterminate | default | false | fillNeutralHeaviest | — | hyphen-bold | — | 1 | 5051:66064 |
+| unchecked | default | true | fillGreyLight | 2 borderNeutralHeavy | — | stateWarning | 1 | 4837:122 |
+| checked | default | true | fillNeutralHeaviest | — | check-bold | stateWarning | 1 | 4837:126 |
+| indeterminate | default | true | fillNeutralHeaviest | — | hyphen-bold | stateWarning | 1 | 5051:66082 |
+| unchecked | disabled | false | fillNeutralHeavy | 2 borderNeutralHeavy | — | — | 0.4 | 4834:118 |
+| checked | disabled | false | fillNeutralHeaviest | — | check-bold | — | 0.4 | 4834:121 |
+| indeterminate | disabled | false | fillNeutralHeaviest | — | hyphen-bold | — | 0.4 | 5051:66073 |
+
+- 아이콘 asset: `icon/check-bold` (checked) / `icon/hyphen-bold` (indeterminate) — 18×18, `color/icon/inverse/heavier`.
+
+## 7. 인터랙션 (Figma 외 · 협의 결정)
+
+> ⚠️ 아래는 Figma `Checkbox` 노드에 **없다** (pressed/hover variant 부재). 출처: design-team `Checkbox-spec.md` §7 Behavior + 구현 협의(MOB-6344).
+
+- 탭 시 토글: `unchecked → checked`, `checked → unchecked`, `indeterminate → checked` (웹 `onCheckedChange(true)` 정렬).
+- 상태 변경은 `onCheckedChange` 콜백으로 통지. 행 전체(라벨 포함)가 터치 타깃.
+- pressed 시각 피드백 없음 (Figma에 pressed variant 없음 — 웹 hover는 포인터 전용이라 미이식).
+- disabled: 입력 차단 + §4 disabled 시각.
+- hasError + disabled 동시 지정 시: Figma에 해당 variant가 없어 disabled 시각을 우선하고 링은 표시하지 않는다.
+
+## 8. 매핑되는 코드 심볼
+
+| 정의 | 파일 |
+|---|---|
+| UIKit 구현 | `BezierCheckbox.swift` (`UIControl`, `BezierComponentable`) |
+| SwiftUI 구현 | `SUBezierCheckbox.swift` |
+| checked 축 / 상수 / 토큰 매핑 | `BezierCheckboxSpec.swift` (`BezierCheckboxChecked`, `BezierCheckboxConstant`) |
+
+> 사용 토큰 실재 확인: `.fillGreyLight` / `.borderNeutralHeavy` / `.fillNeutralHeavy` / `.fillNeutralHeaviest` / `.iconInverseHeavier` / `.stateWarning` / `.textNeutral`(`BCSemanticToken`), `.textXLarge`(`BTSemanticToken`), `BOGlobalToken.disabled`=0.4, `BezierIcon.checkBold` / `BezierIcon.hyphenBold`(번들 asset — Figma `icon/check-bold`·`icon/hyphen-bold`와 동일 글리프 확인).
+
+## 9. Figma 참조 노드
+
+- 심볼 세트 frame: `4838:126` (canvas `4833:114`)
+- variant 노드: §6 표 참조 (9개 전수)

--- a/Sources/BezierSwift/MasterComponent/BezierCheckbox/SUBezierCheckbox.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierCheckbox/SUBezierCheckbox.swift
@@ -1,0 +1,134 @@
+//
+//  SUBezierCheckbox.swift
+//  BezierSwift
+//
+
+import SwiftUI
+
+/// 입력·동의용 체크박스 (SwiftUI). 라벨이 곧 체크 대상이므로 라벨 없이 쓰지 않는다. 폼 입력·약관 동의에 쓰고, 리스트 다중 선택에는 쓰지 않는다. 탭하면 전환된 다음 값을 `onCheckedChange`로 통지하며 상태 반영은 호출 측 책임이다. UIKit에서는 `BezierCheckbox`를 사용한다.
+public struct SUBezierCheckbox: View, Themeable {
+  @Environment(\.colorScheme) public var colorScheme
+  @Environment(\.isEnabled) private var isEnabled
+
+  private let label: String
+  private let checked: BezierCheckboxChecked
+  private let hasError: Bool
+  private let onCheckedChange: ((BezierCheckboxChecked) -> Void)?
+
+  /// 라벨·선택 상태·에러 여부를 지정해 생성한다. 탭하면 `checked.toggled` 값이 `onCheckedChange`로 전달된다.
+  public init(
+    label: String,
+    checked: BezierCheckboxChecked = .unchecked,
+    hasError: Bool = false,
+    onCheckedChange: ((BezierCheckboxChecked) -> Void)? = nil
+  ) {
+    self.label = label
+    self.checked = checked
+    self.hasError = hasError
+    self.onCheckedChange = onCheckedChange
+  }
+
+  public var body: some View {
+    Button {
+      self.onCheckedChange?(self.checked.toggled)
+    } label: {
+      HStack(spacing: BezierCheckboxConstant.contentSpacing) {
+        self.boxView
+        Text(self.label)
+          .applyBezierFontStyle(
+            BezierCheckboxConstant.labelTypography,
+            semanticColorToken: BezierCheckboxConstant.labelColor
+          )
+          .fixedSize(horizontal: false, vertical: true)
+      }
+      .padding(.vertical, BezierCheckboxConstant.verticalPadding)
+      .frame(minHeight: BezierCheckboxConstant.minHeight)
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(SUBezierCheckboxButtonStyle())
+    .opacity(self.isEnabled ? 1 : BezierCheckboxConstant.disabledOpacity)
+  }
+
+  private var boxView: some View {
+    ZStack {
+      RoundedRectangle(cornerRadius: BezierCheckboxConstant.boxCornerRadius)
+        .fill(self.palette(self.boxBackgroundColor))
+
+      if self.checked == .unchecked {
+        RoundedRectangle(cornerRadius: BezierCheckboxConstant.boxCornerRadius)
+          .strokeBorder(
+            self.palette(BezierCheckboxConstant.uncheckedBorderColor),
+            lineWidth: BezierCheckboxConstant.boxBorderWidth
+          )
+      }
+
+      if let icon = self.icon {
+        icon.image
+          .renderingMode(.template)
+          .resizable()
+          .scaledToFit()
+          .frame(width: BezierCheckboxConstant.iconLength, height: BezierCheckboxConstant.iconLength)
+          .foregroundColor(self.palette(BezierCheckboxConstant.iconColor))
+      }
+    }
+    .frame(width: BezierCheckboxConstant.boxLength, height: BezierCheckboxConstant.boxLength)
+    .overlay(self.errorRingView)
+  }
+
+  private var boxBackgroundColor: BCSemanticToken {
+    switch self.checked {
+    case .unchecked:
+      return self.isEnabled
+        ? BezierCheckboxConstant.uncheckedBackgroundColor
+        : BezierCheckboxConstant.uncheckedDisabledBackgroundColor
+    case .checked, .indeterminate:
+      return BezierCheckboxConstant.checkedBackgroundColor
+    }
+  }
+
+  private var icon: BezierIcon? {
+    switch self.checked {
+    case .unchecked: return nil
+    case .checked: return .checkBold
+    case .indeterminate: return .hyphenBold
+    }
+  }
+
+  @ViewBuilder
+  private var errorRingView: some View {
+    // SPEC §7: disabled + hasError 조합은 Figma variant에 없어 disabled 시각을 우선하고 링을 숨긴다.
+    if self.hasError && self.isEnabled {
+      RoundedRectangle(cornerRadius: BezierCheckboxConstant.errorRingCornerRadius)
+        .strokeBorder(
+          self.palette(BezierCheckboxConstant.errorRingColor),
+          lineWidth: BezierCheckboxConstant.errorRingBorderWidth
+        )
+        .frame(
+          width: BezierCheckboxConstant.errorRingLength,
+          height: BezierCheckboxConstant.errorRingLength
+        )
+    }
+  }
+}
+
+// MARK: - ButtonStyle
+
+private struct SUBezierCheckboxButtonStyle: ButtonStyle {
+  func makeBody(configuration: Configuration) -> some View {
+    configuration.label
+  }
+}
+
+struct SUBezierCheckbox_Previews: PreviewProvider {
+  static var previews: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      SUBezierCheckbox(label: "마케팅 정보 수신 동의", checked: .unchecked, onCheckedChange: { _ in })
+      SUBezierCheckbox(label: "이용약관 동의", checked: .checked, onCheckedChange: { _ in })
+      SUBezierCheckbox(label: "전체 선택", checked: .indeterminate, onCheckedChange: { _ in })
+      SUBezierCheckbox(label: "필수 약관 동의", checked: .unchecked, hasError: true)
+      SUBezierCheckbox(label: "비활성 항목", checked: .checked)
+        .disabled(true)
+    }
+    .padding()
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierCheckbox/SUBezierCheckbox.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierCheckbox/SUBezierCheckbox.swift
@@ -46,6 +46,8 @@ public struct SUBezierCheckbox: View, Themeable {
       .contentShape(Rectangle())
     }
     .buttonStyle(SUBezierCheckboxButtonStyle())
+    // 레이어별 opacity 개별 적용 시 박스 fill·border 겹침이 이음새로 비쳐 flatten 후 일괄 적용
+    .compositingGroup()
     .opacity(self.isEnabled ? 1 : BezierCheckboxConstant.disabledOpacity)
   }
 


### PR DESCRIPTION
## MOB-6344

https://linear.app/channel/issue/MOB-6344

V3 Checkbox 컴포넌트를 UIKit + SwiftUI로 구현합니다.

## 구현 내용

### Checkbox — `BezierCheckbox` / `SUBezierCheckbox` / `BezierCheckboxSpec`

- `checked` 축: `BezierCheckboxChecked` — `unchecked` / `checked` / `indeterminate` (Figma `checked` 프로퍼티 대응, DL-089 「전체 선택」 헤더용 indeterminate 포함)
- 탭 토글 규칙: `unchecked → checked`, `checked → unchecked`, `indeterminate → checked` (`BezierCheckboxChecked.toggled`, 웹 `onCheckedChange(true)` 정렬) — 전환 값은 `onCheckedChange` 콜백으로 통지
- 라벨 필수 정책 (DL-083): `label` 파라미터 필수, 라벨 없는 init 미제공 — 라벨이 곧 체크 대상
- 박스 22×22 / radius 10 / unchecked border 2pt(`borderNeutralHeavy`) / 아이콘 `BezierIcon.checkBold`·`hyphenBold` 18×18 (`iconInverseHeavier`)
- 행 전체가 터치 타깃 — 상하 8pt 패딩 + minHeight 40pt (DL-094 터치 타깃 확대)
- `hasError`: 박스 외곽 3pt gap의 28×28 warning 링 (stroke 1.5, radius 13, `stateWarning`, DES-18873) — disabled 상태에서는 Figma variant 부재에 따라 미표시
- disabled: 행 전체 opacity 0.4 + unchecked 박스 배경 `fillGreyLight` → `fillNeutralHeavy` 전환 (Figma disabled variant 그대로). SwiftUI는 `compositingGroup`으로 flatten 후 opacity 적용 (레이어 이음새 방지)
- 라벨 타이포 `textXLarge(weight: .regular)` / `textNeutral`
- UIKit: `UIControl` 기반, 다크모드 대응을 위해 `traitCollectionDidChange`에서 `layer.borderColor` 등 CGColor 재주입
- SwiftUI: 값 + `onCheckedChange` 콜백의 controlled 패턴 (상태 반영은 호출 측 책임), press 시각 피드백 없음 (Figma에 pressed variant 부재)
- 배치(width/full-width)는 컨테이너 책임 — 관련 public API 미노출. 후속 FormGroup(MOB-6345)이 이 컴포넌트를 감싸는 레이아웃 그룹으로 예정

## Spec 검증

figma-component-spec 3단계 사이클로 검증했습니다 (Figma = SSOT):

- Phase 1: Figma 실측 기반 `SPEC.md` 작성 (Checkbox 심볼 세트 `4838:126`, variant 9종 — `checked` 3 × {default, default+hasError, disabled}. **disabled+hasError 조합 variant는 Figma에 없음**)
- Phase 2: Properties / Layout / Color / Typography / Asset / Spec Noise / Implementation Reference 7종 병렬 검증 전부 통과
  - Asset Validator: 번들 `icon-check-bold`·`icon-hyphen-bold`가 Figma export SVG와 동일 글리프임을 확인 (SF Symbol fallback 없음)
  - Noise Detector 권고 3건(출처 태그 정정 등) 반영
- Phase 3: UIKit·SwiftUI Implementation Validator로 구현–SPEC 일치 확인
- Figma에 없는 구현 결정(탭 토글 규칙, pressed 피드백 없음, disabled+hasError 시 링 숨김)은 `SPEC.md` §7에 협의 사항으로 분리 기록

## 스크린샷

iPhone 16 (iOS 18.6) 시뮬레이터 검증 — SwiftUI/UIKit 각각 「전체 선택」 indeterminate 연동 데모.

| 캡처 | 설명 |
|---|---|
| <!-- screenshot: 01-light-default.png --> | 라이트 — indeterminate / unchecked / checked (SwiftUI + UIKit) |
| <!-- screenshot: 02-light-selectall-tapped.png --> | SwiftUI 「전체 선택」 탭 → indeterminate→checked + 하위 전파 |
| <!-- screenshot: 03-light-uikit-selectall-tapped.png --> | UIKit 「전체 선택」 탭 → indeterminate→checked + 하위 전파 |
| <!-- screenshot: 04-light-mixed-indeterminate.png --> | 하위 항목 해제 → 헤더 indeterminate 복귀 |
| <!-- screenshot: 05-light-haserror.png --> | 라이트 — hasError 링 (3pt gap, stateWarning) |
| <!-- screenshot: 06-light-disabled-with-error-flag.png --> | 라이트 — disabled (opacity 0.4, 링 숨김, unchecked 배경 전환) |
| <!-- screenshot: 07-dark-default.png --> | 다크 — 기본 상태 (UIKit CGColor 재주입 확인) |
| <!-- screenshot: 08-dark-haserror.png --> | 다크 — hasError 링 |
| <!-- screenshot: 09-dark-disabled.png --> | 다크 — disabled |

## 테스트

- `BezierSwift` 스킴 + Examples 앱 clean build 통과
- Examples 카탈로그 (Checkbox) 추가 — `hasError`·`isEnabled` 토글 매트릭스, 「전체 선택」 indeterminate 연동 데모
- 시뮬레이터 검증에서 UIKit 데모 disabled 미반영 결함 발견 → environment isEnabled 주입으로 수정 후 재검증 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * SwiftUI와 UIKit에서 사용할 수 있는 체크박스 컴포넌트를 추가했습니다.
  * 체크됨, 선택 해제, 부분 선택 상태를 지원합니다.
  * 전체 선택과 하위 항목 간 상태 동기화를 제공합니다.
  * 비활성화 및 오류 상태를 시각적으로 표시합니다.
  * 컴포넌트 카탈로그에 체크박스 예제를 추가했습니다.

* **문서**
  * 체크박스의 상태, 레이아웃, 색상 및 상호작용 사양을 문서화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->