### PR TITLE
[MOB-6340] BezierProgressBar 컴포넌트 구현 (UIKit + SwiftUI)

### DIFF
--- a/Examples/BezierExamples/BezierExamples/App/CatalogRegistry.swift
+++ b/Examples/BezierExamples/BezierExamples/App/CatalogRegistry.swift
@@ -83,6 +83,12 @@ enum CatalogRegistry {
       destination: AnyView(DividerCatalog())
     ),
     CatalogItem(
+      id: "progress-bar",
+      title: "ProgressBar",
+      section: .v3Components,
+      destination: AnyView(ProgressBarCatalog())
+    ),
+    CatalogItem(
       id: "modal",
       title: "Modal",
       section: .v3Components,

--- a/Examples/BezierExamples/BezierExamples/Components/ProgressBarCatalog.swift
+++ b/Examples/BezierExamples/BezierExamples/Components/ProgressBarCatalog.swift
@@ -59,15 +59,17 @@ struct ProgressBarCatalog: View {
   }
 
   private var swiftUIPreview: some View {
-    self.demoSurface {
+    self.demoSurface(variant: self.variant) {
       SUBezierProgressBar(value: self.value, variant: self.variant, size: self.size)
     }
+    .padding(.vertical, 8)
   }
 
   private var uiKitPreview: some View {
-    self.demoSurface {
+    self.demoSurface(variant: self.variant) {
       ProgressBarUIKitRepresentable(value: self.value, variant: self.variant, size: self.size)
     }
+    .padding(.vertical, 8)
   }
 
   private var swiftUIMatrix: some View {
@@ -76,7 +78,9 @@ struct ProgressBarCatalog: View {
         ForEach(BezierProgressBarSize.allCases, id: \.self) { size in
           VStack(alignment: .leading, spacing: 4) {
             self.matrixLabel(variant: variant, size: size)
-            SUBezierProgressBar(value: self.value, variant: variant, size: size)
+            self.demoSurface(variant: variant) {
+              SUBezierProgressBar(value: self.value, variant: variant, size: size)
+            }
           }
         }
       }
@@ -90,7 +94,9 @@ struct ProgressBarCatalog: View {
         ForEach(BezierProgressBarSize.allCases, id: \.self) { size in
           VStack(alignment: .leading, spacing: 4) {
             self.matrixLabel(variant: variant, size: size)
-            ProgressBarUIKitRepresentable(value: self.value, variant: variant, size: size)
+            self.demoSurface(variant: variant) {
+              ProgressBarUIKitRepresentable(value: self.value, variant: variant, size: size)
+            }
           }
         }
       }
@@ -106,15 +112,17 @@ struct ProgressBarCatalog: View {
 
   // overlaid variant는 콘텐츠 위 겹침 용도라 회색 콘텐츠 배경을 깔아 사용 맥락을 재현한다.
   @ViewBuilder
-  private func demoSurface<Content: View>(@ViewBuilder content: () -> Content) -> some View {
-    if self.variant == .overlaid {
+  private func demoSurface<Content: View>(
+    variant: BezierProgressBarVariant,
+    @ViewBuilder content: () -> Content
+  ) -> some View {
+    if variant == .overlaid {
       content()
         .padding(12)
         .background(RoundedRectangle(cornerRadius: 8).fill(Color(.systemGray3)))
-        .padding(.vertical, 8)
     } else {
       content()
-        .padding(.vertical, 12)
+        .padding(.vertical, 4)
     }
   }
 }

--- a/Examples/BezierExamples/BezierExamples/Components/ProgressBarCatalog.swift
+++ b/Examples/BezierExamples/BezierExamples/Components/ProgressBarCatalog.swift
@@ -1,0 +1,143 @@
+import SwiftUI
+import UIKit
+import BezierSwift
+
+struct ProgressBarCatalog: View {
+  @State private var value: Double = 0.6
+  @State private var variant: BezierProgressBarVariant = .default
+  @State private var size: BezierProgressBarSize = .medium
+
+  var body: some View {
+    CatalogScreen(title: "ProgressBar") {
+      self.controls
+      CatalogSection(.swiftUI) { self.swiftUIPreview }
+      CatalogSection(.uiKit) { self.uiKitPreview }
+      Text("Variant × Size")
+        .font(.system(size: 13, weight: .semibold))
+        .foregroundStyle(.secondary)
+        .textCase(.uppercase)
+      CatalogSection(.swiftUI) { self.swiftUIMatrix }
+      CatalogSection(.uiKit) { self.uiKitMatrix }
+    }
+  }
+
+  private var controls: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      HStack(spacing: 8) {
+        Text("Variant").font(.caption).foregroundStyle(.secondary).frame(width: 72, alignment: .leading)
+        Picker("Variant", selection: self.$variant) {
+          ForEach(BezierProgressBarVariant.allCases, id: \.self) { variant in
+            Text(variant.rawValue).tag(variant)
+          }
+        }
+        .pickerStyle(.segmented)
+      }
+      HStack(spacing: 8) {
+        Text("Size").font(.caption).foregroundStyle(.secondary).frame(width: 72, alignment: .leading)
+        Picker("Size", selection: self.$size) {
+          ForEach(BezierProgressBarSize.allCases, id: \.self) { size in
+            Text(size.rawValue).tag(size)
+          }
+        }
+        .pickerStyle(.segmented)
+      }
+      HStack(spacing: 8) {
+        Text("Value").font(.caption).foregroundStyle(.secondary).frame(width: 72, alignment: .leading)
+        Slider(value: self.$value, in: 0...1)
+        Text("\(Int((self.value * 100).rounded()))%")
+          .font(.caption.monospacedDigit())
+          .frame(width: 44, alignment: .trailing)
+      }
+      HStack(spacing: 8) {
+        ForEach([0.0, 0.25, 0.5, 0.75, 1.0], id: \.self) { preset in
+          Button("\(Int(preset * 100))%") { self.value = preset }
+            .font(.caption)
+            .buttonStyle(.bordered)
+        }
+      }
+    }
+  }
+
+  private var swiftUIPreview: some View {
+    self.demoSurface {
+      SUBezierProgressBar(value: self.value, variant: self.variant, size: self.size)
+    }
+  }
+
+  private var uiKitPreview: some View {
+    self.demoSurface {
+      ProgressBarUIKitRepresentable(value: self.value, variant: self.variant, size: self.size)
+    }
+  }
+
+  private var swiftUIMatrix: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      ForEach(BezierProgressBarVariant.allCases, id: \.self) { variant in
+        ForEach(BezierProgressBarSize.allCases, id: \.self) { size in
+          VStack(alignment: .leading, spacing: 4) {
+            self.matrixLabel(variant: variant, size: size)
+            SUBezierProgressBar(value: self.value, variant: variant, size: size)
+          }
+        }
+      }
+    }
+    .padding(.vertical, 8)
+  }
+
+  private var uiKitMatrix: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      ForEach(BezierProgressBarVariant.allCases, id: \.self) { variant in
+        ForEach(BezierProgressBarSize.allCases, id: \.self) { size in
+          VStack(alignment: .leading, spacing: 4) {
+            self.matrixLabel(variant: variant, size: size)
+            ProgressBarUIKitRepresentable(value: self.value, variant: variant, size: size)
+          }
+        }
+      }
+    }
+    .padding(.vertical, 8)
+  }
+
+  private func matrixLabel(variant: BezierProgressBarVariant, size: BezierProgressBarSize) -> some View {
+    Text("\(variant.rawValue) / \(size.rawValue)")
+      .font(.caption2)
+      .foregroundStyle(.secondary)
+  }
+
+  // overlaid variant는 콘텐츠 위 겹침 용도라 회색 콘텐츠 배경을 깔아 사용 맥락을 재현한다.
+  @ViewBuilder
+  private func demoSurface<Content: View>(@ViewBuilder content: () -> Content) -> some View {
+    if self.variant == .overlaid {
+      content()
+        .padding(12)
+        .background(RoundedRectangle(cornerRadius: 8).fill(Color(.systemGray3)))
+        .padding(.vertical, 8)
+    } else {
+      content()
+        .padding(.vertical, 12)
+    }
+  }
+}
+
+// UIKitWrap은 systemLayoutSizeFitting(.fittingSizeLevel)로 너비를 계산하는데,
+// BezierProgressBar는 intrinsic width가 없어 너비가 0으로 접힌다. 프리뷰에서 바가
+// 보이도록 sizeThatFits가 제안 너비를 그대로 반환하는 전용 래퍼를 사용한다.
+private struct ProgressBarUIKitRepresentable: UIViewRepresentable {
+  let value: Double
+  let variant: BezierProgressBarVariant
+  let size: BezierProgressBarSize
+
+  func makeUIView(context: Context) -> BezierProgressBar {
+    BezierProgressBar(value: CGFloat(self.value), variant: self.variant, size: self.size)
+  }
+
+  func updateUIView(_ uiView: BezierProgressBar, context: Context) {
+    uiView.variant = self.variant
+    uiView.size = self.size
+    uiView.setValue(CGFloat(self.value), animated: true)
+  }
+
+  func sizeThatFits(_ proposal: ProposedViewSize, uiView: BezierProgressBar, context: Context) -> CGSize? {
+    CGSize(width: proposal.width ?? 320, height: self.size.height)
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierProgressBar/BezierProgressBar.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierProgressBar/BezierProgressBar.swift
@@ -1,0 +1,124 @@
+//
+//  BezierProgressBar.swift
+//  BezierSwift
+//
+
+import UIKit
+
+/// 작업의 진행률을 0~1 범위의 색상 바로 시각화하는 컴포넌트 (UIKit). 진행률을 모르는 불확정 로딩에는 `BezierSpinner`를 사용한다. 가로 폭은 컨테이너가 결정한다 (intrinsic width 없음). SwiftUI에서는 `SUBezierProgressBar`를 사용한다.
+public final class BezierProgressBar: UIView, BezierComponentable {
+  // MARK: - BezierComponentable
+
+  public var colorTheme: BezierColorTheme { .systemBezierColorTheme() }
+  public var componentTheme: BezierComponentTheme = .normal {
+    didSet { self.refreshAppearance() }
+  }
+
+  // MARK: - Public Properties
+
+  /// 색상 변형. 기본값은 `.default`다.
+  public var variant: BezierProgressBarVariant = .default {
+    didSet { if oldValue != self.variant { self.refreshAppearance() } }
+  }
+
+  /// 바 크기. 기본값은 `.medium`이다.
+  public var size: BezierProgressBarSize = .medium {
+    didSet { if oldValue != self.size { self.refreshLayout() } }
+  }
+
+  /// 진행률. 0~1 범위를 벗어난 값은 clamp된다. 애니메이션 없이 즉시 반영되며, 애니메이션이 필요하면 `setValue(_:animated:)`를 사용한다.
+  public var value: CGFloat {
+    get { self.clampedValue }
+    set { self.setValue(newValue, animated: false) }
+  }
+
+  // MARK: - Private Properties
+
+  private var clampedValue: CGFloat
+
+  // MARK: - Subviews
+
+  private let activeView = UIView()
+
+  // MARK: - Init
+
+  /// 진행률(0~1, 범위 밖 값은 clamp)·색상 변형·크기를 지정해 생성한다.
+  public init(
+    value: CGFloat = 0,
+    variant: BezierProgressBarVariant = .default,
+    size: BezierProgressBarSize = .medium
+  ) {
+    self.clampedValue = min(max(value, 0), 1)
+    self.variant = variant
+    self.size = size
+    super.init(frame: .zero)
+    self.setUp()
+  }
+
+  public required init?(coder: NSCoder) {
+    self.clampedValue = 0
+    super.init(coder: coder)
+    self.setUp()
+  }
+
+  // MARK: - Public Methods
+
+  /// 진행률을 갱신한다. 0~1 범위를 벗어난 값은 clamp된다. `animated`가 `true`면 진행 바 너비가 easeInOut으로 전환되며, 시스템 Reduce Motion이 켜져 있으면 애니메이션을 생략한다.
+  public func setValue(_ value: CGFloat, animated: Bool) {
+    let clamped = min(max(value, 0), 1)
+    guard clamped != self.clampedValue else { return }
+    self.clampedValue = clamped
+
+    self.setNeedsLayout()
+    if animated && !UIAccessibility.isReduceMotionEnabled {
+      UIView.animate(
+        withDuration: BezierProgressBarConstant.animationDuration,
+        delay: 0,
+        options: [.curveEaseInOut, .beginFromCurrentState]
+      ) {
+        self.layoutIfNeeded()
+      }
+    }
+  }
+
+  // MARK: - Setup
+
+  private func setUp() {
+    self.translatesAutoresizingMaskIntoConstraints = false
+    self.isUserInteractionEnabled = false
+    self.addSubview(self.activeView)
+
+    self.refreshLayout()
+    self.refreshAppearance()
+  }
+
+  // MARK: - Layout
+
+  public override var intrinsicContentSize: CGSize {
+    CGSize(width: UIView.noIntrinsicMetric, height: self.size.height)
+  }
+
+  public override func layoutSubviews() {
+    super.layoutSubviews()
+    self.activeView.frame = CGRect(
+      x: 0,
+      y: 0,
+      width: self.bounds.width * self.clampedValue,
+      height: self.bounds.height
+    )
+  }
+
+  // MARK: - Refresh
+
+  private func refreshLayout() {
+    self.layer.cornerRadius = self.size.cornerRadius
+    self.activeView.layer.cornerRadius = self.size.cornerRadius
+    self.invalidateIntrinsicContentSize()
+    self.setNeedsLayout()
+  }
+
+  private func refreshAppearance() {
+    self.backgroundColor = self.variant.trackColorToken.palette(self)
+    self.activeView.backgroundColor = self.variant.activeColorToken.palette(self)
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierProgressBar/BezierProgressBarSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierProgressBar/BezierProgressBarSpec.swift
@@ -1,0 +1,57 @@
+//
+//  BezierProgressBarSpec.swift
+//  BezierSwift
+//
+
+import Foundation
+
+// MARK: - ProgressBar Variant
+
+/// 프로그레스 바의 색상 변형. Figma `ProgressBar` 컴포넌트의 `variant` 프로퍼티에 대응 (case 이름 = Figma 값). 트랙(배경) 색만 다르고 진행 바 색은 공통이다. 바가 놓이는 배경에 맞춰 고른다.
+public enum BezierProgressBarVariant: String, CaseIterable {
+  /// 기본값. 화면 바탕 등 일반 배경 위에 놓을 때 쓴다.
+  case `default`
+  /// 이미지·파일 썸네일 등 콘텐츠 위에 겹쳐 놓을 때 쓴다. 트랙이 불투명해 콘텐츠 위에서도 식별된다.
+  case overlaid
+
+  var trackColorToken: BCSemanticToken {
+    switch self {
+    case .default: return .fillNeutralHeavy
+    case .overlaid: return .fillGreyHeavier
+    }
+  }
+
+  var activeColorToken: BCSemanticToken {
+    .fillNeutralHeaviest
+  }
+}
+
+// MARK: - ProgressBar Size
+
+/// 프로그레스 바의 크기. Figma `ProgressBar` 컴포넌트의 `size` 프로퍼티에 대응 (case 이름 = Figma 값). 바 높이와 corner radius를 결정한다.
+public enum BezierProgressBarSize: String, CaseIterable {
+  /// 기본값. 사용자 주의가 집중되는 독립적 진행률 표시에 쓴다. 높이 6pt.
+  case medium
+  /// 콘텐츠 위 겹침·좁은 공간 등 보조적 진행률 표시에 쓴다. 높이 4pt.
+  case small
+
+  public var height: CGFloat {
+    switch self {
+    case .medium: return 6
+    case .small: return 4
+    }
+  }
+
+  public var cornerRadius: CGFloat {
+    switch self {
+    case .medium: return 3
+    case .small: return 2
+    }
+  }
+}
+
+// MARK: - ProgressBar Constant
+
+public enum BezierProgressBarConstant {
+  public static let animationDuration: TimeInterval = 0.3
+}

--- a/Sources/BezierSwift/MasterComponent/BezierProgressBar/SPEC.md
+++ b/Sources/BezierSwift/MasterComponent/BezierProgressBar/SPEC.md
@@ -83,7 +83,7 @@ Figma에 없는 구현 결정은 아래에 분리 표기한다. SSOT 값이 아�
 
 총 instance: 2 × 2 = **4개**
 
-```
+```text
 variant=default,  size=medium = 3413:2
 variant=overlaid, size=medium = 3413:4
 variant=default,  size=small  = 3413:6

--- a/Sources/BezierSwift/MasterComponent/BezierProgressBar/SPEC.md
+++ b/Sources/BezierSwift/MasterComponent/BezierProgressBar/SPEC.md
@@ -1,0 +1,91 @@
+# BezierProgressBar SPEC
+
+> **SSOT**: [Figma · Mobile-Components / ProgressBar (3413:10)](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=3413-10)
+> **Design spec doc**: [team-design / bezier-v3 / components / ProgressBar-spec.md](https://github.com/channel-io/team-design/blob/main/bezier-v3/components/ProgressBar-spec.md) (보조 참조 — 값 충돌 시 Figma 파일 우선)
+
+작업의 진행률을 0~100% 범위의 색상 바로 시각화하는 컴포넌트 (Figma component description 1행).
+
+## 1. Component Properties
+
+| Property | 값 | 비고 |
+|---|---|---|
+| **variant** | `default` / `overlaid` | 트랙(배경) 색 결정. 진행 바 색은 공통 |
+| **size** | `medium` / `small` | 바 높이·corner radius 결정 |
+
+총 instance: variant 2 × size 2 = **4개**
+
+## 2. Size 별 Spec
+
+| Size | 높이 | Corner Radius |
+|---|---|---|
+| `medium` | 6pt | 3pt |
+| `small` | 4pt | 2pt |
+
+- 진행 바(ProgressBarActive)는 트랙과 동일한 높이·corner radius, 좌측 정렬.
+- 진행 바 width = 진행률 × 트랙 width (Figma 심볼은 left: 0 / right: 40% — 60% 진행 샘플).
+- Figma 심볼의 트랙 width는 240pt (캔버스 배치 샘플 값).
+
+## 3. Variant 별 컬러 토큰
+
+### 트랙 (배경)
+
+| Variant | Token | Figma Variable | Raw (light) |
+|---|---|---|---|
+| `default` | `fillNeutralHeavy` | `color/fill/neutral/heavy` | `#00000026` |
+| `overlaid` | `fillGreyHeavier` | `color/fill/grey/heavier` | `#EFEFF0` |
+
+### 진행 바 (ProgressBarActive)
+
+| Variant | Token | Figma Variable | Raw (light) |
+|---|---|---|---|
+| `default` / `overlaid` 공통 | `fillNeutralHeaviest` | `color/fill/neutral/heaviest` | `#000000D9` |
+
+## 4. Typography
+
+이 컴포넌트에 텍스트 없음.
+
+## 5. State 별 시각 동작
+
+Figma CS에 state variant 축 없음 (인터랙션 없는 표시 전용 컴포넌트). 진행률 값에 따라 진행 바 width만 변한다.
+
+| 진행률 | 시각 |
+|---|---|
+| 0 | 진행 바 width 0 (트랙만 표시) |
+| 0 < value < 1 | 진행 바 width = value × 트랙 width |
+| 1 | 진행 바가 트랙 전체를 채움 |
+
+## 6. 디자이너 가이드라인 (Figma component description 인용)
+
+- 작업의 진행률을 0~100% 범위의 색상 바로 시각화하는 컴포넌트.
+- variant: default(일반 배경 위) / overlaid(콘텐츠 위 겹침 — 불투명 흰 배경) — (컬러 실측: overlaid 트랙은 현재 `color/fill/grey/heavier` 바인딩)
+- size: medium(6px, 기본) / small(4px)
+- 진행률을 모르면 Spinner 사용. 단계 위치 표시는 Step indicator(커스텀) 사용.
+- 캔버스 노트 (4781:12747): "진행 단계별 애니메이션 정의 필요함" — 진행 애니메이션은 Figma에 미정의.
+
+## 7. 매핑되는 코드 심볼
+
+| 정의 | 파일 |
+|---|---|
+| UIKit 구현 | `BezierProgressBar.swift` |
+| SwiftUI 구현 | `SUBezierProgressBar.swift` |
+| variant / size / constant 정의 | `BezierProgressBarSpec.swift` |
+
+## 8. Figma 외 · 협의 사항
+
+Figma에 없는 구현 결정은 아래에 분리 표기한다. SSOT 값이 아니다.
+
+1. **진행률 값 API**: `value: CGFloat`, 0~1 범위로 clamp (0 미만 → 0, 1 초과 → 1). web(bezier-react)의 0~1 float 관례를 따른다 (android는 0~100 int — 플랫폼별 상이).
+2. **너비**: 배치는 컨테이너 책임 — public width/resizing/isFullWidth API를 제공하지 않는다. UIKit은 intrinsic width 없음(높이만 intrinsic), SwiftUI는 부모가 제안한 폭을 그대로 채운다. Figma 심볼의 240pt는 캔버스 샘플 값.
+3. **진행 애니메이션**: Figma 미정의 (캔버스 노트 "진행 단계별 애니메이션 정의 필요함"). value 변경 시 UIKit `UIView.animate`(0.3s, easeInOut) / SwiftUI `.animation(.easeInOut(duration: 0.3), value:)`로 width 전환. Reduce Motion 활성 시 애니메이션 생략. 디자인 확정 시 값 교체 대상.
+4. **트랙 색 alpha**: `fillNeutralHeavy` 등 fill 토큰은 alpha 내장 — 추가 opacity 곱 금지.
+
+## 9. Variant 매트릭스
+
+총 instance: 2 × 2 = **4개**
+
+```
+variant=default,  size=medium = 3413:2
+variant=overlaid, size=medium = 3413:4
+variant=default,  size=small  = 3413:6
+variant=overlaid, size=small  = 3413:8
+```

--- a/Sources/BezierSwift/MasterComponent/BezierProgressBar/SUBezierProgressBar.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierProgressBar/SUBezierProgressBar.swift
@@ -1,0 +1,62 @@
+//
+//  SUBezierProgressBar.swift
+//  BezierSwift
+//
+
+import SwiftUI
+
+/// 작업의 진행률을 0~1 범위의 색상 바로 시각화하는 컴포넌트 (SwiftUI). 진행률을 모르는 불확정 로딩에는 `SUBezierSpinner`를 사용한다. 가로 폭은 부모가 제안한 너비를 채운다. UIKit에서는 `BezierProgressBar`를 사용한다.
+public struct SUBezierProgressBar: View, Themeable {
+  private let value: CGFloat
+  private let variant: BezierProgressBarVariant
+  private let size: BezierProgressBarSize
+
+  @Environment(\.colorScheme) public var colorScheme
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+  /// 진행률(0~1, 범위 밖 값은 clamp)·색상 변형·크기를 지정해 생성한다. `value` 변경 시 진행 바 너비가 easeInOut으로 전환되며, 시스템 Reduce Motion이 켜져 있으면 애니메이션을 생략한다.
+  public init(
+    value: CGFloat,
+    variant: BezierProgressBarVariant = .default,
+    size: BezierProgressBarSize = .medium
+  ) {
+    self.value = min(max(value, 0), 1)
+    self.variant = variant
+    self.size = size
+  }
+
+  public var body: some View {
+    GeometryReader { proxy in
+      ZStack(alignment: .leading) {
+        RoundedRectangle(cornerRadius: self.size.cornerRadius)
+          .fill(self.palette(self.variant.trackColorToken))
+        RoundedRectangle(cornerRadius: self.size.cornerRadius)
+          .fill(self.palette(self.variant.activeColorToken))
+          .frame(width: proxy.size.width * self.value)
+      }
+      .animation(
+        self.reduceMotion ? nil : .easeInOut(duration: BezierProgressBarConstant.animationDuration),
+        value: self.value
+      )
+    }
+    .frame(height: self.size.height)
+  }
+}
+
+struct SUBezierProgressBar_Previews: PreviewProvider {
+  static var previews: some View {
+    VStack(spacing: 16) {
+      ForEach(BezierProgressBarVariant.allCases, id: \.self) { variant in
+        ForEach(BezierProgressBarSize.allCases, id: \.self) { size in
+          VStack(alignment: .leading, spacing: 4) {
+            Text("\(variant.rawValue) / \(size.rawValue)")
+              .font(.caption2)
+              .foregroundColor(.secondary)
+            SUBezierProgressBar(value: 0.6, variant: variant, size: size)
+          }
+        }
+      }
+    }
+    .padding()
+  }
+}


### PR DESCRIPTION
## MOB-6340

https://linear.app/channel/issue/MOB-6340

V3 ProgressBar 컴포넌트를 UIKit + SwiftUI로 구현합니다.

## 구현 내용

### ProgressBar — `BezierProgressBar` / `SUBezierProgressBar`

- variant `default` / `overlaid` — 트랙 색만 분기 (`fillNeutralHeavy` / `fillGreyHeavier`), 진행 바는 공통 `fillNeutralHeaviest`
- size `medium` / `small` — 높이 6pt / 4pt, corner radius 3pt / 2pt (트랙·진행 바 동일 radius)
- `value` 0~1 clamp (범위 밖 값 자동 보정), 진행 바 width = value × 트랙 width (좌측 정렬)
- 배치는 컨테이너 책임 — public width/resizing API 없음. UIKit은 intrinsic height만 제공(`noIntrinsicMetric` width), SwiftUI는 부모 제안 폭을 채움 (GeometryReader)
- 진행 애니메이션: Figma 미정의(캔버스 노트 "진행 단계별 애니메이션 정의 필요함") — easeInOut 0.3s 잠정 적용, Reduce Motion 활성 시 생략
  - UIKit: `setValue(_:animated:)` + `UIView.animate`, SwiftUI: `.animation(.easeInOut, value:)`
- UIKit 트랙/진행 바 색은 `palette(self)` dynamic UIColor라 다크모드 자동 적응 (CGColor 미사용 — 재주입 불필요)
- Examples 카탈로그 등록: variant/size 세그먼트 + value 슬라이더·프리셋 버튼 실시간 조작, Variant × Size 매트릭스, overlaid는 회색 콘텐츠 배경 위 데모. UIKit 프리뷰는 intrinsic width 부재로 UIKitWrap 대신 proposal.width 반환 전용 representable 사용 (DividerCatalog 선례)

## Spec 검증

figma-component-spec 3단계 사이클로 검증했습니다 (Figma = SSOT, `46idSffz5wpiLD5ykWUFZY` / `3413:10`):

- Phase 1: Figma 실측 기반 `SPEC.md` 작성 (variant 2 × size 2 = 4 심볼: `3413:2/4/6/8`)
- Phase 2: Properties / Layout / Color / Typography / Asset / Spec Noise / Implementation Reference 7종 병렬 검증 전부 통과 (Spec Noise가 지적한 §2 구현 결정 문구 1건은 §8로 정리)
- Phase 3: UIKit·SwiftUI Implementation Validator로 구현–SPEC 일치 확인
- Figma에 없는 구현 결정(value 0~1 clamp, width 미제공 = 컨테이너 책임, 애니메이션 0.3s easeInOut + Reduce Motion, fill 토큰 alpha 내장 — opacity 곱 금지)은 `SPEC.md` §8에 협의 사항으로 분리 기록
- 참고: spec 헤더의 figma-mobile-status는 in-progress지만 Mobile Components 파일에 4개 variant 심볼·토큰 바인딩이 모두 실재함을 실측 확인

## 스크린샷

시뮬레이터(iPhone 16 / iOS 18.6) 라이트·다크 × 진행률(0%/50%/60%/100%) × variant × size 시각 검증 완료. 애니메이션은 20fps 프레임 스트립으로 easeInOut 전환 확인 (05).

| 파일 | 내용 |
|---|---|
| <!-- screenshot: 01-light-default-medium-value50.png --> | 라이트 · default/medium · 50% (SwiftUI + UIKit + 컨트롤) |
| <!-- screenshot: 02-light-variant-size-matrix-value60.png --> | 라이트 · Variant×Size 매트릭스 (SwiftUI 4종 + UIKit 4종) · 60% |
| <!-- screenshot: 03-light-matrix-value0.png --> | 라이트 · 0% (빈 트랙, radius 아티팩트 없음) |
| <!-- screenshot: 04-light-matrix-value100.png --> | 라이트 · 100% (트랙 완전 채움) |
| <!-- screenshot: 05-light-animation-frames-0-to-100.png --> | 0→100% 전환 20fps 프레임 스트립 (easeInOut 0.3s) |
| <!-- screenshot: 06-light-overlaid-medium-value50.png --> | 라이트 · overlaid/medium · 회색 콘텐츠 배경 데모 |
| <!-- screenshot: 07-light-overlaid-small-value50.png --> | 라이트 · overlaid/small |
| <!-- screenshot: 08-dark-default-medium-value50.png --> | 다크 · default/medium (트랙 white/20 · 진행 바 white) |
| <!-- screenshot: 09-dark-variant-size-matrix-value50.png --> | 다크 · Variant×Size 매트릭스 (UIKit 다이내믹 컬러 자동 적응 확인) |
| <!-- screenshot: 10-dark-overlaid-medium-value50.png --> | 다크 · overlaid (트랙 grey750 적응) |

(파일은 `Screenshots-MOB-6340/` 로컬 보관 — 이미지 업로드 후 표 교체 예정)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * UIKit 및 SwiftUI용 ProgressBar 컴포넌트를 추가했습니다.
  * 진행률, 크기, 기본·오버레이 스타일을 지원합니다.
  * 진행률 변경 시 애니메이션을 제공하며, 모션 감소 설정을 반영합니다.
  * 컴포넌트 카탈로그에 ProgressBar 데모와 조합별 미리보기를 추가했습니다.

* **문서**
  * ProgressBar의 크기, 스타일, 색상, 동작 규칙을 문서화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->