### PR TITLE
[MOB-6336] BezierEmoji 컴포넌트 구현 (UIKit + SwiftUI)

### DIFF
--- a/Examples/BezierExamples/BezierExamples/App/CatalogRegistry.swift
+++ b/Examples/BezierExamples/BezierExamples/App/CatalogRegistry.swift
@@ -71,6 +71,12 @@ enum CatalogRegistry {
       destination: AnyView(AvatarGroupCatalog())
     ),
     CatalogItem(
+      id: "emoji",
+      title: "Emoji",
+      section: .v3Components,
+      destination: AnyView(EmojiCatalog())
+    ),
+    CatalogItem(
       id: "spinner",
       title: "Spinner",
       section: .v3Components,

--- a/Examples/BezierExamples/BezierExamples/Components/EmojiCatalog.swift
+++ b/Examples/BezierExamples/BezierExamples/Components/EmojiCatalog.swift
@@ -1,0 +1,122 @@
+import SwiftUI
+import UIKit
+import BezierSwift
+
+struct EmojiCatalog: View {
+  @State private var name: String = "grinning"
+  @State private var size: BezierEmojiSize = .size48
+
+  private let sampleNames = ["grinning", "smiley", "thumbsup", "heart", "tada"]
+
+  var body: some View {
+    CatalogScreen(title: "Emoji") {
+      self.controls
+      CatalogSection(.swiftUI) { self.swiftUIPreview }
+      CatalogSection(.uiKit) { self.uiKitPreview }
+      Text("Size Row")
+        .font(.system(size: 13, weight: .semibold))
+        .foregroundStyle(.secondary)
+        .textCase(.uppercase)
+      CatalogSection(.swiftUI) { self.swiftUISizeRow }
+      CatalogSection(.uiKit) { self.uiKitSizeRow }
+      Text("Names")
+        .font(.system(size: 13, weight: .semibold))
+        .foregroundStyle(.secondary)
+        .textCase(.uppercase)
+      CatalogSection(.swiftUI) { self.swiftUINameRow }
+    }
+  }
+
+  private var controls: some View {
+    VStack(alignment: .leading, spacing: 10) {
+      HStack(spacing: 8) {
+        Text("Name").font(.caption).foregroundStyle(.secondary).frame(width: 72, alignment: .leading)
+        Picker("Name", selection: self.$name) {
+          ForEach(self.sampleNames, id: \.self) { name in
+            Text(name).tag(name)
+          }
+        }
+        .pickerStyle(.menu)
+      }
+      HStack(spacing: 8) {
+        Text("Size").font(.caption).foregroundStyle(.secondary).frame(width: 72, alignment: .leading)
+        Picker("Size", selection: self.$size) {
+          ForEach(BezierEmojiSize.allCases, id: \.self) { size in
+            Text(size.rawValue).tag(size)
+          }
+        }
+        .pickerStyle(.menu)
+      }
+    }
+  }
+
+  private var swiftUIPreview: some View {
+    HStack {
+      Spacer()
+      SUBezierEmoji(name: self.name, size: self.size)
+      Spacer()
+    }
+    .padding(.vertical, 8)
+  }
+
+  private var uiKitPreview: some View {
+    HStack {
+      Spacer()
+      UIKitWrap(
+        { BezierEmoji(name: self.name, size: self.size) },
+        update: { emoji in
+          emoji.name = self.name
+          emoji.size = self.size
+        }
+      )
+      .fixedSize()
+      Spacer()
+    }
+    .padding(.vertical, 8)
+  }
+
+  private var swiftUISizeRow: some View {
+    ScrollView(.horizontal, showsIndicators: false) {
+      HStack(alignment: .bottom, spacing: 12) {
+        ForEach(BezierEmojiSize.allCases, id: \.self) { size in
+          VStack(spacing: 4) {
+            SUBezierEmoji(name: self.name, size: size)
+            Text(size.rawValue).font(.caption2).foregroundStyle(.secondary)
+          }
+        }
+      }
+    }
+  }
+
+  private var uiKitSizeRow: some View {
+    ScrollView(.horizontal, showsIndicators: false) {
+      HStack(alignment: .bottom, spacing: 12) {
+        ForEach(BezierEmojiSize.allCases, id: \.self) { size in
+          VStack(spacing: 4) {
+            UIKitWrap(
+              { BezierEmoji(name: self.name, size: size) },
+              update: { emoji in
+                emoji.name = self.name
+              }
+            )
+            .fixedSize()
+            Text(size.rawValue).font(.caption2).foregroundStyle(.secondary)
+          }
+        }
+      }
+    }
+  }
+
+  private var swiftUINameRow: some View {
+    ScrollView(.horizontal, showsIndicators: false) {
+      HStack(alignment: .top, spacing: 12) {
+        ForEach(self.sampleNames, id: \.self) { name in
+          VStack(spacing: 4) {
+            SUBezierEmoji(name: name, size: .size48)
+            Text(name).font(.caption2).foregroundStyle(.secondary)
+          }
+        }
+      }
+    }
+  }
+}

--- a/Examples/BezierExamples/BezierExamples/Components/EmojiCatalog.swift
+++ b/Examples/BezierExamples/BezierExamples/Components/EmojiCatalog.swift
@@ -6,7 +6,7 @@ struct EmojiCatalog: View {
   @State private var name: String = "grinning"
   @State private var size: BezierEmojiSize = .size48
 
-  private let sampleNames = ["grinning", "smiley", "thumbsup", "heart", "tada"]
+  private let sampleNames = ["grinning", "smiley", "wave", "heart", "tada"]
 
   var body: some View {
     CatalogScreen(title: "Emoji") {

--- a/Sources/BezierSwift/MasterComponent/BezierEmoji/BezierEmoji.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierEmoji/BezierEmoji.swift
@@ -1,0 +1,130 @@
+//
+//  BezierEmoji.swift
+//  BezierSwift
+//
+
+import UIKit
+
+/// 채널톡 이모지 에셋을 지정된 크기로 표시하는 이미지 컴포넌트 (UIKit).
+/// `name`만으로 CDN URL과 에셋 해상도가 자동 결정된다. SwiftUI에서는 `SUBezierEmoji`를 사용한다.
+public final class BezierEmoji: UIView {
+  // MARK: - Public Properties
+
+  /// 채널톡 이모지 이름 (예: `grinning`, `smiley`). 유니코드 이모지 문자가 아니라 에셋 이름을 전달한다.
+  /// 유효하지 않은 이름이면 빈 영역으로 렌더된다.
+  public var name: String {
+    didSet {
+      guard oldValue != self.name else { return }
+      self.accessibilityLabel = self.name
+      self.reloadImage()
+    }
+  }
+
+  /// 이모지 크기. 기본값은 `.size24`다.
+  public var size: BezierEmojiSize = .size24 {
+    didSet {
+      guard oldValue != self.size else { return }
+      self.refreshLayout()
+      self.reloadImage()
+    }
+  }
+
+  // MARK: - Subviews
+
+  private let imageView: UIImageView = {
+    let imageView = UIImageView()
+    imageView.contentMode = .scaleAspectFit
+    imageView.translatesAutoresizingMaskIntoConstraints = false
+    return imageView
+  }()
+
+  // MARK: - Private Properties
+
+  private var widthConstraint: NSLayoutConstraint?
+  private var heightConstraint: NSLayoutConstraint?
+
+  private var currentURL: URL?
+  private var loadTask: Task<Void, Never>?
+
+  // MARK: - Init
+
+  /// 이모지 이름과 크기를 지정해 이모지를 만든다.
+  public init(name: String, size: BezierEmojiSize = .size24) {
+    self.name = name
+    self.size = size
+    super.init(frame: .zero)
+    self.setUp()
+  }
+
+  public required init?(coder: NSCoder) {
+    self.name = ""
+    super.init(coder: coder)
+    self.setUp()
+  }
+
+  deinit {
+    self.loadTask?.cancel()
+  }
+
+  // MARK: - Setup
+
+  private func setUp() {
+    self.translatesAutoresizingMaskIntoConstraints = false
+    self.isAccessibilityElement = true
+    self.accessibilityTraits = .image
+    self.accessibilityLabel = self.name
+
+    self.addSubview(self.imageView)
+
+    let widthConstraint = self.widthAnchor.constraint(equalToConstant: self.size.length)
+    let heightConstraint = self.heightAnchor.constraint(equalToConstant: self.size.length)
+
+    NSLayoutConstraint.activate([
+      widthConstraint,
+      heightConstraint,
+      self.imageView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+      self.imageView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+      self.imageView.topAnchor.constraint(equalTo: self.topAnchor),
+      self.imageView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+    ])
+
+    self.widthConstraint = widthConstraint
+    self.heightConstraint = heightConstraint
+
+    self.reloadImage()
+  }
+
+  // MARK: - Refresh
+
+  private func refreshLayout() {
+    self.widthConstraint?.constant = self.size.length
+    self.heightConstraint?.constant = self.size.length
+    self.invalidateIntrinsicContentSize()
+    self.setNeedsLayout()
+  }
+
+  private func reloadImage() {
+    self.loadTask?.cancel()
+    self.loadTask = nil
+
+    guard let url = BezierEmojiCDN.imageURL(name: self.name, size: self.size) else {
+      self.currentURL = nil
+      self.imageView.image = nil
+      return
+    }
+
+    self.currentURL = url
+
+    if let cached = BezierEmojiImageLoader.shared.cachedImage(for: url) {
+      self.imageView.image = cached
+      return
+    }
+
+    self.imageView.image = nil
+    self.loadTask = Task { @MainActor [weak self] in
+      guard let image = await BezierEmojiImageLoader.shared.image(for: url) else { return }
+      guard let self, !Task.isCancelled, self.currentURL == url else { return }
+      self.imageView.image = image
+    }
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierEmoji/BezierEmojiImageLoader.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierEmoji/BezierEmojiImageLoader.swift
@@ -1,0 +1,32 @@
+//
+//  BezierEmojiImageLoader.swift
+//  BezierSwift
+//
+
+import UIKit
+
+final class BezierEmojiImageLoader {
+  static let shared = BezierEmojiImageLoader()
+
+  private let cache = NSCache<NSURL, UIImage>()
+
+  private init() {}
+
+  func cachedImage(for url: URL) -> UIImage? {
+    self.cache.object(forKey: url as NSURL)
+  }
+
+  func image(for url: URL) async -> UIImage? {
+    if let cached = self.cachedImage(for: url) { return cached }
+
+    guard
+      let (data, response) = try? await URLSession.shared.data(from: url),
+      let httpResponse = response as? HTTPURLResponse,
+      (200..<300).contains(httpResponse.statusCode),
+      let image = UIImage(data: data)
+    else { return nil }
+
+    self.cache.setObject(image, forKey: url as NSURL)
+    return image
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierEmoji/BezierEmojiImageLoader.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierEmoji/BezierEmojiImageLoader.swift
@@ -5,28 +5,43 @@
 
 import UIKit
 
-final class BezierEmojiImageLoader {
+actor BezierEmojiImageLoader {
   static let shared = BezierEmojiImageLoader()
 
-  private let cache = NSCache<NSURL, UIImage>()
+  /// NSCache는 자체 thread-safe라 actor 격리 밖에서도 안전하다.
+  /// 캐시 히트 시 동기 조회(첫 프레임 flash 방지)를 유지하려면 nonisolated여야 한다.
+  private nonisolated let cache = NSCache<NSURL, UIImage>()
+
+  private var inFlightTasks: [URL: Task<UIImage?, Never>] = [:]
 
   private init() {}
 
-  func cachedImage(for url: URL) -> UIImage? {
+  nonisolated func cachedImage(for url: URL) -> UIImage? {
     self.cache.object(forKey: url as NSURL)
   }
 
   func image(for url: URL) async -> UIImage? {
     if let cached = self.cachedImage(for: url) { return cached }
 
-    guard
-      let (data, response) = try? await URLSession.shared.data(from: url),
-      let httpResponse = response as? HTTPURLResponse,
-      (200..<300).contains(httpResponse.statusCode),
-      let image = UIImage(data: data)
-    else { return nil }
+    // 같은 이모지가 목록에 여러 번 렌더될 때 URL별 다운로드가 1회만 나가도록 요청을 공유한다.
+    // 호출자 Task가 취소돼도 이 Task는 독립적이라 남은 대기자의 로드가 끊기지 않는다.
+    if let inFlight = self.inFlightTasks[url] { return await inFlight.value }
 
-    self.cache.setObject(image, forKey: url as NSURL)
-    return image
+    let task = Task<UIImage?, Never> { [cache] in
+      guard
+        let (data, response) = try? await URLSession.shared.data(from: url),
+        let httpResponse = response as? HTTPURLResponse,
+        (200..<300).contains(httpResponse.statusCode),
+        let image = UIImage(data: data)
+      else { return nil }
+
+      cache.setObject(image, forKey: url as NSURL)
+      return image
+    }
+
+    self.inFlightTasks[url] = task
+    defer { self.inFlightTasks[url] = nil }
+
+    return await task.value
   }
 }

--- a/Sources/BezierSwift/MasterComponent/BezierEmoji/BezierEmojiSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierEmoji/BezierEmojiSpec.swift
@@ -66,10 +66,18 @@ public enum BezierEmojiCDN {
   /// 현재 CDN 환경. 기본값은 `.production`이다.
   public static var environment: Environment = .production
 
+  /// `.urlPathAllowed`는 `/`를 통과시켜 name 하나가 여러 경로 세그먼트로 쪼개진다.
+  /// name은 단일 세그먼트여야 하므로 `/`를 인코딩 대상에 포함시킨다.
+  private static let pathSegmentAllowed: CharacterSet = {
+    var allowed = CharacterSet.urlPathAllowed
+    allowed.remove("/")
+    return allowed
+  }()
+
   static func imageURL(name: String, size: BezierEmojiSize) -> URL? {
     guard
       !name.isEmpty,
-      let encodedName = name.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)
+      let encodedName = name.addingPercentEncoding(withAllowedCharacters: self.pathSegmentAllowed)
     else { return nil }
 
     return URL(

--- a/Sources/BezierSwift/MasterComponent/BezierEmoji/BezierEmojiSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierEmoji/BezierEmojiSpec.swift
@@ -1,0 +1,79 @@
+//
+//  BezierEmojiSpec.swift
+//  BezierSwift
+//
+
+import Foundation
+
+// MARK: - Emoji Size
+
+/// 이모지 컨테이너 크기. Figma `Emoji` 컴포넌트의 `size` 프로퍼티에 대응 (Figma 값 `"24"` = `.size24`, bare 숫자에 `size` prefix가 붙은 형태).
+/// `.size60` 이상은 160px 해상도 에셋을, 미만은 80px 해상도 에셋을 내려받는다.
+public enum BezierEmojiSize: String, CaseIterable {
+  case size16
+  case size20
+  case size24
+  case size30
+  case size36
+  case size42
+  case size48
+  case size60
+  case size72
+  case size90
+  case size120
+
+  public var length: CGFloat {
+    switch self {
+    case .size16:  return 16
+    case .size20:  return 20
+    case .size24:  return 24
+    case .size30:  return 30
+    case .size36:  return 36
+    case .size42:  return 42
+    case .size48:  return 48
+    case .size60:  return 60
+    case .size72:  return 72
+    case .size90:  return 90
+    case .size120: return 120
+    }
+  }
+
+  var assetResolution: Int {
+    self.length >= 60 ? 160 : 80
+  }
+}
+
+// MARK: - Emoji CDN
+
+/// 채널톡 이모지 에셋 CDN 설정. 라이브러리는 소비자 앱의 배포 환경을 알 수 없으므로,
+/// 개발 환경 CDN을 사용하려면 앱 시작 시 `BezierEmojiCDN.environment`를 `.development`로 지정한다.
+public enum BezierEmojiCDN {
+  /// 이모지 에셋 CDN 환경.
+  public enum Environment {
+    /// `https://cf.channel.io`에서 에셋을 내려받는다.
+    case production
+    /// `https://cf.exp.channel.io`에서 에셋을 내려받는다.
+    case development
+
+    var baseURLString: String {
+      switch self {
+      case .production:  return "https://cf.channel.io"
+      case .development: return "https://cf.exp.channel.io"
+      }
+    }
+  }
+
+  /// 현재 CDN 환경. 기본값은 `.production`이다.
+  public static var environment: Environment = .production
+
+  static func imageURL(name: String, size: BezierEmojiSize) -> URL? {
+    guard
+      !name.isEmpty,
+      let encodedName = name.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)
+    else { return nil }
+
+    return URL(
+      string: "\(self.environment.baseURLString)/asset/emoji/images/\(size.assetResolution)/\(encodedName).png"
+    )
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierEmoji/SPEC.md
+++ b/Sources/BezierSwift/MasterComponent/BezierEmoji/SPEC.md
@@ -1,0 +1,99 @@
+# BezierEmoji SPEC
+
+> **SSOT**: [Figma · Mobile-Components / Emoji (3462:25)](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=3462-25)
+> **Design spec doc**: [team-design / bezier-v3 / components / Emoji-spec.md](https://github.com/channel-io/team-design/blob/main/bezier-v3/components/Emoji-spec.md) (보조 참조 — 값 충돌 시 Figma 파일 우선)
+
+채널톡 이모지 에셋을 지정된 크기로 표시하는 이미지 컴포넌트 (Figma component description 1행).
+
+## 1. Component Properties
+
+| Property | 값 | 비고 |
+|---|---|---|
+| **size** | `16` / `20` / `24` / `30` / `36` / `42` / `48` / `60` / `72` / `90` / `120` | 컨테이너 정사각 한 변 길이 (pt) |
+
+총 instance: size 11개 (§9 매트릭스 참조)
+
+> Figma COMPONENT_SET의 default variant는 `size=16`이나, design spec doc §4가 "올바른 기본값은 24 (Figma 수정 필요)"로 명시 — 코드 기본값은 `.size24` (§8.5).
+
+## 2. Size 별 Spec
+
+| size | Container (pt) | 콘텐츠 |
+|---|---|---|
+| `16` | 16×16 | 이모지 이미지를 컨테이너 크기에 맞춰 표시 |
+| `20` | 20×20 | 〃 |
+| `24` | 24×24 | 〃 |
+| `30` | 30×30 | 〃 |
+| `36` | 36×36 | 〃 |
+| `42` | 42×42 | 〃 |
+| `48` | 48×48 | 〃 |
+| `60` | 60×60 | 〃 |
+| `72` | 72×72 | 〃 |
+| `90` | 90×90 | 〃 |
+| `120` | 120×120 | 〃 |
+
+- 패딩 없음, corner radius 없음, border 없음.
+- 컨테이너는 고정 크기 (Figma variant가 고정 w/h — 축소·확장 속성 없음).
+
+## 3. Variant 별 컬러 토큰
+
+컬러 토큰 없음 — `get_variable_defs` 결과 공집합. 콘텐츠는 CDN 이미지 원본 색상 그대로 렌더된다 (design spec doc §6: "색상 바인딩이 없는 것은 Figma 구조상 정상이며 스펙 오류가 아니다").
+
+## 4. Typography
+
+이 컴포넌트에 텍스트 없음.
+
+> Figma 각 variant 내부의 😊 TEXT 노드는 실제 텍스트가 아니라 이미지 플레이스홀더다 — component description 명시: "Figma에서는 CDN 이미지를 로드할 수 없어 유니코드 이모지(😊) 플레이스홀더로 표시. 실제 구현은 background-image 방식." 따라서 플레이스홀더의 폰트 수치는 구현 대상이 아니다.
+
+## 5. State 별 시각 동작
+
+Figma CS에 state variant 축 없음 (비인터랙티브 정적 컴포넌트).
+
+## 6. 디자이너 가이드라인 (Figma component description 인용)
+
+- 채널톡 이모지 에셋을 지정된 크기로 표시하는 이미지 컴포넌트.
+- size: 16 / 20 / 24 / 30 / 36 / 42 / 48 / 60 / 72 / 90 / 120 (숫자 = px 크기)
+- Figma에서는 CDN 이미지를 로드할 수 없어 유니코드 이모지(😊) 플레이스홀더로 표시. 실제 구현은 background-image 방식.
+
+## 7. 매핑되는 코드 심볼
+
+| 정의 | 파일 |
+|---|---|
+| UIKit 구현 | `BezierEmoji.swift` |
+| SwiftUI 구현 | `SUBezierEmoji.swift` |
+| size enum / CDN 상수 | `BezierEmojiSpec.swift` |
+| 이미지 로더 (internal) | `BezierEmojiImageLoader.swift` |
+
+## 8. Figma 외 · 협의 사항
+
+Figma에 없는 구현 아키텍처 결정은 아래에 분리 표기한다. SSOT 값이 아니다.
+
+1. **렌더 소스 = 채널톡 CDN 이미지** (design spec doc §7 Behavior):
+   - `name` → URL 자동 결정: `{baseURL}/asset/emoji/images/{해상도}/{name}.png`
+   - 프로덕션 `https://cf.channel.io`, 개발 `https://cf.exp.channel.io`
+   - 에셋 해상도: size ≥ 60 → `160`, 미만 → `80` (design spec doc §4)
+2. **CDN 환경 전역 설정**: 라이브러리는 소비자 앱의 환경을 알 수 없으므로 `BezierEmojiCDN.environment` 전역 설정(기본 `.production`)으로 분기한다. web도 개발/프로덕션 환경별 CDN URL을 분기한다 (design spec doc §7).
+3. **이미지 로딩 = 내장 `URLSession` + `NSCache`** (internal `BezierEmojiImageLoader`): BezierSwift는 zero-dependency 패키지 — 외부 이미지 라이브러리를 도입하지 않는다. 로드 실패 시 빈 영역 유지 (web의 broken image 대응, design spec doc §5).
+4. **접근성**: web `role="img"` + `aria-description={name}` → iOS `accessibilityTraits = .image` + `accessibilityLabel = name`.
+5. **기본값**: `size` 기본 `.size24` (§1 비고 — design spec doc §4 "올바른 기본값은 24").
+6. **`imageUrl` prop 미도입**: web에서 deprecated (design spec doc §9 anti-pattern) — iOS는 처음부터 도입하지 않는다.
+7. **스코프**: 인터랙션·state·placeholder 이미지 없음. 임의 이미지 표시는 비지원 (채널톡 이모지 에셋 전용).
+8. **고정 크기 유지**: 컨테이너는 레이아웃 압박에도 축소되지 않는다 — web 구현 `flex-shrink: 0`의 대응 (design spec doc §6).
+9. **콘텐츠 스케일링**: 이미지를 컨테이너 크기에 맞춰 표시한다 — web 구현이 CSS `background-size`로 조정하는 것의 대응 (design spec doc §7). iOS는 `scaleAspectFit`/`scaledToFit()` (에셋이 정사각 PNG이므로 컨테이너를 가득 채운다).
+
+## 9. Variant 매트릭스
+
+총 instance: size 11개
+
+```
+size=16  = 3462:3
+size=20  = 3462:5
+size=24  = 3462:7
+size=30  = 3462:9
+size=36  = 3462:11
+size=42  = 3462:13
+size=48  = 3462:15
+size=60  = 3462:17
+size=72  = 3462:19
+size=90  = 3462:21
+size=120 = 3462:23
+```

--- a/Sources/BezierSwift/MasterComponent/BezierEmoji/SPEC.md
+++ b/Sources/BezierSwift/MasterComponent/BezierEmoji/SPEC.md
@@ -72,7 +72,7 @@ Figma에 없는 구현 아키텍처 결정은 아래에 분리 표기한다. SSO
    - 프로덕션 `https://cf.channel.io`, 개발 `https://cf.exp.channel.io`
    - 에셋 해상도: size ≥ 60 → `160`, 미만 → `80` (design spec doc §4)
 2. **CDN 환경 전역 설정**: 라이브러리는 소비자 앱의 환경을 알 수 없으므로 `BezierEmojiCDN.environment` 전역 설정(기본 `.production`)으로 분기한다. web도 개발/프로덕션 환경별 CDN URL을 분기한다 (design spec doc §7).
-3. **이미지 로딩 = 내장 `URLSession` + `NSCache`** (internal `BezierEmojiImageLoader`): BezierSwift는 zero-dependency 패키지 — 외부 이미지 라이브러리를 도입하지 않는다. 로드 실패 시 빈 영역 유지 (web의 broken image 대응, design spec doc §5).
+3. **이미지 로딩 = 내장 `URLSession` + `NSCache`** (internal `BezierEmojiImageLoader`): BezierSwift는 zero-dependency 패키지 — 외부 이미지 라이브러리를 도입하지 않는다. 로드 실패 시 빈 영역 유지 (web의 broken image 대응, design spec doc §5). 같은 이모지가 목록에 여러 번 렌더되는 것이 정상 사용 패턴이므로, 로더는 URL별 in-flight 요청을 공유해 중복 다운로드를 막는다.
 4. **접근성**: web `role="img"` + `aria-description={name}` → iOS `accessibilityTraits = .image` + `accessibilityLabel = name`.
 5. **기본값**: `size` 기본 `.size24` (§1 비고 — design spec doc §4 "올바른 기본값은 24").
 6. **`imageUrl` prop 미도입**: web에서 deprecated (design spec doc §9 anti-pattern) — iOS는 처음부터 도입하지 않는다.

--- a/Sources/BezierSwift/MasterComponent/BezierEmoji/SUBezierEmoji.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierEmoji/SUBezierEmoji.swift
@@ -85,7 +85,7 @@ struct SUBezierEmoji_Previews: PreviewProvider {
           .font(.caption.weight(.semibold))
           .foregroundColor(.secondary)
         HStack(spacing: 12) {
-          ForEach(["grinning", "smiley", "thumbsup"], id: \.self) { name in
+          ForEach(["grinning", "smiley", "wave"], id: \.self) { name in
             SUBezierEmoji(name: name, size: .size48)
           }
         }

--- a/Sources/BezierSwift/MasterComponent/BezierEmoji/SUBezierEmoji.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierEmoji/SUBezierEmoji.swift
@@ -1,0 +1,96 @@
+//
+//  SUBezierEmoji.swift
+//  BezierSwift
+//
+
+import SwiftUI
+
+/// 채널톡 이모지 에셋을 지정된 크기로 표시하는 이미지 컴포넌트 (SwiftUI).
+/// `name`만으로 CDN URL과 에셋 해상도가 자동 결정된다. UIKit에서는 `BezierEmoji`를 사용한다.
+public struct SUBezierEmoji: View {
+  private let name: String
+  private let size: BezierEmojiSize
+
+  @State private var loadedImage: LoadedImage?
+
+  /// 이모지 이름과 크기를 지정해 이모지를 만든다.
+  /// - Parameters:
+  ///   - name: 채널톡 이모지 이름 (예: `grinning`, `smiley`). 유니코드 이모지 문자가 아니라 에셋 이름을 전달한다.
+  ///           유효하지 않은 이름이면 빈 영역으로 렌더된다.
+  ///   - size: 이모지 크기. 기본값은 `.size24`다.
+  public init(name: String, size: BezierEmojiSize = .size24) {
+    self.name = name
+    self.size = size
+  }
+
+  public var body: some View {
+    Group {
+      if let image = self.displayedImage {
+        Image(uiImage: image)
+          .resizable()
+          .scaledToFit()
+      } else {
+        Color.clear
+      }
+    }
+    .frame(width: self.size.length, height: self.size.length)
+    .task(id: self.imageURL) {
+      guard let url = self.imageURL else {
+        self.loadedImage = nil
+        return
+      }
+      guard let image = await BezierEmojiImageLoader.shared.image(for: url) else { return }
+      self.loadedImage = LoadedImage(url: url, image: image)
+    }
+    .accessibilityElement()
+    .accessibilityAddTraits(.isImage)
+    .accessibilityLabel(self.name)
+  }
+
+  // MARK: - Private
+
+  /// 로드 완료 이미지를 URL에 키잉해, name·size 전환 중 이전 URL의 이미지가 표시되는 상태 오염을 막는다.
+  private struct LoadedImage {
+    let url: URL
+    let image: UIImage
+  }
+
+  private var imageURL: URL? {
+    BezierEmojiCDN.imageURL(name: self.name, size: self.size)
+  }
+
+  private var displayedImage: UIImage? {
+    guard let url = self.imageURL else { return nil }
+    if let loadedImage = self.loadedImage, loadedImage.url == url { return loadedImage.image }
+    return BezierEmojiImageLoader.shared.cachedImage(for: url)
+  }
+}
+
+struct SUBezierEmoji_Previews: PreviewProvider {
+  static var previews: some View {
+    ScrollView {
+      VStack(alignment: .leading, spacing: 20) {
+        Text("size row")
+          .font(.caption.weight(.semibold))
+          .foregroundColor(.secondary)
+        ScrollView(.horizontal, showsIndicators: false) {
+          HStack(alignment: .bottom, spacing: 12) {
+            ForEach(BezierEmojiSize.allCases, id: \.self) { size in
+              SUBezierEmoji(name: "smile", size: size)
+            }
+          }
+        }
+
+        Text("names")
+          .font(.caption.weight(.semibold))
+          .foregroundColor(.secondary)
+        HStack(spacing: 12) {
+          ForEach(["grinning", "smiley", "thumbsup"], id: \.self) { name in
+            SUBezierEmoji(name: name, size: .size48)
+          }
+        }
+      }
+      .padding()
+    }
+  }
+}

--- a/Tests/BezierSwiftTests/BezierEmojiSpecTests.swift
+++ b/Tests/BezierSwiftTests/BezierEmojiSpecTests.swift
@@ -1,0 +1,85 @@
+import Testing
+import CoreGraphics
+@testable import BezierSwift
+
+// MARK: - Size
+
+@Suite("BezierEmojiSize")
+struct BezierEmojiSizeTests {
+  @Test("length는 Figma size 값과 일치한다", arguments: [
+    (BezierEmojiSize.size16, CGFloat(16)),
+    (.size20, 20),
+    (.size24, 24),
+    (.size30, 30),
+    (.size36, 36),
+    (.size42, 42),
+    (.size48, 48),
+    (.size60, 60),
+    (.size72, 72),
+    (.size90, 90),
+    (.size120, 120),
+  ])
+  func length(size: BezierEmojiSize, expected: CGFloat) {
+    #expect(size.length == expected)
+  }
+
+  @Test("size 60 미만은 80px 에셋을 사용한다", arguments: [
+    BezierEmojiSize.size16, .size20, .size24, .size30, .size36, .size42, .size48,
+  ])
+  func lowResolution(size: BezierEmojiSize) {
+    #expect(size.assetResolution == 80)
+  }
+
+  @Test("size 60 이상은 160px 에셋을 사용한다", arguments: [
+    BezierEmojiSize.size60, .size72, .size90, .size120,
+  ])
+  func highResolution(size: BezierEmojiSize) {
+    #expect(size.assetResolution == 160)
+  }
+}
+
+// MARK: - CDN URL
+
+// BezierEmojiCDN.environment는 전역 상태라 테스트 간 간섭을 막기 위해 직렬 실행한다.
+@Suite("BezierEmojiCDN", .serialized)
+struct BezierEmojiCDNTests {
+  @Test("production URL 형식")
+  func productionURL() {
+    BezierEmojiCDN.environment = .production
+    let url = BezierEmojiCDN.imageURL(name: "grinning", size: .size24)
+
+    #expect(url?.absoluteString == "https://cf.channel.io/asset/emoji/images/80/grinning.png")
+  }
+
+  @Test("development URL 형식")
+  func developmentURL() {
+    BezierEmojiCDN.environment = .development
+    defer { BezierEmojiCDN.environment = .production }
+    let url = BezierEmojiCDN.imageURL(name: "grinning", size: .size24)
+
+    #expect(url?.absoluteString == "https://cf.exp.channel.io/asset/emoji/images/80/grinning.png")
+  }
+
+  @Test("size 60 이상은 160 경로를 사용한다")
+  func highResolutionPath() {
+    BezierEmojiCDN.environment = .production
+    let url = BezierEmojiCDN.imageURL(name: "grinning", size: .size60)
+
+    #expect(url?.absoluteString == "https://cf.channel.io/asset/emoji/images/160/grinning.png")
+  }
+
+  @Test("빈 name은 nil을 반환한다")
+  func emptyName() {
+    BezierEmojiCDN.environment = .production
+
+    #expect(BezierEmojiCDN.imageURL(name: "", size: .size24) == nil)
+  }
+
+  @Test("URL에 부적합한 문자는 percent-encoding된다")
+  func percentEncoding() {
+    BezierEmojiCDN.environment = .production
+    let url = BezierEmojiCDN.imageURL(name: "+1", size: .size24)
+
+    #expect(url?.absoluteString == "https://cf.channel.io/asset/emoji/images/80/+1.png")
+  }
+}

--- a/Tests/BezierSwiftTests/BezierEmojiSpecTests.swift
+++ b/Tests/BezierSwiftTests/BezierEmojiSpecTests.swift
@@ -78,6 +78,22 @@ struct BezierEmojiCDNTests {
   @Test("URL에 부적합한 문자는 percent-encoding된다")
   func percentEncoding() {
     BezierEmojiCDN.environment = .production
+    let url = BezierEmojiCDN.imageURL(name: "my emoji", size: .size24)
+
+    #expect(url?.absoluteString == "https://cf.channel.io/asset/emoji/images/80/my%20emoji.png")
+  }
+
+  @Test("name의 /는 경로를 쪼개지 않고 인코딩된다")
+  func pathSeparatorEncoding() {
+    BezierEmojiCDN.environment = .production
+    let url = BezierEmojiCDN.imageURL(name: "foo/bar", size: .size24)
+
+    #expect(url?.absoluteString == "https://cf.channel.io/asset/emoji/images/80/foo%2Fbar.png")
+  }
+
+  @Test("path에 유효한 문자를 포함한 이름은 그대로 유지된다")
+  func pathSafeNameIsPreserved() {
+    BezierEmojiCDN.environment = .production
     let url = BezierEmojiCDN.imageURL(name: "+1", size: .size24)
 
     #expect(url?.absoluteString == "https://cf.channel.io/asset/emoji/images/80/+1.png")


### PR DESCRIPTION
## MOB-6336

https://linear.app/channel/issue/MOB-6336

V3 Emoji 컴포넌트를 UIKit + SwiftUI로 구현합니다.

> spec 헤더의 `figma-mobile-status: not-started`는 stale 표기였습니다 — Figma Mobile-Components 파일(`3462:25`)에 size 11종 COMPONENT_SET이 실재함을 실측으로 확인하고 구현했습니다.

## 구현 내용

### Emoji — `BezierEmoji` / `SUBezierEmoji`

- `name` 하나로 채널톡 CDN URL과 에셋 해상도가 자동 결정되는 이미지 컴포넌트 (`{baseURL}/asset/emoji/images/{80|160}/{name}.png`)
- size 11종: `size16`~`size120` (Figma variant와 1:1, 기본값 `.size24` — Figma default `16`은 design spec doc이 오류로 명시)
- 에셋 해상도 분기: size ≥ 60 → 160px 에셋, 미만 → 80px 에셋
- CDN 환경 전역 설정: `BezierEmojiCDN.environment` (기본 `.production` = `cf.channel.io`, `.development` = `cf.exp.channel.io`) — 라이브러리가 소비자 앱의 배포 환경을 알 수 없어 전역 1회 설정 방식
- 이미지 로딩: 내장 `URLSession` + `NSCache` (internal `BezierEmojiImageLoader`) — BezierSwift zero-dependency 유지, 로드 실패 시 빈 영역 (web broken image 대응, 임의 fallback 이미지 없음)
- UIKit: `name`/`size` didSet 재로드, 이전 요청 cancel + stale 응답 가드 (`currentURL` 비교), 토큰색 미사용이므로 traitCollectionDidChange 재주입 불필요
- SwiftUI: `.task(id: imageURL)`로 name·size 변경 모두 포착, 캐시 히트 시 동기 표시로 첫 프레임 flash 방지
- 접근성: web `role="img"` + `aria-description={name}` 대응 — `.image` trait + `accessibilityLabel = name`
- web에서 deprecated인 `imageUrl` prop은 처음부터 미도입, 임의 이미지 표시 비지원 (채널톡 이모지 에셋 전용)

## Spec 검증

figma-component-spec 3단계 사이클로 검증했습니다 (Figma = SSOT):

- Phase 1: Figma 실측 기반 `SPEC.md` 작성 (Emoji COMPONENT_SET `3462:25`, size variant 11개 노드 전수)
- Phase 2: Properties / Layout / Color / Typography / Asset / Spec Noise / Implementation Reference 7종 병렬 검증 전부 통과
  - Figma의 😊 TEXT 노드는 component description이 명시한 이미지 플레이스홀더("Figma에서는 CDN 이미지를 로드할 수 없어 유니코드 이모지(😊) 플레이스홀더로 표시. 실제 구현은 background-image 방식")로 판정 — 텍스트 렌더링 미구현이 SSOT 준수
  - 컬러·typography 토큰 바인딩 공집합 실측 확인 (이미지 컴포넌트 — design spec doc이 정상 상태로 명시)
- Phase 3: UIKit·SwiftUI Implementation Validator로 구현–SPEC 일치 확인
- Figma에 없는 구현 결정(CDN URL 스킴·해상도 분기·환경 전역 설정·내장 로더·접근성 매핑·기본값 24·imageUrl 미도입·고정 크기·스케일링)은 `SPEC.md` §8에 협의 사항으로 분리 기록

## 스크린샷

시뮬레이터(iPhone 16 / iOS 18.6) 검증 완료 — 캡처 파일은 `Screenshots-MOB-6336/` (로컬, 미커밋):

| 파일 | 내용 |
|---|---|
| `01-emoji-catalog-light.png` | 카탈로그 상단 — grinning size48, SwiftUI + UIKit 프리뷰 (CDN 로드 성공) |
| `02-emoji-size-row-160px-light.png` | size row 대형 구간 (size72/90/120 — 160px 고해상도 에셋) |
| `03-emoji-names-uikit-sizerow-light.png` | UIKit size row (80px 구간) + names 5종 전부 로드 |
| `04-emoji-name-wave-light.png` | Name Picker로 wave 전환 — SwiftUI·UIKit 동시 반영, stale 이미지 없음 |
| `05-emoji-catalog-dark.png` | 다크 모드 — 이모지 원본색 유지 (토큰색 없음) |

> CDN 실응답 검증: `grinning`/`smiley`/`heart`/`tada` 80·160 모두 200. **`thumbsup`은 80·160 모두 403** (design spec doc §8 Content Guidelines의 DO 예시이지만 실제 CDN에 부재 — `+1`, `thumbs_up`도 403) → 데모 name을 `wave`(200)로 교체.

## 테스트

- `BezierEmojiSpecTests` — size length 11종 / 에셋 해상도 분기(80·160) / CDN URL 형식(prod·dev) / 빈 name nil / percent-encoding — `xcodebuild test` 통과 (49 tests in 14 suites)
- BezierSwift 패키지 + Examples 앱 clean build 통과
- Examples 카탈로그 (Emoji) 추가 — name·size 컨트롤, size row, names row

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - SwiftUI와 UIKit에서 사용할 수 있는 이모지 렌더링 컴포넌트를 추가했습니다.
  - 이모지 이름/크기에 따른 CDN 이미지 로딩, 캐싱, 로딩 중 표시를 지원합니다.
  - 카탈로그에 “Emoji” 섹션이 추가되어 미리보기와 크기별/이름별 목록을 제공합니다.
- **문서**
  - 이모지 컴포넌트의 크기 옵션과 이미지/표시 동작을 사양으로 정리했습니다.
- **테스트**
  - 크기-해상도 매핑, CDN 환경 분기, 이미지 URL 생성 및 인코딩 동작을 검증하는 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->