### PR TITLE
[MOB-6346] BezierTextInput 컴포넌트 구현 (UIKit + SwiftUI)

### DIFF
--- a/Examples/BezierExamples/BezierExamples/App/CatalogRegistry.swift
+++ b/Examples/BezierExamples/BezierExamples/App/CatalogRegistry.swift
@@ -124,6 +124,12 @@ enum CatalogRegistry {
       section: .v3Components,
       destination: AnyView(FloatingBannerCatalog())
     ),
+    CatalogItem(
+      id: "text-input",
+      title: "TextInput",
+      section: .v3Components,
+      destination: AnyView(TextInputCatalog())
+    ),
     // MARK: - Legacy Components
     CatalogItem(
       id: "legacy-button",

--- a/Examples/BezierExamples/BezierExamples/Components/TextInputCatalog.swift
+++ b/Examples/BezierExamples/BezierExamples/Components/TextInputCatalog.swift
@@ -1,0 +1,234 @@
+import SwiftUI
+import UIKit
+import BezierSwift
+
+struct TextInputCatalog: View {
+  enum SlotKind: String, CaseIterable, Identifiable {
+    case none, icon, affix
+    var id: String { self.rawValue }
+  }
+
+  @State private var variant: BezierTextInputVariant = .primary
+  @State private var size: BezierTextInputSize = .medium
+  @State private var hasError = false
+  @State private var isReadOnly = false
+  @State private var isEnabled = true
+  @State private var allowClear = true
+  @State private var leadingKind: SlotKind = .icon
+  @State private var trailingKind: SlotKind = .none
+  @State private var swiftUIText = ""
+  @State private var uiKitText = ""
+
+  var body: some View {
+    CatalogScreen(title: "TextInput") {
+      self.controls
+      CatalogSection(.swiftUI) { self.swiftUIPreview }
+      CatalogSection(.uiKit) { self.uiKitPreview }
+    }
+  }
+
+  private var controls: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Picker("variant", selection: self.$variant) {
+        ForEach(BezierTextInputVariant.allCases, id: \.self) { variant in
+          Text(self.variantLabel(variant)).tag(variant)
+        }
+      }
+      .pickerStyle(.segmented)
+
+      Picker("size", selection: self.$size) {
+        ForEach(BezierTextInputSize.allCases, id: \.self) { size in
+          Text(self.sizeLabel(size)).tag(size)
+        }
+      }
+      .pickerStyle(.segmented)
+
+      Toggle("hasError", isOn: self.$hasError)
+      Toggle("isReadOnly", isOn: self.$isReadOnly)
+      Toggle("isEnabled", isOn: self.$isEnabled)
+      Toggle("allowClear", isOn: self.$allowClear)
+
+      Picker("leading", selection: self.$leadingKind) {
+        ForEach(SlotKind.allCases) { kind in
+          Text("leading: \(kind.rawValue)").tag(kind)
+        }
+      }
+      .pickerStyle(.segmented)
+
+      Picker("trailing", selection: self.$trailingKind) {
+        ForEach(SlotKind.allCases) { kind in
+          Text("trailing: \(kind.rawValue)").tag(kind)
+        }
+      }
+      .pickerStyle(.segmented)
+
+      Button("키보드 내리기") {
+        UIApplication.shared.sendAction(
+          #selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil
+        )
+      }
+    }
+    .font(.caption)
+  }
+
+  private var swiftUIPreview: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      SUBezierTextInput(
+        text: self.$swiftUIText,
+        placeholder: "예: hong@company.com",
+        variant: self.variant,
+        size: self.size,
+        hasError: self.hasError,
+        isReadOnly: self.isReadOnly,
+        allowClear: self.allowClear,
+        leadingContent: { self.leadingSlot },
+        trailingContent: { self.trailingSlot }
+      )
+      .disabled(!self.isEnabled)
+
+      Text("value: \(self.swiftUIText)")
+        .font(.caption2)
+        .foregroundColor(.secondary)
+    }
+  }
+
+  @ViewBuilder
+  private var leadingSlot: some View {
+    switch self.leadingKind {
+    case .none:
+      EmptyView()
+    case .icon:
+      BezierIcon.email.image
+        .scaledToFit()
+        .foregroundColor(.secondary)
+    case .affix:
+      SUBezierTextInputAffix(text: "https://")
+    }
+  }
+
+  @ViewBuilder
+  private var trailingSlot: some View {
+    switch self.trailingKind {
+    case .none:
+      EmptyView()
+    case .icon:
+      BezierIcon.lock.image
+        .scaledToFit()
+        .foregroundColor(.secondary)
+    case .affix:
+      SUBezierTextInputAffix(text: "%")
+    }
+  }
+
+  private var uiKitPreview: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      TextInputUIKitRepresentable(
+        text: self.$uiKitText,
+        variant: self.variant,
+        size: self.size,
+        hasError: self.hasError,
+        isReadOnly: self.isReadOnly,
+        isEnabled: self.isEnabled,
+        allowClear: self.allowClear,
+        leadingKind: self.leadingKind,
+        trailingKind: self.trailingKind
+      )
+
+      Text("value: \(self.uiKitText)")
+        .font(.caption2)
+        .foregroundColor(.secondary)
+    }
+  }
+
+  private func variantLabel(_ variant: BezierTextInputVariant) -> String {
+    switch variant {
+    case .primary: return "primary"
+    case .secondary: return "secondary"
+    }
+  }
+
+  private func sizeLabel(_ size: BezierTextInputSize) -> String {
+    switch size {
+    case .small: return "small"
+    case .medium: return "medium"
+    }
+  }
+}
+
+private struct TextInputUIKitRepresentable: UIViewRepresentable {
+  @Binding var text: String
+  let variant: BezierTextInputVariant
+  let size: BezierTextInputSize
+  let hasError: Bool
+  let isReadOnly: Bool
+  let isEnabled: Bool
+  let allowClear: Bool
+  let leadingKind: TextInputCatalog.SlotKind
+  let trailingKind: TextInputCatalog.SlotKind
+
+  final class Coordinator {
+    var leadingKind: TextInputCatalog.SlotKind?
+    var trailingKind: TextInputCatalog.SlotKind?
+  }
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator()
+  }
+
+  func makeUIView(context: Context) -> BezierTextInput {
+    let input = BezierTextInput(placeholder: "예: hong@company.com")
+    input.onTextChanged = { self.text = $0 }
+    return input
+  }
+
+  func updateUIView(_ input: BezierTextInput, context: Context) {
+    input.variant = self.variant
+    input.size = self.size
+    input.hasError = self.hasError
+    input.isReadOnly = self.isReadOnly
+    input.isEnabled = self.isEnabled
+    input.allowClear = self.allowClear
+    if input.text != self.text {
+      input.text = self.text
+    }
+
+    if context.coordinator.leadingKind != self.leadingKind {
+      context.coordinator.leadingKind = self.leadingKind
+      input.leadingContent = Self.makeSlotView(kind: self.leadingKind, icon: .email, affixText: "https://")
+    }
+    if context.coordinator.trailingKind != self.trailingKind {
+      context.coordinator.trailingKind = self.trailingKind
+      input.trailingContent = Self.makeSlotView(kind: self.trailingKind, icon: .lock, affixText: "%")
+    }
+  }
+
+  func sizeThatFits(_ proposal: ProposedViewSize, uiView: BezierTextInput, context: Context) -> CGSize? {
+    let width = proposal.width ?? 320
+    let fitting = uiView.systemLayoutSizeFitting(
+      CGSize(width: width, height: UIView.layoutFittingCompressedSize.height),
+      withHorizontalFittingPriority: .required,
+      verticalFittingPriority: .fittingSizeLevel
+    )
+    return CGSize(width: width, height: fitting.height)
+  }
+
+  private static func makeSlotView(
+    kind: TextInputCatalog.SlotKind,
+    icon: BezierIcon,
+    affixText: String
+  ) -> UIView? {
+    switch kind {
+    case .none:
+      return nil
+    case .icon:
+      let imageView = UIImageView(image: icon.uiImage)
+      imageView.contentMode = .scaleAspectFit
+      imageView.tintColor = .secondaryLabel
+      imageView.translatesAutoresizingMaskIntoConstraints = false
+      imageView.widthAnchor.constraint(equalTo: imageView.heightAnchor).isActive = true
+      return imageView
+    case .affix:
+      return BezierTextInputAffix(text: affixText)
+    }
+  }
+}

--- a/Examples/BezierExamples/BezierExamples/Components/TextInputCatalog.swift
+++ b/Examples/BezierExamples/BezierExamples/Components/TextInputCatalog.swift
@@ -175,13 +175,24 @@ private struct TextInputUIKitRepresentable: UIViewRepresentable {
     Coordinator()
   }
 
