### PR TITLE
[MOB-6341] BezierCard 컴포넌트 구현 (UIKit + SwiftUI)

### DIFF
--- a/Examples/BezierExamples/BezierExamples/App/CatalogRegistry.swift
+++ b/Examples/BezierExamples/BezierExamples/App/CatalogRegistry.swift
@@ -107,6 +107,12 @@ enum CatalogRegistry {
       destination: AnyView(BannerCatalog())
     ),
     CatalogItem(
+      id: "card",
+      title: "Card",
+      section: .v3Components,
+      destination: AnyView(CardCatalog())
+    ),
+    CatalogItem(
       id: "section",
       title: "Section",
       section: .v3Components,

--- a/Examples/BezierExamples/BezierExamples/Components/CardCatalog.swift
+++ b/Examples/BezierExamples/BezierExamples/Components/CardCatalog.swift
@@ -1,0 +1,168 @@
+import SwiftUI
+import UIKit
+import BezierSwift
+
+struct CardCatalog: View {
+  @State private var rowCount = 2
+  @State private var showsFreeContent = true
+
+  private static let rowTitles = ["운영시간 설정", "휴무일 설정", "부재중 메시지", "자동 응답", "상담 분배"]
+
+  private var rows: [String] {
+    Array(Self.rowTitles.prefix(self.rowCount))
+  }
+
+  var body: some View {
+    CatalogScreen(title: "Card") {
+      self.controls
+      CatalogSection(.swiftUI) { self.swiftUIPreview }
+      CatalogSection(.uiKit) { self.uiKitPreview }
+    }
+  }
+
+  private var controls: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Stepper("rows: \(self.rowCount)", value: self.$rowCount, in: 1...Self.rowTitles.count)
+      Toggle("자유 콘텐츠 카드", isOn: self.$showsFreeContent)
+    }
+    .font(.caption)
+  }
+
+  // MARK: - SwiftUI
+
+  private var swiftUIPreview: some View {
+    VStack(alignment: .leading, spacing: 16) {
+      Text("리스트 콘텐츠")
+        .font(.caption2)
+        .foregroundStyle(.secondary)
+
+      SUBezierCard {
+        VStack(alignment: .leading, spacing: 0) {
+          ForEach(self.rows, id: \.self) { title in
+            self.swiftUIRow(title)
+          }
+        }
+      }
+
+      if self.showsFreeContent {
+        Text("자유 콘텐츠")
+          .font(.caption2)
+          .foregroundStyle(.secondary)
+
+        SUBezierCard {
+          VStack(alignment: .leading, spacing: 4) {
+            Text("운영시간")
+              .font(.system(size: 15, weight: .semibold))
+            Text("설정한 운영시간에만 상담을 받습니다.")
+              .font(.system(size: 13))
+              .foregroundStyle(.secondary)
+          }
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .padding(16)
+        }
+      }
+    }
+  }
+
+  private func swiftUIRow(_ title: String) -> some View {
+    SUBezierBaseItem(
+      title: title,
+      onTap: {},
+      leading: {
+        BezierIcon.settings.image
+          .renderingMode(.template)
+          .resizable()
+          .scaledToFit()
+          .foregroundColor(.secondary)
+      },
+      trailing: {
+        BezierIcon.chevronSmallRight.image
+          .renderingMode(.template)
+          .resizable()
+          .scaledToFit()
+          .frame(width: 20, height: 20)
+          .foregroundColor(.secondary)
+      }
+    )
+  }
+
+  // MARK: - UIKit
+
+  private var uiKitPreview: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Text("BezierCard")
+        .font(.caption2)
+        .foregroundStyle(.secondary)
+
+      CardRepresentable(rows: self.rows)
+    }
+  }
+}
+
+// MARK: - Representable
+
+private struct CardRepresentable: UIViewRepresentable {
+  let rows: [String]
+
+  func makeUIView(context: Context) -> UIView {
+    let wrapper = UIView()
+    let card = BezierCard(content: Self.makeContentStackView())
+    self.apply(to: card)
+    wrapper.addSubview(card)
+    NSLayoutConstraint.activate([
+      card.topAnchor.constraint(equalTo: wrapper.topAnchor),
+      card.leadingAnchor.constraint(equalTo: wrapper.leadingAnchor),
+      card.trailingAnchor.constraint(equalTo: wrapper.trailingAnchor),
+      card.bottomAnchor.constraint(equalTo: wrapper.bottomAnchor),
+    ])
+    return wrapper
+  }
+
+  func updateUIView(_ wrapper: UIView, context: Context) {
+    guard let card = wrapper.subviews.first as? BezierCard else { return }
+    self.apply(to: card)
+  }
+
+  func sizeThatFits(_ proposal: ProposedViewSize, uiView: UIView, context: Context) -> CGSize? {
+    let width = proposal.width ?? 320
+    let fitting = uiView.systemLayoutSizeFitting(
+      CGSize(width: width, height: UIView.layoutFittingCompressedSize.height),
+      withHorizontalFittingPriority: .required,
+      verticalFittingPriority: .fittingSizeLevel
+    )
+    return CGSize(width: width, height: fitting.height)
+  }
+
+  private func apply(to card: BezierCard) {
+    guard let stackView = card.content as? UIStackView else { return }
+
+    if stackView.arrangedSubviews.count != self.rows.count {
+      stackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+      self.rows.map(Self.makeRow).forEach(stackView.addArrangedSubview)
+    } else {
+      for case let (row, title) in zip(stackView.arrangedSubviews, self.rows) {
+        (row as? BezierBaseItem)?.title = title
+      }
+    }
+  }
+
+  private static func makeContentStackView() -> UIStackView {
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    stackView.alignment = .fill
+    stackView.distribution = .fill
+    stackView.spacing = 0
+    return stackView
+  }
+
+  private static func makeRow(_ title: String) -> BezierBaseItem {
+    let item = BezierBaseItem(title: title, onTap: {})
+    let imageView = UIImageView(
+      image: BezierIcon.settings.uiImage?.withRenderingMode(.alwaysTemplate)
+    )
+    imageView.contentMode = .scaleAspectFit
+    imageView.tintColor = .secondaryLabel
+    item.leadingContent = imageView
+    return item
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierCard/BezierCard.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierCard/BezierCard.swift
@@ -1,0 +1,85 @@
+//
+//  BezierCard.swift
+//  BezierSwift
+//
+
+import UIKit
+
+/// 콘텐츠를 하나의 독립 묶음으로 감싸는 카드 컨테이너 (UIKit). `surface` 배경 + 1pt `borderNeutral` 테두리 + radius 16의 외형만 소유하고 내용은 `content` 슬롯에 위임한다. 너비는 소비자 제약으로 정하고 높이는 콘텐츠에 맞게 늘어난다. SwiftUI에서는 `SUBezierCard`를 사용한다.
+public final class BezierCard: UIView, BezierComponentable {
+  // MARK: - BezierComponentable
+
+  public var colorTheme: BezierColorTheme { .systemBezierColorTheme() }
+  public var componentTheme: BezierComponentTheme = .normal {
+    didSet { self.refreshAppearance() }
+  }
+
+  // MARK: - Public Properties
+
+  /// 카드 안(contentSlot)에 넣을 뷰. 패딩 안쪽을 가득 채우며 `nil`이면 비운다 (기본값 `nil`).
+  public var content: UIView? {
+    didSet { self.updateContent(old: oldValue, new: self.content) }
+  }
+
+  // MARK: - Init
+
+  /// 콘텐츠 뷰로 카드를 만든다. 콘텐츠는 이후 `content`로 교체할 수 있다.
+  public init(content: UIView? = nil) {
+    self.content = content
+    super.init(frame: .zero)
+    self.setUp()
+  }
+
+  public required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    self.setUp()
+  }
+
+  // MARK: - Setup
+
+  private func setUp() {
+    self.translatesAutoresizingMaskIntoConstraints = false
+    self.layer.masksToBounds = true
+    self.layer.cornerRadius = BezierCardConstant.cornerRadius
+    self.layer.borderWidth = BezierCardConstant.borderWidth
+    self.insetsLayoutMarginsFromSafeArea = false
+    self.directionalLayoutMargins = NSDirectionalEdgeInsets(
+      top: BezierCardConstant.verticalPadding,
+      leading: BezierCardConstant.horizontalPadding,
+      bottom: BezierCardConstant.verticalPadding,
+      trailing: BezierCardConstant.horizontalPadding
+    )
+
+    self.updateContent(old: nil, new: self.content)
+    self.refreshAppearance()
+  }
+
+  // MARK: - Trait
+
+  public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    self.refreshAppearance()
+  }
+
+  // MARK: - Refresh
+
+  private func updateContent(old: UIView?, new: UIView?) {
+    old?.removeFromSuperview()
+    guard let new = new else { return }
+
+    new.translatesAutoresizingMaskIntoConstraints = false
+    self.addSubview(new)
+    let margins = self.layoutMarginsGuide
+    NSLayoutConstraint.activate([
+      new.topAnchor.constraint(equalTo: margins.topAnchor),
+      new.leadingAnchor.constraint(equalTo: margins.leadingAnchor),
+      new.trailingAnchor.constraint(equalTo: margins.trailingAnchor),
+      new.bottomAnchor.constraint(equalTo: margins.bottomAnchor),
+    ])
+  }
+
+  private func refreshAppearance() {
+    self.backgroundColor = BezierCardConstant.backgroundColor.palette(self)
+    self.layer.borderColor = BezierCardConstant.borderColor.palette(self).cgColor
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierCard/BezierCardSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierCard/BezierCardSpec.swift
@@ -1,0 +1,16 @@
+//
+//  BezierCardSpec.swift
+//  BezierSwift
+//
+
+import CoreGraphics
+
+public enum BezierCardConstant {
+  public static let cornerRadius: CGFloat = 16
+  public static let borderWidth: CGFloat = 1
+  public static let verticalPadding: CGFloat = 2
+  public static let horizontalPadding: CGFloat = 4
+
+  static let backgroundColor: BCSemanticToken = .surface
+  static let borderColor: BCSemanticToken = .borderNeutral
+}

--- a/Sources/BezierSwift/MasterComponent/BezierCard/SPEC.md
+++ b/Sources/BezierSwift/MasterComponent/BezierCard/SPEC.md
@@ -1,0 +1,68 @@
+# BezierCard SPEC
+
+> **SSOT**: [Figma · Mobile-Components / Card (4990:10601)](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=5039-12108)
+> **Design spec doc**: [team-design / bezier-v3 / components / Card-spec.md](https://github.com/channel-io/team-design/blob/main/bezier-v3/components/Card-spec.md) (보조 참조 — 값 충돌 시 Figma 파일 우선)
+
+단일 주제·엔티티에 관한 콘텐츠를 하나의 독립 묶음으로 구분하는 범용 레이아웃 컨테이너. 배경·테두리·radius·padding만 소유하고 내용은 contentSlot에 위임한다.
+
+## 1. Component Properties
+
+### Card (COMPONENT `4990:10601`)
+
+| Property | 값 | 비고 |
+|---|---|---|
+| **contentSlot** | SLOT | 내부 콘텐츠 자유 배치 영역 |
+
+variant / state 축 없음 — 단일 COMPONENT (component set 아님).
+
+총 instance: 1개 (`4990:10601`)
+
+## 2. Layout Spec
+
+| Part | 값 |
+|---|---|
+| 컨테이너 너비 | FIXED (Figma 값 361pt) |
+| 컨테이너 높이 | HUG — contentSlot 높이 + 상하 패딩 |
+| 패딩 | 상하 `2pt`, 좌우 `4pt` |
+| radius | `16pt` (`radius/16`) |
+| 테두리 | `1pt` solid |
+| overflow | clip (radius 밖 콘텐츠 잘림) |
+| contentSlot | FILL × HUG (너비는 패딩 안쪽을 채우고 높이는 자식에 맞춤) |
+
+## 3. 컬러 토큰
+
+| 영역 | Token | Figma Variable | Raw |
+|---|---|---|---|
+| 배경 | `surface` | `color/surface` | `#FFFFFF` |
+| 테두리 | `borderNeutral` | `color/border/neutral` | `#00000014` |
+
+## 4. Typography
+
+이 컴포넌트에 텍스트 없음.
+
+## 5. State 별 시각 동작
+
+Figma CS에 state variant 축 없음 (정적 레이아웃 컨테이너).
+
+## 6. 매핑되는 코드 심볼
+
+| 정의 | 파일 |
+|---|---|
+| UIKit 구현 | `BezierCard.swift` |
+| SwiftUI 구현 | `SUBezierCard.swift` |
+| constant | `BezierCardSpec.swift` |
+
+## 7. Figma 외 · 협의 사항
+
+Figma에 없는 구현 아키텍처 결정은 아래에 분리 표기한다. SSOT 값이 아니다.
+
+1. **단일 슬롯 API**: Figma contentSlot(SLOT 1개)을 UIKit은 `content: UIView?` 프로퍼티(BezierBaseItem 슬롯 idiom), SwiftUI는 `@ViewBuilder content`로 표현한다.
+2. **너비 거동**: Figma 컨테이너 FIXED(사용처 지정)를 UIKit은 소비자 제약, SwiftUI는 제안 폭 채움(`maxWidth: .infinity`)으로 해석 — `SUBezierSection` card variant와 동형. public resizing API는 두지 않는다(배치는 컨테이너 책임).
+3. **componentTheme 지원**: UIKit `BezierComponentable`(normal/inverted) 채택 — `BezierSection`과 동형.
+4. **후속 합성**: Form(MOB-6351)이 이 컨테이너를 조합할 예정 — Card는 chrome(배경·테두리·radius·패딩)만 소유하고 콘텐츠 규칙을 부과하지 않는다.
+
+## 8. Variant 매트릭스
+
+```
+Card: 단일 COMPONENT = 4990:10601 (variant 없음, 총 1)
+```

--- a/Sources/BezierSwift/MasterComponent/BezierCard/SUBezierCard.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierCard/SUBezierCard.swift
@@ -1,0 +1,64 @@
+//
+//  SUBezierCard.swift
+//  BezierSwift
+//
+
+import SwiftUI
+
+/// 콘텐츠를 하나의 독립 묶음으로 감싸는 카드 컨테이너 (SwiftUI). `surface` 배경 + 1pt `borderNeutral` 테두리 + radius 16의 외형만 소유하고 내용은 `content`에 위임한다. 제안받은 너비를 채우고 높이는 콘텐츠에 맞게 늘어난다. UIKit에서는 `BezierCard`를 사용한다.
+public struct SUBezierCard<Content: View>: View, Themeable {
+  @Environment(\.colorScheme) public var colorScheme
+
+  private let content: Content
+
+  /// 카드 안(contentSlot)에 그릴 콘텐츠로 카드를 만든다.
+  public init(@ViewBuilder content: () -> Content) {
+    self.content = content()
+  }
+
+  public var body: some View {
+    self.content
+      .padding(
+        EdgeInsets(
+          top: BezierCardConstant.verticalPadding,
+          leading: BezierCardConstant.horizontalPadding,
+          bottom: BezierCardConstant.verticalPadding,
+          trailing: BezierCardConstant.horizontalPadding
+        )
+      )
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .background(
+        RoundedRectangle(cornerRadius: BezierCardConstant.cornerRadius)
+          .fill(self.palette(BezierCardConstant.backgroundColor))
+      )
+      .overlay(
+        RoundedRectangle(cornerRadius: BezierCardConstant.cornerRadius)
+          .strokeBorder(
+            self.palette(BezierCardConstant.borderColor),
+            lineWidth: BezierCardConstant.borderWidth
+          )
+      )
+      .clipShape(RoundedRectangle(cornerRadius: BezierCardConstant.cornerRadius))
+  }
+}
+
+struct SUBezierCard_Previews: PreviewProvider {
+  static var previews: some View {
+    ScrollView {
+      VStack(spacing: 20) {
+        SUBezierCard {
+          VStack(alignment: .leading, spacing: 8) {
+            Text("제목")
+            Text("설명 텍스트가 들어가는 영역입니다.")
+          }
+          .padding(16)
+        }
+
+        SUBezierCard {
+          Color.clear.frame(height: 120)
+        }
+      }
+      .padding(16)
+    }
+  }
+}


### PR DESCRIPTION
## MOB-6341

https://linear.app/channel/issue/MOB-6341

V3 Card 컴포넌트를 UIKit + SwiftUI로 구현합니다.

## 구현 내용

### Card — `BezierCard` / `SUBezierCard`

- `surface` 배경 + 1pt `borderNeutral` 테두리 + radius 16의 chrome만 소유하는 범용 카드 컨테이너 — 콘텐츠는 단일 슬롯(Figma `contentSlot`)에 위임
- 패딩 상하 2pt / 좌우 4pt, overflow clip. 너비는 소비자가 결정(Figma FIXED), 높이는 콘텐츠 hug
- UIKit: `content: UIView?` 슬롯 (didSet 교체 + layoutMarginsGuide pin), `BezierComponentable`(componentTheme normal/inverted), 다크모드 시 `traitCollectionDidChange`에서 `layer.borderColor` CGColor 재주입
- SwiftUI: `SUBezierCard { ... }` @ViewBuilder 단일 슬롯, 제안 폭 채움(`maxWidth: .infinity`) — `SUBezierSection` card variant와 동형 idiom
- variant/state 축 없음 (Figma 단일 COMPONENT) — public API에 스타일·resizing 축 미노출
- 후속 Form(MOB-6351)이 이 컨테이너를 조합할 예정 — Card는 chrome만 소유하고 콘텐츠 규칙을 부과하지 않습니다

### Examples

- `CardCatalog` — 리스트 콘텐츠(BaseItem rows) / 자유 콘텐츠 카드 2종, row 수 stepper로 높이 hug 동작 확인. UIKit representable은 `sizeThatFits`로 hug 높이 반환

## Spec 검증

figma-component-spec 3단계 사이클로 검증했습니다 (Figma = SSOT):

- Phase 1: Figma 실측 기반 `SPEC.md` 작성 (Mobile-Components / Card `4990:10601`) — team-design spec 문서 헤더의 `figma-mobile-status: not-started` 표기는 stale로 확인 (모바일 파일에 Card COMPONENT 실재, 361×150 · contentSlot 353×146)
- Phase 2: Properties / Layout / Color / Typography / Asset / Spec Noise / Implementation Reference 7종 병렬 검증 전부 통과
- Phase 3: UIKit·SwiftUI Implementation Validator로 구현–SPEC 일치 확인
- Figma에 없는 구현 결정(단일 슬롯 API 형태, SwiftUI 너비 해석, componentTheme 지원, Form 합성 표면)은 `SPEC.md` §7에 협의 사항으로 분리 기록

참고: 모바일 Card의 패딩은 상하 2 / 좌우 4로, web spec(상 20 / 우 24 / 하 16 / 좌 24)과 다릅니다. 모바일 Figma 파일이 이 구현의 SSOT입니다.

## 스크린샷

시뮬레이터(iPhone 16 · iOS 18.6) 라이트/다크 × 리스트/자유 콘텐츠 × rows 변화 검증 완료. 캡처 파일은 로컬 `Screenshots-MOB-6341/`에 있으며 아래 파일명 기준으로 첨부 예정.

| 파일 | 내용 |
|---|---|
| `01-card-light-rows2-list-free.png` | 라이트 · rows 2 · 리스트 + 자유 콘텐츠 카드 (SwiftUI + UIKit) |
| `02-card-light-rows5-swiftui.png` | 라이트 · rows 5 — SwiftUI 카드 높이 hug 성장 |
| `03-card-light-rows5-uikit.png` | 라이트 · rows 5 — UIKit 카드 재주입 + sizeThatFits hug |
| `04-card-light-rows5-list-only.png` | 라이트 · 자유 콘텐츠 토글 off (리스트 카드만) |
| `05-card-dark-rows2-list-free.png` | 다크 — SwiftUI 자동 적응 + UIKit `layer.borderColor` CGColor 재주입 확인 |

## 빌드 검증

- `BezierSwift` 패키지 clean build — BUILD SUCCEEDED (iOS Simulator)
- `BezierExamples` 앱 clean build — BUILD SUCCEEDED (iOS Simulator)
- 시뮬레이터 시각 검증 — 렌더링 결함 없음 (라이트/다크, rows 2·5, 자유 콘텐츠 on/off)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