-  func makeUIView(context: Context) -> BezierTextInput {
+  // BezierTextInput을 representable 루트로 직접 반환하면 SwiftUI가 프레임을 직접 지정하는 과정에서
+  // 내부 스택의 trailing 제약이 재해석되지 않아 콘텐츠가 hug 폭으로 붙는다. wrapper에 pin해 우회한다.
+  func makeUIView(context: Context) -> UIView {
+    let wrapper = UIView()
     let input = BezierTextInput(placeholder: "예: hong@company.com")
     input.onTextChanged = { self.text = $0 }
-    return input
+    wrapper.addSubview(input)
+    NSLayoutConstraint.activate([
+      input.leadingAnchor.constraint(equalTo: wrapper.leadingAnchor),
+      input.trailingAnchor.constraint(equalTo: wrapper.trailingAnchor),
+      input.topAnchor.constraint(equalTo: wrapper.topAnchor),
+      input.bottomAnchor.constraint(equalTo: wrapper.bottomAnchor),
+    ])
+    return wrapper
   }
 
-  func updateUIView(_ input: BezierTextInput, context: Context) {
+  func updateUIView(_ wrapper: UIView, context: Context) {
+    guard let input = wrapper.subviews.compactMap({ $0 as? BezierTextInput }).first else { return }
     input.variant = self.variant
     input.size = self.size
     input.hasError = self.hasError
@@ -202,7 +213,7 @@ private struct TextInputUIKitRepresentable: UIViewRepresentable {
     }
   }
 
-  func sizeThatFits(_ proposal: ProposedViewSize, uiView: BezierTextInput, context: Context) -> CGSize? {
+  func sizeThatFits(_ proposal: ProposedViewSize, uiView: UIView, context: Context) -> CGSize? {
     let width = proposal.width ?? 320
     let fitting = uiView.systemLayoutSizeFitting(
       CGSize(width: width, height: UIView.layoutFittingCompressedSize.height),

--- a/Sources/BezierSwift/MasterComponent/BezierBaseInput/BezierBaseInputSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBaseInput/BezierBaseInputSpec.swift
@@ -1,0 +1,110 @@
+//
+//  BezierBaseInputSpec.swift
+//  BezierSwift
+//
+
+import Foundation
+
+// MARK: - Variant
+
+enum BezierBaseInputVariant {
+  case primary
+  case secondary
+}
+
+// MARK: - State
+
+enum BezierBaseInputState: Equatable {
+  case `default`
+  case focused
+  case error
+  case readOnly
+  case disabled
+
+  static func resolve(
+    isEnabled: Bool,
+    isReadOnly: Bool,
+    hasError: Bool,
+    isFocused: Bool
+  ) -> BezierBaseInputState {
+    if !isEnabled { return .disabled }
+    if isReadOnly { return .readOnly }
+    if hasError { return .error }
+    if isFocused { return .focused }
+    return .default
+  }
+}
+
+// MARK: - Metric
+
+struct BezierBaseInputMetric: Equatable {
+  let height: CGFloat
+  let cornerRadius: CGFloat
+  let leadingContentLength: CGFloat
+
+  static let small = BezierBaseInputMetric(height: 40, cornerRadius: 12, leadingContentLength: 20)
+  static let medium = BezierBaseInputMetric(height: 48, cornerRadius: 14, leadingContentLength: 24)
+}
+
+// MARK: - Constant
+
+enum BezierBaseInputConstant {
+  static let horizontalPadding: CGFloat = 10
+  static let contentSpacing: CGFloat = 6
+  static let borderWidth: CGFloat = 1.5
+  static let minWidth: CGFloat = 40
+  static let trailingContentLength: CGFloat = 20
+  static let systemElementLength: CGFloat = 20
+
+  static let disabledOpacity: CGFloat = BOGlobalToken.disabled
+
+  static let textTypography: BTSemanticToken = .textXLarge(weight: .regular)
+  static let affixTypography: BTSemanticToken = .textLarge(weight: .regular)
+
+  static let textColor: BCSemanticToken = .textNeutral
+  static let readOnlyTextColor: BCSemanticToken = .textNeutralLight
+  static let placeholderColor: BCSemanticToken = .textNeutralLighter
+  static let iconColor: BCSemanticToken = .iconNeutral
+  static let affixTextColor: BCSemanticToken = .textNeutralLight
+}
+
+// MARK: - Appearance
+
+enum BezierBaseInputAppearance {
+  static func backgroundColor(
+    variant: BezierBaseInputVariant,
+    state: BezierBaseInputState
+  ) -> BCSemanticToken {
+    switch variant {
+    case .primary:
+      switch state {
+      case .default, .disabled: return .fillGrey
+      case .focused, .error: return .fillGreyLight
+      case .readOnly: return .fillGreyHeavy
+      }
+    case .secondary:
+      return .fillNeutralLight
+    }
+  }
+
+  static func borderColor(
+    variant: BezierBaseInputVariant,
+    state: BezierBaseInputState
+  ) -> BCSemanticToken? {
+    switch state {
+    case .focused: return .stateActive
+    case .error: return .stateWarning
+    case .default, .readOnly, .disabled:
+      switch variant {
+      case .primary: return .stateDefault
+      case .secondary: return nil
+      }
+    }
+  }
+
+  static func textColor(state: BezierBaseInputState) -> BCSemanticToken {
+    state == .readOnly
+      ? BezierBaseInputConstant.readOnlyTextColor
+      : BezierBaseInputConstant.textColor
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierTextInput/BezierTextInput.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierTextInput/BezierTextInput.swift
@@ -1,0 +1,408 @@
+//
+//  BezierTextInput.swift
+//  BezierSwift
+//
+
+import UIKit
+
+/// 단일 행 텍스트 입력 필드 (UIKit). 폼 안에서 이름·이메일 등 한 줄 텍스트를 자유 입력받을 때 쓴다. SwiftUI에서는 `SUBezierTextInput`을 사용한다.
+///
+/// 너비는 컨테이너가 결정한다 — leading/trailing 제약으로 부모 폭을 채우는 배치가 기본이다. 높이는 `size`에 따라 고정된다.
+public final class BezierTextInput: UIView, BezierComponentable {
+  // MARK: - BezierComponentable
+
+  public var colorTheme: BezierColorTheme { .systemBezierColorTheme() }
+  public var componentTheme: BezierComponentTheme = .normal {
+    didSet { self.refreshAppearance() }
+  }
+
+  // MARK: - Public Properties
+
+  /// 입력 필드의 스타일. 기본값 `.primary`.
+  public var variant: BezierTextInputVariant = .primary {
+    didSet { if oldValue != self.variant { self.refreshAppearance() } }
+  }
+
+  /// 입력 필드의 크기. 기본값 `.medium`.
+  public var size: BezierTextInputSize = .medium {
+    didSet { if oldValue != self.size { self.refreshSize() } }
+  }
+
+  /// 현재 입력값. 코드로 값을 바꿔도 `onTextChanged`는 호출되지 않는다.
+  public var text: String {
+    get { self.textField.text ?? "" }
+    set {
+      guard self.textField.text != newValue else { return }
+      self.textField.text = newValue
+      self.refreshClearButton()
+    }
+  }
+
+  /// 입력 전 안내 텍스트. 입력 형식이나 예시를 보여준다 (예: `예: hong@company.com`). 기본값은 빈 문자열.
+  public var placeholder: String = "" {
+    didSet { if oldValue != self.placeholder { self.refreshPlaceholder() } }
+  }
+
+  /// 에러 상태 여부. 켜면 에러 보더가 표시된다. 원인·해결 방법 메시지를 함께 노출해야 한다. 기본값 `false`.
+  public var hasError: Bool = false {
+    didSet { if oldValue != self.hasError { self.refreshAppearance() } }
+  }
+
+  /// 읽기 전용 여부. 편집만 차단하고 텍스트 선택·복사는 유지한다. 기본값 `false`.
+  public var isReadOnly: Bool = false {
+    didSet {
+      if oldValue != self.isReadOnly {
+        self.refreshAppearance()
+        self.refreshClearButton()
+      }
+    }
+  }
+
+  /// 활성화 여부. 끄면 모든 인터랙션이 차단되고 40% 투명도가 적용된다. 기본값 `true`.
+  public var isEnabled: Bool = true {
+    didSet { if oldValue != self.isEnabled { self.refreshEnabled() } }
+  }
+
+  /// 편집 중 값이 있을 때 값을 한 번에 지우는 clear 버튼을 표시할지 여부. 기본값 `false`.
+  public var allowClear: Bool = false {
+    didSet { if oldValue != self.allowClear { self.refreshClearButton() } }
+  }
+
+  /// leading(앞) 영역에 넣는 뷰 (아이콘 또는 `BezierTextInputAffix`). 슬롯 높이는 `size`에 맞춰 고정되고 너비는 콘텐츠를 따른다. 기본값 `nil`.
+  public var leadingContent: UIView? {
+    didSet { self.updateSlot(container: self.leadingContainer, old: oldValue, new: self.leadingContent) }
+  }
+
+  /// trailing(뒤) 영역에 넣는 뷰 (아이콘 또는 `BezierTextInputAffix`). 기본값 `nil`.
+  public var trailingContent: UIView? {
+    didSet { self.updateSlot(container: self.trailingContainer, old: oldValue, new: self.trailingContent) }
+  }
+
+  /// 키보드 타입. 내부 텍스트 필드에 그대로 전달된다.
+  public var keyboardType: UIKeyboardType {
+    get { self.textField.keyboardType }
+    set { self.textField.keyboardType = newValue }
+  }
+
+  /// 리턴 키 타입. 내부 텍스트 필드에 그대로 전달된다.
+  public var returnKeyType: UIReturnKeyType {
+    get { self.textField.returnKeyType }
+    set { self.textField.returnKeyType = newValue }
+  }
+
+  // MARK: - Callbacks
+
+  /// 사용자 입력으로 값이 바뀔 때마다 호출된다.
+  public var onTextChanged: ((String) -> Void)?
+
+  /// 포커스가 시작(`true`)·종료(`false`)될 때 호출된다.
+  public var onEditingChanged: ((Bool) -> Void)?
+
+  /// 리턴 키를 눌렀을 때 호출된다.
+  public var onSubmit: (() -> Void)?
+
+  // MARK: - Subviews
+
+  private let rootStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .horizontal
+    stackView.alignment = .center
+    stackView.distribution = .fill
+    stackView.spacing = BezierBaseInputConstant.contentSpacing
+    stackView.isLayoutMarginsRelativeArrangement = true
+    stackView.directionalLayoutMargins = NSDirectionalEdgeInsets(
+      top: 0,
+      leading: BezierBaseInputConstant.horizontalPadding,
+      bottom: 0,
+      trailing: BezierBaseInputConstant.horizontalPadding
+    )
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    return stackView
+  }()
+
+  private let leadingContainer = UIView()
+
+  private let textField: UITextField = {
+    let textField = UITextField()
+    textField.borderStyle = .none
+    textField.backgroundColor = .clear
+    textField.contentVerticalAlignment = .center
+    return textField
+  }()
+
+  private let trailingContainer = UIView()
+
+  private let clearButton: UIButton = {
+    let button = UIButton(type: .system)
+    button.setImage(BezierIcon.cancelCircleFilled.uiImage, for: .normal)
+    return button
+  }()
+
+  // MARK: - Constraints
+
+  private var heightConstraint: NSLayoutConstraint?
+  private var leadingHeightConstraint: NSLayoutConstraint?
+
+  // MARK: - Init
+
+  /// 스타일·크기·placeholder를 지정해 생성한다. 슬롯 뷰는 생성 후 `leadingContent`·`trailingContent`로 주입한다.
+  public init(
+    variant: BezierTextInputVariant = .primary,
+    size: BezierTextInputSize = .medium,
+    placeholder: String = ""
+  ) {
+    self.variant = variant
+    self.size = size
+    self.placeholder = placeholder
+    super.init(frame: .zero)
+    self.setUp()
+  }
+
+  public required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    self.setUp()
+  }
+
+  // MARK: - Setup
+
+  private func setUp() {
+    self.translatesAutoresizingMaskIntoConstraints = false
+    self.layer.masksToBounds = true
+
+    self.setUpSlotContainers()
+    self.setUpTextField()
+    self.setUpClearButton()
+
+    self.rootStackView.addArrangedSubview(self.leadingContainer)
+    self.rootStackView.addArrangedSubview(self.textField)
+    self.rootStackView.addArrangedSubview(self.trailingContainer)
+    self.rootStackView.addArrangedSubview(self.clearButton)
+    self.addSubview(self.rootStackView)
+
+    let heightConstraint = self.heightAnchor.constraint(equalToConstant: self.size.metric.height)
+    self.heightConstraint = heightConstraint
+    NSLayoutConstraint.activate([
+      self.rootStackView.topAnchor.constraint(equalTo: self.topAnchor),
+      self.rootStackView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+      self.rootStackView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+      self.rootStackView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+      self.widthAnchor.constraint(greaterThanOrEqualToConstant: BezierBaseInputConstant.minWidth),
+      heightConstraint,
+    ])
+
+    // 패딩·슬롯 영역을 탭해도 포커스되도록 한다. cancelsTouchesInView를 끄면 clearButton 등 내부 컨트롤 탭을 삼키지 않는다.
+    let tapGesture = UITapGestureRecognizer(target: self, action: #selector(self.handleTap))
+    tapGesture.cancelsTouchesInView = false
+    self.addGestureRecognizer(tapGesture)
+
+    self.refreshSize()
+    self.refreshEnabled()
+    self.refreshClearButton()
+    self.refreshAppearance()
+  }
+
+  private func setUpSlotContainers() {
+    for container in [self.leadingContainer, self.trailingContainer] {
+      container.setContentHuggingPriority(.required, for: .horizontal)
+      container.setContentCompressionResistancePriority(.required, for: .horizontal)
+      container.isHidden = true
+    }
+    let leadingHeightConstraint = self.leadingContainer.heightAnchor.constraint(
+      equalToConstant: self.size.metric.leadingContentLength
+    )
+    self.leadingHeightConstraint = leadingHeightConstraint
+    NSLayoutConstraint.activate([
+      leadingHeightConstraint,
+      self.trailingContainer.heightAnchor.constraint(
+        equalToConstant: BezierBaseInputConstant.trailingContentLength
+      ),
+    ])
+  }
+
+  private func setUpTextField() {
+    self.textField.delegate = self
+    self.textField.addTarget(self, action: #selector(self.handleTextChanged), for: .editingChanged)
+    self.textField.setContentHuggingPriority(UILayoutPriority(1), for: .horizontal)
+    self.textField.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+  }
+
+  private func setUpClearButton() {
+    self.clearButton.addTarget(self, action: #selector(self.handleClear), for: .touchUpInside)
+    NSLayoutConstraint.activate([
+      self.clearButton.widthAnchor.constraint(
+        equalToConstant: BezierBaseInputConstant.systemElementLength
+      ),
+      self.clearButton.heightAnchor.constraint(
+        equalToConstant: BezierBaseInputConstant.systemElementLength
+      ),
+    ])
+    self.clearButton.isHidden = true
+  }
+
+  // MARK: - Slot
+
+  private func updateSlot(container: UIView, old: UIView?, new: UIView?) {
+    old?.removeFromSuperview()
+    guard let new = new else {
+      container.isHidden = true
+      return
+    }
+    new.translatesAutoresizingMaskIntoConstraints = false
+    container.addSubview(new)
+    NSLayoutConstraint.activate([
+      new.topAnchor.constraint(equalTo: container.topAnchor),
+      new.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+      new.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+      new.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+    ])
+    container.isHidden = false
+  }
+
+  // MARK: - First Responder
+
+  public override var canBecomeFirstResponder: Bool { self.textField.canBecomeFirstResponder }
+
+  public override var isFirstResponder: Bool { self.textField.isFirstResponder }
+
+  @discardableResult
+  public override func becomeFirstResponder() -> Bool {
+    self.textField.becomeFirstResponder()
+  }
+
+  @discardableResult
+  public override func resignFirstResponder() -> Bool {
+    self.textField.resignFirstResponder()
+  }
+
+  // MARK: - Trait
+
+  public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    self.refreshAppearance()
+  }
+
+  // MARK: - State
+
+  private var currentState: BezierBaseInputState {
+    .resolve(
+      isEnabled: self.isEnabled,
+      isReadOnly: self.isReadOnly,
+      hasError: self.hasError,
+      isFocused: self.textField.isEditing
+    )
+  }
+
+  // MARK: - Refresh
+
+  private func refreshSize() {
+    let metric = self.size.metric
+    self.heightConstraint?.constant = metric.height
+    self.leadingHeightConstraint?.constant = metric.leadingContentLength
+    self.layer.cornerRadius = metric.cornerRadius
+    self.setNeedsLayout()
+  }
+
+  private func refreshEnabled() {
+    self.textField.isEnabled = self.isEnabled
+    self.isUserInteractionEnabled = self.isEnabled
+    self.refreshClearButton()
+    self.refreshAppearance()
+  }
+
+  private func refreshAppearance() {
+    let state = self.currentState
+
+    self.backgroundColor = BezierBaseInputAppearance
+      .backgroundColor(variant: self.variant.base, state: state)
+      .palette(self)
+
+    if let borderColor = BezierBaseInputAppearance.borderColor(variant: self.variant.base, state: state) {
+      self.layer.borderWidth = BezierBaseInputConstant.borderWidth
+      self.layer.borderColor = borderColor.palette(self).cgColor
+    } else {
+      self.layer.borderWidth = 0
+      self.layer.borderColor = nil
+    }
+
+    self.alpha = state == .disabled ? BezierBaseInputConstant.disabledOpacity : 1
+
+    let typography = BezierBaseInputConstant.textTypography
+    var attributes = self.textField.defaultTextAttributes
+    attributes[.font] = typography.uiFont
+    attributes[.kern] = typography.letterSpacing
+    attributes[.foregroundColor] = BezierBaseInputAppearance.textColor(state: state).palette(self)
+    self.textField.defaultTextAttributes = attributes
+
+    self.clearButton.tintColor = BezierBaseInputConstant.iconColor.palette(self)
+
+    self.refreshPlaceholder()
+  }
+
+  private func refreshPlaceholder() {
+    let typography = BezierBaseInputConstant.textTypography
+    self.textField.attributedPlaceholder = NSAttributedString(
+      string: self.placeholder,
+      attributes: [
+        .font: typography.uiFont,
+        .kern: typography.letterSpacing,
+        .foregroundColor: BezierBaseInputConstant.placeholderColor.palette(self),
+      ]
+    )
+  }
+
+  private func refreshClearButton() {
+    let isVisible = self.allowClear
+      && self.textField.isEditing
+      && !self.text.isEmpty
+      && !self.isReadOnly
+      && self.isEnabled
+    self.clearButton.isHidden = !isVisible
+  }
+
+  // MARK: - Action
+
+  @objc private func handleTap() {
+    guard self.isEnabled, !self.textField.isEditing else { return }
+    self.textField.becomeFirstResponder()
+  }
+
+  @objc private func handleTextChanged() {
+    self.onTextChanged?(self.text)
+    self.refreshClearButton()
+  }
+
+  @objc private func handleClear() {
+    self.textField.text = ""
+    self.onTextChanged?("")
+    self.refreshClearButton()
+  }
+}
+
+// MARK: - UITextFieldDelegate
+
+extension BezierTextInput: UITextFieldDelegate {
+  public func textFieldDidBeginEditing(_ textField: UITextField) {
+    self.refreshAppearance()
+    self.refreshClearButton()
+    self.onEditingChanged?(true)
+  }
+
+  public func textFieldDidEndEditing(_ textField: UITextField) {
+    self.refreshAppearance()
+    self.refreshClearButton()
+    self.onEditingChanged?(false)
+  }
+
+  public func textField(
+    _ textField: UITextField,
+    shouldChangeCharactersIn range: NSRange,
+    replacementString string: String
+  ) -> Bool {
+    !self.isReadOnly
+  }
+
+  public func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+    self.onSubmit?()
+    return true
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierTextInput/BezierTextInputAffix.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierTextInput/BezierTextInputAffix.swift
@@ -1,0 +1,83 @@
+//
+//  BezierTextInputAffix.swift
+//  BezierSwift
+//
+
+import UIKit
+
+/// `BezierTextInput`의 leadingContent/trailingContent 슬롯에 넣는 접사 텍스트 (UIKit). `https://`, `%`, `.channel.io`처럼 짧고 고정된 포맷 힌트에 쓴다. 단독 배치는 금지한다. SwiftUI에서는 `SUBezierTextInputAffix`를 사용한다.
+public final class BezierTextInputAffix: UIView, BezierComponentable {
+  // MARK: - BezierComponentable
+
+  public var colorTheme: BezierColorTheme { .systemBezierColorTheme() }
+  public var componentTheme: BezierComponentTheme = .normal {
+    didSet { self.refreshText() }
+  }
+
+  // MARK: - Public Properties
+
+  /// 표시할 접사 텍스트.
+  public var text: String {
+    didSet { if oldValue != self.text { self.refreshText() } }
+  }
+
+  // MARK: - Subviews
+
+  private let label: UILabel = {
+    let label = UILabel()
+    label.numberOfLines = 1
+    label.translatesAutoresizingMaskIntoConstraints = false
+    return label
+  }()
+
+  // MARK: - Init
+
+  /// 접사 텍스트를 지정해 생성한다.
+  public init(text: String) {
+    self.text = text
+    super.init(frame: .zero)
+    self.setUp()
+  }
+
+  public required init?(coder: NSCoder) {
+    self.text = ""
+    super.init(coder: coder)
+    self.setUp()
+  }
+
+  // MARK: - Setup
+
+  private func setUp() {
+    self.translatesAutoresizingMaskIntoConstraints = false
+    self.setContentHuggingPriority(.required, for: .horizontal)
+    self.setContentCompressionResistancePriority(.required, for: .horizontal)
+
+    self.addSubview(self.label)
+    NSLayoutConstraint.activate([
+      self.label.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+      self.label.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+      self.label.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+    ])
+
+    self.refreshText()
+  }
+
+  // MARK: - Trait
+
+  public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    self.refreshText()
+  }
+
+  // MARK: - Refresh
+
+  private func refreshText() {
+    self.label.attributedText = BezierBaseInputConstant.affixTypography.attributedString(
+      self,
+      text: self.text,
+      semanticColorToken: BezierBaseInputConstant.affixTextColor,
+      alignment: .left,
+      lineBreakMode: .byClipping
+    )
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierTextInput/BezierTextInputSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierTextInput/BezierTextInputSpec.swift
@@ -1,0 +1,40 @@
+//
+//  BezierTextInputSpec.swift
+//  BezierSwift
+//
+
+import Foundation
+
+// MARK: - Variant
+
+/// 입력 필드의 스타일. Figma `TextInput` 컴포넌트의 `variant` 프로퍼티에 대응 (case 이름 = Figma 값).
+public enum BezierTextInputVariant: CaseIterable {
+  /// 일반 흰 배경(surface) 위에 입력 필드를 배치할 때 쓰는 기본값. 배경과 보더로 입력 가능 영역을 명확히 표시한다.
+  case primary
+  /// 중첩 패널·카드·사이드바처럼 이미 배경색이 있는 영역 위에 배치할 때 쓴다. 배경색이 state와 무관하게 고정되어 에러 인지가 어려우므로, `hasError` 표시가 필요한 폼에는 `primary`를 쓴다 (secondary + error 조합 금지).
+  case secondary
+
+  var base: BezierBaseInputVariant {
+    switch self {
+    case .primary: return .primary
+    case .secondary: return .secondary
+    }
+  }
+}
+
+// MARK: - Size
+
+/// 입력 필드의 크기. Figma `TextInput` 컴포넌트의 `size` 프로퍼티에 대응 (case 이름 = Figma 값).
+public enum BezierTextInputSize: CaseIterable {
+  /// 검색바·인라인 필터 등 소형 맥락에 쓴다. 높이 40pt.
+  case small
+  /// 설정·프로필 입력, 모달 내 폼 등 대부분의 모바일 폼 맥락에 쓰는 기본값. 높이 48pt.
+  case medium
+
+  var metric: BezierBaseInputMetric {
+    switch self {
+    case .small: return .small
+    case .medium: return .medium
+    }
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierTextInput/SPEC.md
+++ b/Sources/BezierSwift/MasterComponent/BezierTextInput/SPEC.md
@@ -1,0 +1,212 @@
+# BezierTextInput SPEC
+
+> **SSOT**: [Figma · Mobile-Components / TextInput (3612:2)](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=3612-2) · [Internal/TextInputAffix (4453:12044)](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9A%A7-Mobile-Components?node-id=4453-12044)
+> **Design spec doc**: [team-design / bezier-v3 / components / TextInput-spec.md](https://github.com/channel-io/team-design/blob/main/bezier-v3/components/TextInput-spec.md) · [BaseInput.md](https://github.com/channel-io/team-design/blob/main/bezier-v3/components/BaseInput.md) (보조 참조 — 값 충돌 시 Figma 파일 우선)
+
+단일 행 텍스트 입력 필드 (Figma component description 1행).
+
+- **배치**: width 기본 fill(부모 폭 채움). 최소 너비 40pt. ⚠️ secondary + error 조합 금지 (Figma description)
+
+## 1. Component Properties
+
+### TextInput (CS `3612:2`)
+
+| Property | 값 | 비고 |
+|---|---|---|
+| **variant** | `primary` / `secondary` | 배경·보더 결정 |
+| **size** | `small` / `medium` | 높이·radius·leadingContent 크기 결정 |
+| **state** | `default` / `focused` / `error` / `readOnly` / `disabled` | 배경·보더·텍스트 색 결정 |
+| **hasValue** | `false` / `true` | `false`: `placeholder` 레이어만 표시, `true`: `value` 레이어만 표시 |
+| **placeholder** / **value** | TEXT | 각 텍스트 레이어의 내용 |
+| **hasLeadingContent** | BOOLEAN, 기본 `false` | leadingContent 슬롯 표시 여부 |
+| **leadingContent** | SLOT | 좌측 슬롯 (아이콘 또는 Internal/TextInputAffix) |
+| **hasTrailingContent** | BOOLEAN, 기본 `false` | trailingContent 슬롯 표시 여부 |
+| **trailingContent** | SLOT | 우측 슬롯 (아이콘 또는 Internal/TextInputAffix) |
+| **allowClear** | BOOLEAN, 기본 `false` | 시스템 자동 요소 — cancel-circle-filled 아이콘 20pt |
+| **passwordToggle** | BOOLEAN, 기본 `false` | 시스템 자동 요소 — view 형상 아이콘 20pt (SVG 실측 — slash 없는 뜬 눈) |
+
+총 instance: variant 2 × size 2 × state 5 × hasValue 2 = **40개**
+
+자식 배치 순서: `leadingContent → 입력 텍스트 → trailingContent → allowClear → passwordToggle`
+
+### Internal/TextInputAffix (CS `4453:12044`)
+
+| Property | 값 | 비고 |
+|---|---|---|
+| **size** | `medium` / `large` | 두 size 모두 동일 typography (Figma description: "모두 Typography/text/large 15px") |
+| **text** | TEXT | 표시할 접사 텍스트 |
+
+총 instance: size 2개 (`medium` = `4453:77`, `large` = `4453:12042`)
+
+## 2. Size 별 Layout Spec
+
+| Part | small | medium |
+|---|---|---|
+| 높이 (FIXED) | `40pt` | `48pt` |
+| corner radius | `12pt` (`radius/12`) | `14pt` (`radius/14`) |
+| 좌우 패딩 | `10pt` | `10pt` |
+| 영역 간 gap | `6pt` | `6pt` |
+| leadingContent 슬롯 높이 | `20pt` | `24pt` |
+| trailingContent 슬롯 | `20×20pt` | `20×20pt` |
+| allowClear / passwordToggle | `20×20pt` | `20×20pt` |
+| 최소 너비 | `40pt` | `40pt` |
+| 보더(INNER_SHADOW) 두께 | `1.5pt` (spread) | `1.5pt` |
+
+- 너비: 기본 fill — 부모 폭을 채움 (Figma description). 높이는 콘텐츠와 무관하게 고정.
+- 입력 텍스트는 1줄, 초과분 ellipsis (`textTruncation=ENDING`, `maxLines=1`).
+- 보더는 Effect `State/*` — `INNER_SHADOW, offset (0,0), radius 0, spread 1.5` (안쪽 1.5pt 라인).
+
+## 3. Variant × State 컬러 토큰
+
+### Background
+
+| State | primary | secondary |
+|---|---|---|
+| `default` | `fillGrey` (`color/fill/grey` `#FBFBFB`) | `fillNeutralLight` (`color/fill/neutral/light` `#0000000D`) |
+| `focused` | `fillGreyLight` (`color/fill/grey/light` `#FDFDFD`) | `fillNeutralLight` |
+| `error` | `fillGreyLight` | `fillNeutralLight` |
+| `readOnly` | `fillGreyHeavy` (`color/fill/grey/heavy` `#F7F7F8`) | `fillNeutralLight` |
+| `disabled` | `fillGrey` | `fillNeutralLight` |
+
+### Border (INNER_SHADOW 1.5pt)
+
+| State | primary | secondary |
+|---|---|---|
+| `default` | `State/default` — `stateDefault` (`color/state/default` `#00000026`) | — *(없음)* |
+| `focused` | `State/active` — `stateActive` (`color/state/active` `#000000D9`) | `State/active` |
+| `error` | `State/error` — `stateWarning` (`color/state/warning` `#E67F2B`) | `State/error` |
+| `readOnly` | `State/default` | — *(없음)* |
+| `disabled` | `State/default` | — *(없음)* |
+
+### Text / Icon
+
+| 위치 | Token | Figma Variable | Raw |
+|---|---|---|---|
+| placeholder (`hasValue=false`) | `textNeutralLighter` | `color/text/neutral/lighter` | `#00000066` |
+| value (`hasValue=true`) | `textNeutral` | `color/text/neutral` | `#000000D9` |
+| value (`state=readOnly`) | `textNeutralLight` | `color/text/neutral/light` | `#00000099` |
+| allowClear / passwordToggle 아이콘 | `iconNeutral` | — (SVG 실측 `fill black 40%`) | `#00000066` 상당 |
+| TextInputAffix 텍스트 | `textNeutralLight` | `color/text/neutral/light` | `#00000099` |
+
+### Opacity
+
+| State | 값 |
+|---|---|
+| `disabled` | `opacity/disabled` = 40% (전체) |
+
+## 4. Typography
+
+### Case A — Typography Token 사용
+
+| 위치 | Token | Figma Style 이름 |
+|---|---|---|
+| placeholder / value (size 공통) | `BTSemanticToken.textXLarge(weight: .regular)` | `Typography/text/xlarge` (16 / 400 / lh 24 / ls -0.1) |
+| Internal/TextInputAffix (size 공통) | `BTSemanticToken.textLarge(weight: .regular)` | `Typography/text/large` (15 / 400 / lh 20 / ls -0.1) |
+
+### Case B — Custom Typography
+
+없음.
+
+## 5. State 별 시각 동작
+
+| State | primary 변경점 | secondary 변경점 | 인터랙션 |
+|---|---|---|---|
+| `default` | 기본 | 기본 (보더 없음) | 활성 |
+| `focused` | 배경 `fillGreyLight` + 보더 `State/active` | 보더 `State/active` (배경 불변) | 편집 중 |
+| `error` | 배경 `fillGreyLight` + 보더 `State/error` | 보더 `State/error` (배경 불변) | 활성 |
+| `readOnly` | 배경 `fillGreyHeavy`, value 텍스트 `textNeutralLight` | 배경 불변 (보더 없음) | 편집 차단, 선택·복사 가능 |
+| `disabled` | 전체 opacity 40% | 전체 opacity 40% | 비활성 |
+
+### 시스템 자동 요소
+
+- **allowClear**: `allowClear=true` + focused + 값 있을 때 cancel-circle-filled(20pt, `iconNeutral`) 표시. 탭 시 값 초기화 후 포커스 유지.
+- **passwordToggle**: `passwordToggle=true` 시 view 형상 아이콘(20pt, `iconNeutral`) 표시. allowClear보다 바깥쪽(더 오른쪽)에 배치.
+
+## 6. 디자이너 가이드라인 (Figma component description 인용)
+
+### TextInput
+
+- 단일 행 텍스트 입력 필드. variant: primary / secondary • size: small / medium • state: default / focused / error / readOnly / disabled
+- hasLeadingContent / hasTrailingContent: 슬롯 ON/OFF (아이콘 또는 TextInputAffix 배치)
+- allowClear / passwordToggle: 시스템 자동 요소
+- width: 기본 fill(부모 폭 채움). 비율 지정도 가능하나 Figma는 auto-layout 기능 한계로 표현 불가(FILL/FIXED/HUG만 지원). 최소 너비 40px.
+- ⚠️ secondary + error 조합 금지
+
+### Internal/TextInputAffix
+
+- Used within TextInput only. Do not place standalone. TextInput의 leadingContent / trailingContent에 넣는 포맷 힌트 텍스트 (예: https://, %, .channel.io)
+- text: 표시할 접사 텍스트 (기본값: https://) • size: medium / large (모두 Typography/text/large 15px)
+
+## 7. 매핑되는 코드 심볼
+
+| 정의 | 파일 |
+|---|---|
+| UIKit 구현 | `BezierTextInput.swift` |
+| SwiftUI 구현 | `SUBezierTextInput.swift` |
+| variant / size / constant | `BezierTextInputSpec.swift` |
+| 공유 Input 레이어 (internal) | `../BezierBaseInput/BezierBaseInputSpec.swift` |
+| Affix UIKit | `BezierTextInputAffix.swift` |
+| Affix SwiftUI | `SUBezierTextInputAffix.swift` |
+
+## 8. Figma 외 · 협의 사항 (구현 결정 — SSOT 값 아님)
+
+1. **internal BaseInput 레이어**: 후속 TextArea(MOB-6348)·Search(MOB-6347)·Select(MOB-6353)가 BaseInput.md의 공통 시각 언어(배경·보더·radius·패딩·gap·state 해석)를 공유하므로, variant/state/appearance/metric을 `MasterComponent/BezierBaseInput/`의 **internal** 타입으로 분리한다. public 컴포넌트로 노출하지 않는다 (BaseInput.md: "이 문서는 독립 컴포넌트 스펙이 아니다").
+2. **passwordToggle iOS 미구현**: Figma CS에 BOOLEAN으로 존재하나 design spec doc(§3 Anatomy G, §11 Platform)이 **Android 전용**으로 명시 — iOS v1 스코프에서 제외. secure text entry 자체도 미제공 (후속 티켓에서 필요 시 추가).
+3. **state 우선순위**: Figma state 축은 배타적 단일 축. 코드 상태 조합의 해석 순서는 `disabled > readOnly > error > focused > default` (readOnly 중 focus되어도 readOnly 시각 유지, error 중 focus되어도 error 시각 유지).
+4. **INNER_SHADOW → 보더 구현**: spread 1.5 / blur 0 / offset (0,0)의 INNER_SHADOW는 안쪽 1.5pt 라인과 동일 — UIKit `layer.borderWidth = 1.5` (bounds 안쪽 렌더), SwiftUI `strokeBorder(lineWidth: 1.5)` (inset stroke)로 구현.
+5. **UITextField line-height 미적용**: 단일 행 UITextField에 `minimumLineHeight`(24pt) paragraph style을 적용하면 caret·세로 정렬 이상이 생긴다. 컨테이너 높이가 40/48pt로 고정돼 세로 중앙 정렬로 동일한 시각 결과가 나오므로 font(16pt) + kern(-0.1)만 적용한다. SwiftUI도 동일하게 고정 높이 컨테이너 중앙 정렬.
+6. **readOnly 동작**: UIKit은 delegate에서 문자 변경 차단(선택·복사 유지), SwiftUI는 `TextField` 대신 `.textSelection(.enabled)` `Text`로 렌더 (SwiftUI TextField에 readOnly가 없음).
+7. **allowClear 아이콘**: `BezierIcon.cancelCircleFilled` 기존 에셋 사용 (Figma 인스턴스 SVG와 동일 형상 확인). 표시 조건 `allowClear && focused && !text.isEmpty` — readOnly/disabled에서는 미표시.
+8. **allowClear/입력 콜백 API**: UIKit은 `onTextChanged` / `onEditingChanged` / `onSubmit` 클로저, 포커스 제어는 `becomeFirstResponder()`/`resignFirstResponder()` 포워딩 (design spec doc §7 Ref API의 focus/blur 대응). SwiftUI는 `Binding<String>` + 표준 environment 상속(`.keyboardType` 등).
+9. **UIKit 키보드 옵션**: 내부 UITextField가 캡슐화되어 접근 불가하므로 `keyboardType` / `returnKeyType` passthrough만 최소 제공.
+10. **TextInputAffix**: Figma의 size 축(medium/large)은 두 값의 typography가 동일해 코드에서는 축 없이 단일 뷰로 제공. 슬롯 콘텐츠는 소비자가 생성해 주입하므로 public 타입으로 노출한다 (`Internal/SectionLabel` → public `BezierSectionLabel`과 동일 패턴). Figma description "Do not place standalone"은 doc comment의 단독 배치 금지 안내로 전달한다.
+11. **웹 전용 요소 스코프 제외**: copyButton(웹 전용, Mobile CS에 레이어 없음)·type/selectAllOn*/Ref API 등 bezier-react 전용 props는 미구현.
+
+## 9. Variant 매트릭스
+
+총 instance: variant 2 × size 2 × state 5 × hasValue 2 = **40개**
+
+```
+variant=primary,   size=small,  state=default,  hasValue=false = 1105:3
+variant=primary,   size=small,  state=default,  hasValue=true  = 2451:146
+variant=primary,   size=small,  state=focused,  hasValue=false = 1105:5
+variant=primary,   size=small,  state=focused,  hasValue=true  = 2451:154
+variant=primary,   size=small,  state=error,    hasValue=false = 1105:7
+variant=primary,   size=small,  state=error,    hasValue=true  = 2451:162
+variant=primary,   size=small,  state=readOnly, hasValue=false = 4548:925
+variant=primary,   size=small,  state=readOnly, hasValue=true  = 4548:931
+variant=primary,   size=small,  state=disabled, hasValue=false = 1105:9
+variant=primary,   size=small,  state=disabled, hasValue=true  = 2451:170
+variant=primary,   size=medium, state=default,  hasValue=false = 1105:11
+variant=primary,   size=medium, state=default,  hasValue=true  = 2451:178
+variant=primary,   size=medium, state=focused,  hasValue=false = 1105:13
+variant=primary,   size=medium, state=focused,  hasValue=true  = 2451:186
+variant=primary,   size=medium, state=error,    hasValue=false = 1105:15
+variant=primary,   size=medium, state=error,    hasValue=true  = 2451:194
+variant=primary,   size=medium, state=readOnly, hasValue=false = 4548:937
+variant=primary,   size=medium, state=readOnly, hasValue=true  = 4548:943
+variant=primary,   size=medium, state=disabled, hasValue=false = 1105:17
+variant=primary,   size=medium, state=disabled, hasValue=true  = 2451:202
+variant=secondary, size=small,  state=default,  hasValue=false = 1105:27
+variant=secondary, size=small,  state=default,  hasValue=true  = 2451:242
+variant=secondary, size=small,  state=focused,  hasValue=false = 1105:29
+variant=secondary, size=small,  state=focused,  hasValue=true  = 2451:250
+variant=secondary, size=small,  state=error,    hasValue=false = 1105:31
+variant=secondary, size=small,  state=error,    hasValue=true  = 2451:258
+variant=secondary, size=small,  state=readOnly, hasValue=false = 4548:949
+variant=secondary, size=small,  state=readOnly, hasValue=true  = 4548:955
+variant=secondary, size=small,  state=disabled, hasValue=false = 1105:33
+variant=secondary, size=small,  state=disabled, hasValue=true  = 2451:266
+variant=secondary, size=medium, state=default,  hasValue=false = 1105:35
+variant=secondary, size=medium, state=default,  hasValue=true  = 2451:274
+variant=secondary, size=medium, state=focused,  hasValue=false = 1105:37
+variant=secondary, size=medium, state=focused,  hasValue=true  = 2451:282
+variant=secondary, size=medium, state=error,    hasValue=false = 1105:39
+variant=secondary, size=medium, state=error,    hasValue=true  = 2451:290
+variant=secondary, size=medium, state=readOnly, hasValue=false = 4548:961
+variant=secondary, size=medium, state=readOnly, hasValue=true  = 4548:967
+variant=secondary, size=medium, state=disabled, hasValue=false = 1105:41
+variant=secondary, size=medium, state=disabled, hasValue=true  = 2451:298
+
+Internal/TextInputAffix: size=medium = 4453:77, size=large = 4453:12042  (총 2)
+```

--- a/Sources/BezierSwift/MasterComponent/BezierTextInput/SPEC.md
+++ b/Sources/BezierSwift/MasterComponent/BezierTextInput/SPEC.md
@@ -166,7 +166,7 @@
 
 총 instance: variant 2 × size 2 × state 5 × hasValue 2 = **40개**
 
-```
+```text
 variant=primary,   size=small,  state=default,  hasValue=false = 1105:3
 variant=primary,   size=small,  state=default,  hasValue=true  = 2451:146
 variant=primary,   size=small,  state=focused,  hasValue=false = 1105:5

--- a/Sources/BezierSwift/MasterComponent/BezierTextInput/SUBezierTextInput.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierTextInput/SUBezierTextInput.swift
@@ -1,0 +1,265 @@
+//
+//  SUBezierTextInput.swift
+//  BezierSwift
+//
+
+import SwiftUI
+
+/// 단일 행 텍스트 입력 필드 (SwiftUI). 폼 안에서 이름·이메일 등 한 줄 텍스트를 자유 입력받을 때 쓴다. UIKit에서는 `BezierTextInput`을 사용한다.
+///
+/// 너비는 컨테이너가 결정한다 — 기본으로 부모 폭을 채운다. 높이는 `size`에 따라 고정된다.
+/// 키보드 옵션·제출 처리는 표준 modifier(`.keyboardType`, `.onSubmit` 등)를 밖에서 적용하면 내부 텍스트 필드로 전파된다.
+public struct SUBezierTextInput<Leading: View, Trailing: View>: View, Themeable {
+  @Environment(\.colorScheme) public var colorScheme
+  @Environment(\.isEnabled) private var isEnabled
+  @FocusState private var isFocused: Bool
+
+  @Binding private var text: String
+  private let placeholder: String
+  private let variant: BezierTextInputVariant
+  private let size: BezierTextInputSize
+  private let hasError: Bool
+  private let isReadOnly: Bool
+  private let allowClear: Bool
+  private let leading: Leading
+  private let trailing: Trailing
+
+  /// 입력값 바인딩과 스타일·상태, leading·trailing 슬롯 뷰를 지정해 생성한다.
+  ///
+  /// - `hasError`: 에러 보더 표시. 원인·해결 방법 메시지를 함께 노출해야 한다.
+  /// - `isReadOnly`: 편집만 차단하고 텍스트 선택·복사는 유지한다.
+  /// - `allowClear`: 편집 중 값이 있을 때 값을 한 번에 지우는 clear 버튼을 표시한다.
+  /// - 슬롯에는 아이콘 또는 `SUBezierTextInputAffix`를 넣는다.
+  public init(
+    text: Binding<String>,
+    placeholder: String = "",
+    variant: BezierTextInputVariant = .primary,
+    size: BezierTextInputSize = .medium,
+    hasError: Bool = false,
+    isReadOnly: Bool = false,
+    allowClear: Bool = false,
+    @ViewBuilder leadingContent: () -> Leading,
+    @ViewBuilder trailingContent: () -> Trailing
+  ) {
+    self._text = text
+    self.placeholder = placeholder
+    self.variant = variant
+    self.size = size
+    self.hasError = hasError
+    self.isReadOnly = isReadOnly
+    self.allowClear = allowClear
+    self.leading = leadingContent()
+    self.trailing = trailingContent()
+  }
+
+  public var body: some View {
+    HStack(spacing: BezierBaseInputConstant.contentSpacing) {
+      self.leadingView
+      self.fieldView
+      self.trailingView
+      self.clearButtonView
+    }
+    .padding(.horizontal, BezierBaseInputConstant.horizontalPadding)
+    .frame(height: self.metric.height)
+    .frame(minWidth: BezierBaseInputConstant.minWidth, maxWidth: .infinity)
+    .background(
+      RoundedRectangle(cornerRadius: self.metric.cornerRadius)
+        .fill(self.palette(BezierBaseInputAppearance.backgroundColor(variant: self.variant.base, state: self.state)))
+    )
+    .overlay { self.borderOverlay }
+    .opacity(self.state == .disabled ? BezierBaseInputConstant.disabledOpacity : 1)
+    .contentShape(Rectangle())
+    .onTapGesture {
+      guard !self.isReadOnly else { return }
+      self.isFocused = true
+    }
+  }
+
+  // MARK: - State
+
+  private var metric: BezierBaseInputMetric { self.size.metric }
+
+  private var state: BezierBaseInputState {
+    .resolve(
+      isEnabled: self.isEnabled,
+      isReadOnly: self.isReadOnly,
+      hasError: self.hasError,
+      isFocused: self.isFocused
+    )
+  }
+
+  // MARK: - Subviews
+
+  @ViewBuilder
+  private var leadingView: some View {
+    if Leading.self != EmptyView.self {
+      self.leading
+        .frame(height: self.metric.leadingContentLength)
+    }
+  }
+
+  @ViewBuilder
+  private var fieldView: some View {
+    if self.isReadOnly {
+      Text(self.text.isEmpty ? self.placeholder : self.text)
+        .applyBezierFontStyle(
+          BezierBaseInputConstant.textTypography,
+          semanticColorToken: self.text.isEmpty
+            ? BezierBaseInputConstant.placeholderColor
+            : BezierBaseInputConstant.readOnlyTextColor
+        )
+        .lineLimit(1)
+        .truncationMode(.tail)
+        .textSelection(.enabled)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    } else {
+      TextField("", text: self.$text, prompt: self.promptText)
+        .focused(self.$isFocused)
+        .textFieldStyle(.plain)
+        .applyBezierFontStyle(
+          BezierBaseInputConstant.textTypography,
+          semanticColorToken: BezierBaseInputConstant.textColor
+        )
+        .frame(maxWidth: .infinity)
+    }
+  }
+
+  private var promptText: Text {
+    Text(self.placeholder)
+      .font(BezierBaseInputConstant.textTypography.font)
+      .kerning(BezierBaseInputConstant.textTypography.letterSpacing)
+      .foregroundColor(self.palette(BezierBaseInputConstant.placeholderColor))
+  }
+
+  @ViewBuilder
+  private var trailingView: some View {
+    if Trailing.self != EmptyView.self {
+      self.trailing
+        .frame(height: BezierBaseInputConstant.trailingContentLength)
+    }
+  }
+
+  @ViewBuilder
+  private var clearButtonView: some View {
+    if self.allowClear, self.isFocused, !self.text.isEmpty, !self.isReadOnly {
+      Button {
+        self.text = ""
+      } label: {
+        BezierIcon.cancelCircleFilled.image
+          .foregroundColor(self.palette(BezierBaseInputConstant.iconColor))
+          .frame(
+            width: BezierBaseInputConstant.systemElementLength,
+            height: BezierBaseInputConstant.systemElementLength
+          )
+      }
+      .buttonStyle(.plain)
+    }
+  }
+
+  @ViewBuilder
+  private var borderOverlay: some View {
+    if let borderColor = BezierBaseInputAppearance.borderColor(variant: self.variant.base, state: self.state) {
+      RoundedRectangle(cornerRadius: self.metric.cornerRadius)
+        .strokeBorder(self.palette(borderColor), lineWidth: BezierBaseInputConstant.borderWidth)
+    }
+  }
+}
+
+// MARK: - Convenience init (슬롯 생략)
+
+extension SUBezierTextInput where Leading == EmptyView, Trailing == EmptyView {
+  /// 슬롯 없이 생성하는 편의 이니셜라이저.
+  public init(
+    text: Binding<String>,
+    placeholder: String = "",
+    variant: BezierTextInputVariant = .primary,
+    size: BezierTextInputSize = .medium,
+    hasError: Bool = false,
+    isReadOnly: Bool = false,
+    allowClear: Bool = false
+  ) {
+    self.init(
+      text: text,
+      placeholder: placeholder,
+      variant: variant,
+      size: size,
+      hasError: hasError,
+      isReadOnly: isReadOnly,
+      allowClear: allowClear,
+      leadingContent: { EmptyView() },
+      trailingContent: { EmptyView() }
+    )
+  }
+}
+
+extension SUBezierTextInput where Trailing == EmptyView {
+  /// leading 슬롯만 지정하는 편의 이니셜라이저.
+  public init(
+    text: Binding<String>,
+    placeholder: String = "",
+    variant: BezierTextInputVariant = .primary,
+    size: BezierTextInputSize = .medium,
+    hasError: Bool = false,
+    isReadOnly: Bool = false,
+    allowClear: Bool = false,
+    @ViewBuilder leadingContent: () -> Leading
+  ) {
+    self.init(
+      text: text,
+      placeholder: placeholder,
+      variant: variant,
+      size: size,
+      hasError: hasError,
+      isReadOnly: isReadOnly,
+      allowClear: allowClear,
+      leadingContent: leadingContent,
+      trailingContent: { EmptyView() }
+    )
+  }
+}
+
+extension SUBezierTextInput where Leading == EmptyView {
+  /// trailing 슬롯만 지정하는 편의 이니셜라이저.
+  public init(
+    text: Binding<String>,
+    placeholder: String = "",
+    variant: BezierTextInputVariant = .primary,
+    size: BezierTextInputSize = .medium,
+    hasError: Bool = false,
+    isReadOnly: Bool = false,
+    allowClear: Bool = false,
+    @ViewBuilder trailingContent: () -> Trailing
+  ) {
+    self.init(
+      text: text,
+      placeholder: placeholder,
+      variant: variant,
+      size: size,
+      hasError: hasError,
+      isReadOnly: isReadOnly,
+      allowClear: allowClear,
+      leadingContent: { EmptyView() },
+      trailingContent: trailingContent
+    )
+  }
+}
+
+struct SUBezierTextInput_Previews: PreviewProvider {
+  static var previews: some View {
+    VStack(spacing: 12) {
+      SUBezierTextInput(text: .constant(""), placeholder: "예: hong@company.com")
+      SUBezierTextInput(text: .constant("hong@company.com"), size: .small)
+      SUBezierTextInput(text: .constant("wrong value"), hasError: true)
+      SUBezierTextInput(text: .constant("read only value"), isReadOnly: true)
+      SUBezierTextInput(text: .constant("disabled value"))
+        .disabled(true)
+      SUBezierTextInput(text: .constant(""), placeholder: "url", variant: .secondary, leadingContent: {
+        SUBezierTextInputAffix(text: "https://")
+      })
+      SUBezierTextInput(text: .constant("50"), trailingContent: {
+        SUBezierTextInputAffix(text: "%")
+      })
+    }
+    .padding()
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierTextInput/SUBezierTextInput.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierTextInput/SUBezierTextInput.swift
@@ -108,7 +108,7 @@ public struct SUBezierTextInput<Leading: View, Trailing: View>: View, Themeable 
           BezierBaseInputConstant.textTypography,
           semanticColorToken: self.text.isEmpty
             ? BezierBaseInputConstant.placeholderColor
-            : BezierBaseInputConstant.readOnlyTextColor
+            : BezierBaseInputAppearance.textColor(state: self.state)
         )
         .lineLimit(1)
         .truncationMode(.tail)

--- a/Sources/BezierSwift/MasterComponent/BezierTextInput/SUBezierTextInput.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierTextInput/SUBezierTextInput.swift
@@ -67,6 +67,8 @@ public struct SUBezierTextInput<Leading: View, Trailing: View>: View, Themeable 
         .fill(self.palette(BezierBaseInputAppearance.backgroundColor(variant: self.variant.base, state: self.state)))
     )
     .overlay { self.borderOverlay }
+    // opacity는 per-view 곱이라 배경·보더가 겹치는 링 영역이 이중 블렌딩됨 — 합성 후 1회 적용 (UIKit self.alpha와 동일 결과)
+    .compositingGroup()
     .opacity(self.state == .disabled ? BezierBaseInputConstant.disabledOpacity : 1)
     .contentShape(Rectangle())
     .onTapGesture {

--- a/Sources/BezierSwift/MasterComponent/BezierTextInput/SUBezierTextInputAffix.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierTextInput/SUBezierTextInputAffix.swift
@@ -1,0 +1,26 @@
+//
+//  SUBezierTextInputAffix.swift
+//  BezierSwift
+//
+
+import SwiftUI
+
+/// `SUBezierTextInput`의 leadingContent/trailingContent 슬롯에 넣는 접사 텍스트 (SwiftUI). `https://`, `%`, `.channel.io`처럼 짧고 고정된 포맷 힌트에 쓴다. 단독 배치는 금지한다. UIKit에서는 `BezierTextInputAffix`를 사용한다.
+public struct SUBezierTextInputAffix: View {
+  private let text: String
+
+  /// 접사 텍스트를 지정해 생성한다.
+  public init(text: String) {
+    self.text = text
+  }
+
+  public var body: some View {
+    Text(self.text)
+      .applyBezierFontStyle(
+        BezierBaseInputConstant.affixTypography,
+        semanticColorToken: BezierBaseInputConstant.affixTextColor
+      )
+      .lineLimit(1)
+      .fixedSize()
+  }
+}


### PR DESCRIPTION
## MOB-6346

https://linear.app/channel/issue/MOB-6346

V3 TextInput 컴포넌트를 UIKit + SwiftUI로 구현합니다. Input 패밀리(TextArea·Search·Select 후속 예정)의 첫 구현체로, 공유 시각 언어(BaseInput.md)를 internal 레이어로 분리했습니다.

## 구현 내용

### internal BaseInput 레이어 — `BezierBaseInput/BezierBaseInputSpec.swift`

후속 TextArea(MOB-6348) / Search(MOB-6347) / Select(MOB-6353)가 재사용할 공통 값·로직을 internal로 중앙화했습니다 (BaseInput.md 원칙에 따라 public 컴포넌트로 노출하지 않음):

- `BezierBaseInputVariant` (primary / secondary), `BezierBaseInputState` (default / focused / error / readOnly / disabled) + 상태 해석 우선순위 `disabled > readOnly > error > focused > default`
- `BezierBaseInputMetric` — 높이 40/48 · radius 12/14 · leading 슬롯 20/24
- `BezierBaseInputConstant` — 좌우 패딩 10 · gap 6 · 보더 1.5 · min-width 40 · trailing/시스템 요소 20 · 타이포(`textXLarge` 입력 / `textLarge` 접사) · 색 토큰
- `BezierBaseInputAppearance` — variant × state → 배경/보더/텍스트색 해석 (secondary는 배경 고정 + default·readOnly·disabled 보더 없음)

### TextInput — `BezierTextInput` / `SUBezierTextInput`

- variant primary/secondary × size small(40pt)/medium(48pt), 기본값 primary·medium
- state: 포커스(`State/active` 보더 + primary 배경 전환) / 에러(`State/error`) / readOnly(편집 차단·선택 복사 유지, `fillGreyHeavy` 배경 + `textNeutralLight` 값 텍스트) / disabled(opacity 40%)
- 슬롯 2개 (leadingContent / trailingContent) — 아이콘 또는 TextInputAffix 배치, 슬롯 높이 고정(leading 20/24 · trailing 20) + 너비 HUG, 공간 부족 시 입력 텍스트가 먼저 ellipsis
- allowClear — 편집 중 + 값 있을 때 `BezierIcon.cancelCircleFilled`(20pt, `iconNeutral`) 표시, 탭 시 값 초기화 후 포커스 유지
- UIKit: `UITextField` 래핑. `onTextChanged`/`onEditingChanged`/`onSubmit` 클로저, `becomeFirstResponder()`/`resignFirstResponder()` 포워딩(스펙 §7 Ref API의 focus/blur 대응), `keyboardType`/`returnKeyType` passthrough. 다크모드 시 `layer.borderColor` CGColor·`defaultTextAttributes` 재주입(traitCollectionDidChange). readOnly는 delegate에서 문자 변경만 차단
- SwiftUI: `Binding<String>` + `@FocusState`. readOnly는 `TextField` 대신 `.textSelection(.enabled)` `Text`로 렌더(SwiftUI TextField에 readOnly 부재). 키보드 옵션·제출은 표준 modifier(`.keyboardType`, `.onSubmit`) 상속
- 너비는 컨테이너 책임 — public resizing/isFullWidth 류 API 없음. min-width 40 제약만 컴포넌트가 보유

### TextInputAffix — `BezierTextInputAffix` / `SUBezierTextInputAffix`

- 슬롯 전용 접사 텍스트 (`https://`, `%` 등). `textLarge(weight: .regular)` + `textNeutralLight`
- Figma의 size 축(medium/large)은 두 값의 typography가 동일해 코드에서는 축 없이 단일 뷰
- Figma description "Do not place standalone"에 따라 doc comment로 단독 배치 금지 안내

### Examples

- `TextInputCatalog` — variant/size/hasError/readOnly/isEnabled/allowClear/슬롯(icon·affix) 매트릭스를 실시간 조작, SwiftUI·UIKit 나란히 비교. UIKit 값은 `onTextChanged` → Binding으로 동기화, 실제 포커스·입력·clear 동작 확인 가능

## Spec 검증

figma-component-spec 3단계 사이클로 검증했습니다 (Figma = SSOT, Mobile CS `3612:2` 40 variants + Internal/TextInputAffix `4453:12044`):

- Phase 1: Figma 실측 기반 `SPEC.md` 작성 (variant 2 × size 2 × state 5 × hasValue 2 = 40개 심볼 전수 매핑)
- Phase 2: Properties / Layout / Color / Typography / Asset / Spec Noise / Implementation Reference 7종 병렬 검증 전부 통과
  - Asset Validator 실측 반영: Figma passwordToggle 아이콘의 정적 렌더는 view 형상(slash 없음) — SPEC에 실측대로 기록
  - Implementation Reference Validator 관찰: Figma `color/state/active` raw `#000000D9`(85%) vs 코드 `BCSemanticToken.stateActive`(black80) 괴리 존재 — 토큰 파이프라인 이슈로 이 PR 스코프 밖, 구현은 semantic 토큰 사용이라 영향 없음
- Phase 3: UIKit·SwiftUI Implementation Validator로 구현–SPEC 일치 확인
- Figma에 없는 구현 결정은 `SPEC.md` §8에 분리 기록:
  - passwordToggle iOS 미구현 (design spec doc상 Android 전용 — secure entry 자체를 v1 스코프 제외)
  - INNER_SHADOW(spread 1.5) → UIKit `layer.borderWidth` / SwiftUI `strokeBorder` 등가 구현
  - 단일 행 UITextField 특성상 line-height 24 미적용(고정 높이 중앙 정렬로 시각 동일), font 16 + kern -0.1만 적용
  - readOnly의 SwiftUI 구현(Text + textSelection), copyButton 등 웹 전용 요소 스코프 제외

## 시뮬레이터 검증 (iPhone 16 / iOS 18.6)

라이트/다크 × variant × size × 상태 매트릭스와 포커스 전환·입력·clear 동작을 실기 확인했습니다. 검증 중 발견·수정 2건:

1. **SwiftUI disabled 이중 블렌딩** — `.opacity()`는 per-view 곱이라 배경·보더가 겹치는 링 영역이 이중 블렌딩됨 → `.compositingGroup()` 선행으로 UIKit `self.alpha`와 동일한 합성 결과 보장
2. **UIKit 데모 representable 레이아웃** — `BezierTextInput`을 representable 루트로 직접 반환하면 내부 스택의 trailing 제약이 갱신되지 않아 콘텐츠가 hug 폭으로 붙는 문제 → 저장소 관례(Banner/BaseItem 데모)대로 wrapper UIView에 pin (컴포넌트 자체는 일반 Auto Layout 사용 시 정상)

## 스크린샷

<!-- Screenshots-MOB-6346/ 로컬 캡처 — 첨부 예정 -->

| 기본 (placeholder) | 포커스 | 입력+allowClear | clear 후 포커스 유지 |
|---|---|---|---|
| <!-- screenshot: 01-light-primary-medium-placeholder.png --> | <!-- screenshot: 02-light-primary-medium-focused.png --> | <!-- screenshot: 03-light-focused-filled-allowclear.png --> | <!-- screenshot: 04-light-after-clear-focus-kept.png --> |

| UIKit 포커스+입력 | error | readOnly | disabled |
|---|---|---|---|
| <!-- screenshot: 05-light-uikit-focused-filled.png --> | <!-- screenshot: 06-light-error.png --> | <!-- screenshot: 07-light-readonly-filled.png --> | <!-- screenshot: 08-light-disabled.png --> |

| secondary 기본 | secondary 포커스 | small+affix | dark |
|---|---|---|---|
| <!-- screenshot: 09-light-secondary-default.png --> | <!-- screenshot: 10-light-secondary-focused.png --> | <!-- screenshot: 11-light-small-affix.png --> | <!-- screenshot: 12-dark-small-affix-focused.png --> <!-- screenshot: 13-dark-medium-icon.png --> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * SwiftUI와 UIKit에서 사용할 수 있는 단일 행 텍스트 입력 컴포넌트를 추가했습니다.
  * 기본·보조 스타일과 소형·중형 크기를 지원합니다.
  * 오류, 읽기 전용, 비활성화, 포커스 상태를 제공합니다.
  * 앞·뒤 콘텐츠, 지우기 버튼, 플레이스홀더 및 키보드 동작을 지원합니다.
  * 텍스트 접사 표시 컴포넌트를 추가했습니다.
  * 다양한 입력 상태를 확인할 수 있는 카탈로그 화면을 제공합니다.

* **문서**
  * 텍스트 입력 컴포넌트의 레이아웃, 스타일, 상태 및 상호작용 사양을 문서화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->