### PR TITLE
[MOB-6356] BezierCollapsibleSection 컴포넌트 구현 (UIKit + SwiftUI)

### DIFF
--- a/Examples/BezierExamples/BezierExamples/App/CatalogRegistry.swift
+++ b/Examples/BezierExamples/BezierExamples/App/CatalogRegistry.swift
@@ -119,6 +119,12 @@ enum CatalogRegistry {
       destination: AnyView(SectionItemCatalog())
     ),
     CatalogItem(
+      id: "collapsible-section",
+      title: "CollapsibleSection",
+      section: .v3Components,
+      destination: AnyView(CollapsibleSectionCatalog())
+    ),
+    CatalogItem(
       id: "floating-banner",
       title: "FloatingBanner",
       section: .v3Components,

--- a/Examples/BezierExamples/BezierExamples/Components/CollapsibleSectionCatalog.swift
+++ b/Examples/BezierExamples/BezierExamples/Components/CollapsibleSectionCatalog.swift
@@ -131,7 +131,7 @@ private struct CollapsibleSectionRepresentable: UIViewRepresentable {
     let wrapper = UIView()
     let section = BezierCollapsibleSection(labelText: "고객 정보", isOpen: self.isOpen)
     section.onOpenChange = { open in
-      withAnimation(.easeInOut(duration: 0.25)) {
+      withAnimation(.easeInOut(duration: BezierCollapsibleSectionConstant.openAnimationDuration)) {
         self.isOpen = open
       }
     }

--- a/Examples/BezierExamples/BezierExamples/Components/CollapsibleSectionCatalog.swift
+++ b/Examples/BezierExamples/BezierExamples/Components/CollapsibleSectionCatalog.swift
@@ -1,0 +1,187 @@
+import SwiftUI
+import UIKit
+import BezierSwift
+
+struct CollapsibleSectionCatalog: View {
+  @State private var labelColor: BezierSectionLabelColor = .neutralDark
+  @State private var rowCount = 3
+  @State private var basicOpen = true
+  @State private var slotOpen = false
+  @State private var uikitOpen = true
+
+  private static let rowTitles = ["태그 관리", "고객 노트", "첨부파일", "담당자 지정", "메시지 번역"]
+
+  private var rows: [String] {
+    Array(Self.rowTitles.prefix(self.rowCount))
+  }
+
+  var body: some View {
+    CatalogScreen(title: "CollapsibleSection") {
+      self.controls
+      CatalogSection(.swiftUI) { self.swiftUIPreview }
+      CatalogSection(.uiKit) { self.uiKitPreview }
+    }
+  }
+
+  private var controls: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Picker("labelColor", selection: self.$labelColor) {
+        ForEach(BezierSectionLabelColor.allCases, id: \.self) { color in
+          Text(self.labelColorLabel(color)).tag(color)
+        }
+      }
+      .pickerStyle(.segmented)
+
+      Stepper("rows: \(self.rowCount)", value: self.$rowCount, in: 1...Self.rowTitles.count)
+    }
+    .font(.caption)
+  }
+
+  // MARK: - SwiftUI
+
+  private var swiftUIPreview: some View {
+    VStack(alignment: .leading, spacing: 16) {
+      SUBezierCollapsibleSection(
+        self.rows,
+        id: \.self,
+        isOpen: self.$basicOpen,
+        labelText: "고객 정보",
+        labelColor: self.labelColor
+      ) { title in
+        self.swiftUIRow(title)
+      }
+
+      Text("labelLeading + labelTrailing 슬롯")
+        .font(.caption2)
+        .foregroundStyle(.secondary)
+
+      SUBezierCollapsibleSection(
+        self.rows,
+        id: \.self,
+        isOpen: self.$slotOpen,
+        labelText: "첨부파일",
+        labelColor: self.labelColor,
+        labelLeading: {
+          BezierIcon.folder.image
+            .renderingMode(.template)
+            .resizable()
+            .scaledToFit()
+            .foregroundColor(.secondary)
+        },
+        labelTrailing: {
+          BezierIcon.plus.image
+            .renderingMode(.template)
+            .resizable()
+            .scaledToFit()
+            .frame(width: 16, height: 16)
+            .foregroundColor(.secondary)
+        }
+      ) { title in
+        self.swiftUIRow(title)
+      }
+    }
+  }
+
+  private func swiftUIRow(_ title: String) -> some View {
+    SUBezierBaseItem(
+      title: title,
+      onTap: {},
+      leading: {
+        BezierIcon.personCircle.image
+          .renderingMode(.template)
+          .resizable()
+          .scaledToFit()
+          .foregroundColor(.secondary)
+      },
+      trailing: { EmptyView() }
+    )
+  }
+
+  // MARK: - UIKit
+
+  private var uiKitPreview: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Toggle("isOpen (setOpen 프로그래매틱 제어)", isOn: self.$uikitOpen)
+        .font(.caption)
+
+      CollapsibleSectionRepresentable(
+        isOpen: self.$uikitOpen,
+        labelColor: self.labelColor,
+        rows: self.rows
+      )
+    }
+  }
+
+  private func labelColorLabel(_ color: BezierSectionLabelColor) -> String {
+    switch color {
+    case .neutralDark: return "neutralDark"
+    case .neutralLight: return "neutralLight"
+    }
+  }
+}
+
+// MARK: - UIKit Representable
+
+private struct CollapsibleSectionRepresentable: UIViewRepresentable {
+  @Binding var isOpen: Bool
+  let labelColor: BezierSectionLabelColor
+  let rows: [String]
+
+  func makeUIView(context: Context) -> UIView {
+    let wrapper = UIView()
+    let section = BezierCollapsibleSection(labelText: "고객 정보", isOpen: self.isOpen)
+    section.onOpenChange = { open in
+      withAnimation(.easeInOut(duration: 0.25)) {
+        self.isOpen = open
+      }
+    }
+    self.apply(to: section)
+    wrapper.addSubview(section)
+    NSLayoutConstraint.activate([
+      section.topAnchor.constraint(equalTo: wrapper.topAnchor),
+      section.leadingAnchor.constraint(equalTo: wrapper.leadingAnchor),
+      section.trailingAnchor.constraint(equalTo: wrapper.trailingAnchor),
+      section.bottomAnchor.constraint(equalTo: wrapper.bottomAnchor),
+    ])
+    return wrapper
+  }
+
+  func updateUIView(_ wrapper: UIView, context: Context) {
+    guard let section = wrapper.subviews.first as? BezierCollapsibleSection else { return }
+    self.apply(to: section)
+  }
+
+  func sizeThatFits(_ proposal: ProposedViewSize, uiView: UIView, context: Context) -> CGSize? {
+    let width = proposal.width ?? 320
+    let fitting = uiView.systemLayoutSizeFitting(
+      CGSize(width: width, height: UIView.layoutFittingCompressedSize.height),
+      withHorizontalFittingPriority: .required,
+      verticalFittingPriority: .fittingSizeLevel
+    )
+    return CGSize(width: width, height: fitting.height)
+  }
+
+  private func apply(to section: BezierCollapsibleSection) {
+    section.labelColor = self.labelColor
+    section.setOpen(self.isOpen, animated: false)
+
+    if section.items.count != self.rows.count {
+      section.setItems(self.rows.map(Self.makeRow))
+    } else {
+      for case let (row, title) in zip(section.items, self.rows) {
+        (row as? BezierBaseItem)?.title = title
+      }
+    }
+  }
+
+  private static func makeRow(_ title: String) -> BezierBaseItem {
+    let item = BezierBaseItem(title: title, onTap: {})
+    let imageView = UIImageView(
+      image: BezierIcon.personCircle.uiImage?.withRenderingMode(.alwaysTemplate)
+    )
+    imageView.contentMode = .scaleAspectFit
+    imageView.tintColor = .secondaryLabel
+    item.leadingContent = imageView
+    return item
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierCollapsibleSection/BezierCollapsibleSection.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierCollapsibleSection/BezierCollapsibleSection.swift
@@ -1,0 +1,197 @@
+//
+//  BezierCollapsibleSection.swift
+//  BezierSwift
+//
+
+import UIKit
+
+/// 헤더 탭으로 콘텐츠를 접고 펼치는 인터랙티브 섹션 컨테이너 (UIKit). 헤더(라벨·chevron) + 행 목록으로 구성되며 행에는 `BezierSectionItem`을 넣는다. Figma `CollapsibleSection`의 `open` 프로퍼티가 `isOpen`에 대응한다. 정적 그룹핑만 필요하면 `BezierSection`을 사용한다. SwiftUI에서는 `SUBezierCollapsibleSection`을 사용한다.
+public final class BezierCollapsibleSection: UIView, BezierComponentable {
+  // MARK: - BezierComponentable
+
+  public var colorTheme: BezierColorTheme { .systemBezierColorTheme() }
+  public var componentTheme: BezierComponentTheme = .normal {
+    didSet { self.headerLabel.componentTheme = self.componentTheme }
+  }
+
+  // MARK: - Public Properties
+
+  /// 펼침 상태 (기본값 `true`). 대입 시 애니메이션 없이 즉시 반영되며 `onOpenChange`는 호출되지 않는다. 애니메이션이 필요하면 `setOpen(_:animated:)`를 사용한다.
+  public var isOpen: Bool {
+    get { self.openState }
+    set { self.setOpen(newValue, animated: false) }
+  }
+
+  /// 사용자가 헤더를 탭해 펼침 상태가 바뀔 때 호출되는 클로저. 프로그래매틱 변경(`isOpen`/`setOpen`)에는 호출되지 않는다.
+  public var onOpenChange: ((Bool) -> Void)?
+
+  /// 헤더 라벨 텍스트. 헤더는 필수 파트라 항상 표시된다.
+  public var labelText: String {
+    didSet { if oldValue != self.labelText { self.headerLabel.text = self.labelText } }
+  }
+
+  /// 헤더 라벨·chevron 색(neutralDark/neutralLight) (기본값 `.neutralDark`).
+  public var labelColor: BezierSectionLabelColor = .neutralDark {
+    didSet { if oldValue != self.labelColor { self.headerLabel.color = self.labelColor } }
+  }
+
+  /// 헤더 라벨 좌측 슬롯에 넣을 20×20 뷰(아이콘 등). `nil`이면 비운다.
+  public var labelLeadingContent: UIView? {
+    didSet { self.headerLabel.leadingContent = self.labelLeadingContent }
+  }
+
+  /// 헤더 라벨 우측 슬롯에 넣을 액션 뷰(높이 20). 헤더 탭(토글)과 별개의 액션을 배치한다. `nil`이면 비운다.
+  public var labelTrailingContent: UIView? {
+    didSet { self.headerLabel.trailingContent = self.labelTrailingContent }
+  }
+
+  /// 현재 표시 중인 행 뷰 배열. 읽기 전용이며 `setItems(_:)`/`addItem(_:)`으로 변경한다.
+  public private(set) var items: [UIView] = []
+
+  // MARK: - Private Properties
+
+  private var openState: Bool
+
+  // MARK: - Subviews
+
+  private let rootStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    stackView.alignment = .fill
+    stackView.distribution = .fill
+    stackView.spacing = BezierSectionConstant.labelToContentSpacing
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    return stackView
+  }()
+
+  private let headerLabel: BezierCollapsibleSectionLabel
+
+  private let contentContainer: UIView = {
+    let view = UIView()
+    view.clipsToBounds = true
+    return view
+  }()
+
+  private let itemsStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    stackView.alignment = .fill
+    stackView.distribution = .fill
+    stackView.spacing = 0
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    return stackView
+  }()
+
+  // MARK: - Init
+
+  /// 헤더 텍스트·색·초기 펼침 상태·초기 행 배열로 섹션을 만든다. 행은 이후 `setItems(_:)`/`addItem(_:)`으로 교체·추가할 수 있다.
+  public init(
+    labelText: String,
+    labelColor: BezierSectionLabelColor = .neutralDark,
+    isOpen: Bool = true,
+    items: [UIView] = []
+  ) {
+    self.labelText = labelText
+    self.labelColor = labelColor
+    self.openState = isOpen
+    self.items = items
+    self.headerLabel = BezierCollapsibleSectionLabel(text: labelText, color: labelColor)
+    super.init(frame: .zero)
+    self.setUp()
+  }
+
+  public required init?(coder: NSCoder) {
+    self.labelText = ""
+    self.openState = true
+    self.headerLabel = BezierCollapsibleSectionLabel()
+    super.init(coder: coder)
+    self.setUp()
+  }
+
+  // MARK: - Setup
+
+  private func setUp() {
+    self.translatesAutoresizingMaskIntoConstraints = false
+
+    self.contentContainer.addSubview(self.itemsStackView)
+    NSLayoutConstraint.activate([
+      self.itemsStackView.topAnchor.constraint(equalTo: self.contentContainer.topAnchor),
+      self.itemsStackView.leadingAnchor.constraint(equalTo: self.contentContainer.leadingAnchor),
+      self.itemsStackView.trailingAnchor.constraint(equalTo: self.contentContainer.trailingAnchor),
+      self.itemsStackView.bottomAnchor.constraint(equalTo: self.contentContainer.bottomAnchor),
+    ])
+
+    self.rootStackView.addArrangedSubview(self.headerLabel)
+    self.rootStackView.addArrangedSubview(self.contentContainer)
+    self.addSubview(self.rootStackView)
+    NSLayoutConstraint.activate([
+      self.rootStackView.topAnchor.constraint(equalTo: self.topAnchor),
+      self.rootStackView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+      self.rootStackView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+      self.rootStackView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+    ])
+
+    self.headerLabel.isOpen = self.openState
+    self.headerLabel.onTap = { [weak self] in
+      self?.handleHeaderTap()
+    }
+
+    self.rebuildRows()
+    self.applyContentVisibility(animated: false)
+  }
+
+  // MARK: - Open State
+
+  /// 펼침 상태를 변경한다. `animated`가 `true`면 콘텐츠 영역이 접히고 펼쳐지는 전환을 애니메이션한다 (Reduce Motion 활성 시 생략). `onOpenChange`는 호출되지 않는다.
+  public func setOpen(_ isOpen: Bool, animated: Bool) {
+    guard isOpen != self.openState else { return }
+    self.openState = isOpen
+    self.headerLabel.isOpen = isOpen
+    self.applyContentVisibility(animated: animated && !UIAccessibility.isReduceMotionEnabled)
+  }
+
+  private func handleHeaderTap() {
+    let newValue = !self.openState
+    self.setOpen(newValue, animated: true)
+    self.onOpenChange?(newValue)
+  }
+
+  private func applyContentVisibility(animated: Bool) {
+    let hidden = !self.openState
+
+    guard animated, self.window != nil else {
+      self.contentContainer.isHidden = hidden
+      self.contentContainer.alpha = hidden ? 0 : 1
+      return
+    }
+
+    UIView.animate(
+      withDuration: BezierCollapsibleSectionConstant.openAnimationDuration,
+      delay: 0,
+      options: [.curveEaseInOut, .beginFromCurrentState]
+    ) {
+      self.contentContainer.isHidden = hidden
+      self.contentContainer.alpha = hidden ? 0 : 1
+      self.rootStackView.layoutIfNeeded()
+    }
+  }
+
+  // MARK: - Items
+
+  /// 행 배열을 통째로 교체한다.
+  public func setItems(_ items: [UIView]) {
+    self.items = items
+    self.rebuildRows()
+  }
+
+  /// 행을 끝에 하나 추가한다.
+  public func addItem(_ item: UIView) {
+    self.items.append(item)
+    self.rebuildRows()
+  }
+
+  private func rebuildRows() {
+    self.itemsStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+    self.items.forEach { self.itemsStackView.addArrangedSubview($0) }
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierCollapsibleSection/BezierCollapsibleSectionLabel.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierCollapsibleSection/BezierCollapsibleSectionLabel.swift
@@ -1,0 +1,252 @@
+//
+//  BezierCollapsibleSectionLabel.swift
+//  BezierSwift
+//
+
+import UIKit
+
+// Figma Internal/CollapsibleSectionLabel — "Do not place standalone" 정책에 따라 internal.
+final class BezierCollapsibleSectionLabel: UIControl, BezierComponentable {
+  // MARK: - BezierComponentable
+
+  var colorTheme: BezierColorTheme { .systemBezierColorTheme() }
+  var componentTheme: BezierComponentTheme = .normal {
+    didSet { self.refreshAppearance() }
+  }
+
+  // MARK: - Internal Properties
+
+  var text: String = "" {
+    didSet { if oldValue != self.text { self.refreshText() } }
+  }
+
+  var color: BezierSectionLabelColor = .neutralDark {
+    didSet { if oldValue != self.color { self.refreshAppearance() } }
+  }
+
+  var isOpen: Bool = true {
+    didSet { if oldValue != self.isOpen { self.refreshChevron() } }
+  }
+
+  var leadingContent: UIView? {
+    didSet { self.updateSlot(container: self.leadingContainer, old: oldValue, new: self.leadingContent) }
+  }
+
+  var trailingContent: UIView? {
+    didSet { self.updateSlot(container: self.trailingContainer, old: oldValue, new: self.trailingContent) }
+  }
+
+  var onTap: (() -> Void)?
+
+  // MARK: - State
+
+  override var isHighlighted: Bool {
+    didSet {
+      if oldValue != self.isHighlighted {
+        self.refreshPressed()
+      }
+    }
+  }
+
+  // MARK: - Subviews
+
+  private let rootStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .horizontal
+    stackView.alignment = .center
+    stackView.distribution = .fill
+    stackView.spacing = 0
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    stackView.isUserInteractionEnabled = false
+    return stackView
+  }()
+
+  private let centerStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .horizontal
+    stackView.alignment = .center
+    stackView.distribution = .fill
+    stackView.spacing = BezierSectionConstant.labelLeadingSpacing
+    return stackView
+  }()
+
+  private let leadingContainer = UIView()
+
+  private let textLabel: UILabel = {
+    let label = UILabel()
+    label.numberOfLines = 1
+    return label
+  }()
+
+  private let chevronImageView: UIImageView = {
+    let imageView = UIImageView()
+    imageView.contentMode = .scaleAspectFit
+    return imageView
+  }()
+
+  private let spacerView = UIView()
+
+  private let trailingContainer = UIView()
+
+  // MARK: - Init
+
+  init(text: String = "", color: BezierSectionLabelColor = .neutralDark) {
+    self.text = text
+    self.color = color
+    super.init(frame: .zero)
+    self.setUp()
+  }
+
+  required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    self.setUp()
+  }
+
+  // MARK: - Setup
+
+  private func setUp() {
+    self.translatesAutoresizingMaskIntoConstraints = false
+    self.layer.cornerRadius = BezierSectionConstant.labelCornerRadius
+    self.layer.masksToBounds = true
+    self.directionalLayoutMargins = NSDirectionalEdgeInsets(
+      top: 0,
+      leading: BezierSectionConstant.labelHorizontalPadding,
+      bottom: 0,
+      trailing: BezierSectionConstant.labelHorizontalPadding
+    )
+
+    // spacer가 남는 가로 공간을 흡수해 텍스트·chevron이 좌측에 붙고 trailing이 우측 끝으로 밀린다.
+    let expandingPriority = UILayoutPriority(1)
+    self.spacerView.setContentHuggingPriority(expandingPriority, for: .horizontal)
+    self.spacerView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+    self.centerStackView.setContentHuggingPriority(.required, for: .horizontal)
+    self.textLabel.setContentHuggingPriority(.required, for: .horizontal)
+    self.textLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+    self.leadingContainer.setContentHuggingPriority(.required, for: .horizontal)
+    self.leadingContainer.setContentCompressionResistancePriority(.required, for: .horizontal)
+    self.chevronImageView.setContentHuggingPriority(.required, for: .horizontal)
+    self.chevronImageView.setContentCompressionResistancePriority(.required, for: .horizontal)
+    self.trailingContainer.setContentHuggingPriority(.required, for: .horizontal)
+    self.trailingContainer.setContentCompressionResistancePriority(.required, for: .horizontal)
+
+    self.leadingContainer.isHidden = true
+    self.trailingContainer.isHidden = true
+
+    self.centerStackView.addArrangedSubview(self.leadingContainer)
+    self.centerStackView.addArrangedSubview(self.textLabel)
+    self.centerStackView.addArrangedSubview(self.chevronImageView)
+    self.rootStackView.addArrangedSubview(self.centerStackView)
+    self.rootStackView.addArrangedSubview(self.spacerView)
+    self.rootStackView.addArrangedSubview(self.trailingContainer)
+    self.addSubview(self.rootStackView)
+
+    let margins = self.layoutMarginsGuide
+    NSLayoutConstraint.activate([
+      self.rootStackView.leadingAnchor.constraint(equalTo: margins.leadingAnchor),
+      self.rootStackView.trailingAnchor.constraint(equalTo: margins.trailingAnchor),
+      self.rootStackView.topAnchor.constraint(greaterThanOrEqualTo: self.topAnchor),
+      self.rootStackView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+      self.heightAnchor.constraint(greaterThanOrEqualToConstant: BezierSectionConstant.labelHeight),
+      self.spacerView.widthAnchor.constraint(
+        greaterThanOrEqualToConstant: BezierSectionConstant.labelTrailingSpacing
+      ),
+      self.leadingContainer.widthAnchor.constraint(
+        equalToConstant: BezierSectionConstant.labelLeadingContentLength
+      ),
+      self.leadingContainer.heightAnchor.constraint(
+        equalToConstant: BezierSectionConstant.labelLeadingContentLength
+      ),
+      self.chevronImageView.widthAnchor.constraint(
+        equalToConstant: BezierCollapsibleSectionConstant.chevronLength
+      ),
+      self.chevronImageView.heightAnchor.constraint(
+        equalToConstant: BezierCollapsibleSectionConstant.chevronLength
+      ),
+      self.trailingContainer.heightAnchor.constraint(
+        equalToConstant: BezierSectionConstant.labelTrailingContentHeight
+      ),
+    ])
+
+    self.addTarget(self, action: #selector(self.handleTap), for: .touchUpInside)
+
+    self.refreshText()
+    self.refreshChevron()
+  }
+
+  // MARK: - Layout
+
+  override var intrinsicContentSize: CGSize {
+    CGSize(width: UIView.noIntrinsicMetric, height: BezierSectionConstant.labelHeight)
+  }
+
+  // MARK: - Slot
+
+  private func updateSlot(container: UIView, old: UIView?, new: UIView?) {
+    old?.removeFromSuperview()
+    guard let new else {
+      container.isHidden = true
+      return
+    }
+    new.translatesAutoresizingMaskIntoConstraints = false
+    container.addSubview(new)
+    NSLayoutConstraint.activate([
+      new.topAnchor.constraint(equalTo: container.topAnchor),
+      new.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+      new.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+      new.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+    ])
+    container.isHidden = false
+  }
+
+  // MARK: - Trait
+
+  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    self.refreshAppearance()
+  }
+
+  // MARK: - Refresh
+
+  private func refreshAppearance() {
+    self.refreshText()
+    self.refreshChevron()
+    self.refreshPressed()
+  }
+
+  private func refreshText() {
+    if !self.text.isEmpty {
+      self.textLabel.attributedText = BezierSectionConstant.labelTypography.attributedString(
+        self,
+        text: self.text,
+        semanticColorToken: self.color.textColor,
+        alignment: .left,
+        lineBreakMode: .byTruncatingTail
+      )
+      self.textLabel.isHidden = false
+    } else {
+      self.textLabel.attributedText = nil
+      self.textLabel.isHidden = true
+    }
+  }
+
+  private func refreshChevron() {
+    self.chevronImageView.image = BezierCollapsibleSectionConstant
+      .chevronIcon(isOpen: self.isOpen)
+      .uiImage?
+      .withRenderingMode(.alwaysTemplate)
+    self.chevronImageView.tintColor = self.color.chevronColor.palette(self)
+  }
+
+  private func refreshPressed() {
+    self.backgroundColor = self.isHighlighted
+      ? BezierCollapsibleSectionConstant.labelPressedBackgroundColor.palette(self)
+      : .clear
+    BezierPressFeedback.apply(isPressed: self.isHighlighted, to: self.rootStackView)
+  }
+
+  // MARK: - Action
+
+  @objc private func handleTap() {
+    self.onTap?()
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierCollapsibleSection/BezierCollapsibleSectionLabel.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierCollapsibleSection/BezierCollapsibleSectionLabel.swift
@@ -106,6 +106,8 @@ final class BezierCollapsibleSectionLabel: UIControl, BezierComponentable {
 
   private func setUp() {
     self.translatesAutoresizingMaskIntoConstraints = false
+    self.isAccessibilityElement = true
+    self.accessibilityTraits = .button
     self.layer.cornerRadius = BezierSectionConstant.labelCornerRadius
     self.layer.masksToBounds = true
     self.directionalLayoutMargins = NSDirectionalEdgeInsets(
@@ -214,6 +216,8 @@ final class BezierCollapsibleSectionLabel: UIControl, BezierComponentable {
   }
 
   private func refreshText() {
+    self.accessibilityLabel = self.text
+
     if !self.text.isEmpty {
       self.textLabel.attributedText = BezierSectionConstant.labelTypography.attributedString(
         self,

--- a/Sources/BezierSwift/MasterComponent/BezierCollapsibleSection/BezierCollapsibleSectionSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierCollapsibleSection/BezierCollapsibleSectionSpec.swift
@@ -12,7 +12,9 @@ public enum BezierCollapsibleSectionConstant {
   /// 헤더 chevron 아이콘 한 변 길이 (Figma `chevron` 16×16).
   public static let chevronLength: CGFloat = 16
 
-  static let openAnimationDuration: TimeInterval = 0.25
+  /// 접기/펼치기 전환 시간(초). 소비자가 `isOpen`을 외부에서 토글할 때 컴포넌트와 같은 리듬으로
+  /// 애니메이션하려면 이 값을 `withAnimation`에 전달한다.
+  public static let openAnimationDuration: TimeInterval = 0.25
 
   static let labelPressedBackgroundColor: BCSemanticToken = .fillNeutralLighter
 

--- a/Sources/BezierSwift/MasterComponent/BezierCollapsibleSection/BezierCollapsibleSectionSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierCollapsibleSection/BezierCollapsibleSectionSpec.swift
@@ -1,0 +1,33 @@
+//
+//  BezierCollapsibleSectionSpec.swift
+//  BezierSwift
+//
+
+import Foundation
+import CoreGraphics
+
+// MARK: - Constant
+
+public enum BezierCollapsibleSectionConstant {
+  /// 헤더 chevron 아이콘 한 변 길이 (Figma `chevron` 16×16).
+  public static let chevronLength: CGFloat = 16
+
+  static let openAnimationDuration: TimeInterval = 0.25
+
+  static let labelPressedBackgroundColor: BCSemanticToken = .fillNeutralLighter
+
+  static func chevronIcon(isOpen: Bool) -> BezierIcon {
+    isOpen ? .chevronSmallDown : .chevronSmallRight
+  }
+}
+
+// MARK: - Chevron Color
+
+extension BezierSectionLabelColor {
+  var chevronColor: BCSemanticToken {
+    switch self {
+    case .neutralDark: return .iconNeutralHeavier
+    case .neutralLight: return .iconNeutral
+    }
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierCollapsibleSection/SPEC.md
+++ b/Sources/BezierSwift/MasterComponent/BezierCollapsibleSection/SPEC.md
@@ -1,0 +1,146 @@
+# BezierCollapsibleSection SPEC
+
+> **SSOT**: [Figma · Mobile-Components / CollapsibleSection (4281:36)](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=4281-36) · [Internal/CollapsibleSectionLabel (4279:6229)](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=4279-6229)
+> **Design spec doc**: [team-design / bezier-v3 / components / CollapsibleSection-spec.md](https://github.com/channel-io/team-design/blob/main/bezier-v3/components/CollapsibleSection-spec.md) (보조 참조 — 값 충돌 시 Figma 파일 우선)
+
+접기/펼치기 가능한 인터랙티브 섹션 컴포넌트 (Figma component description 1행).
+
+## 1. Component Properties
+
+### CollapsibleSection (CS `4281:36`)
+
+| Property | 값 | 비고 |
+|---|---|---|
+| **open** | `true` / `false` (기본 `true`) | `true`: SectionContent 표시, `false`: 숨김 |
+| **SectionContent** | SLOT | 리스트 아이템 영역 (`open=false`에서 hidden) |
+
+총 instance: open 2개 (`true` = `4281:10`, `false` = `4281:23`)
+
+### Internal/CollapsibleSectionLabel (CS `4279:6229`)
+
+| Property | 값 | 비고 |
+|---|---|---|
+| **color** | `neutral-dark` / `neutral-light` | 텍스트·chevron 색 결정 |
+| **open** | `true` / `false` | chevron 방향 결정 |
+| **hasLeadingContent** | BOOLEAN, 기본 `false` | 좌측 아이콘 슬롯 표시 |
+| **hasTrailingContent** | BOOLEAN, 기본 `false` | 우측 액션 영역 표시 |
+| **label** | TEXT | 헤더 텍스트 |
+| **leadingContent** | SLOT (20×20) | 좌측 아이콘 |
+| **trailingContent** | SLOT (높이 20, 우측 정렬) | 우측 액션 |
+
+총 instance: color 2 × open 2 = 4개
+
+## 2. Layout Spec
+
+### CollapsibleSection 루트
+
+| Part | 값 |
+|---|---|
+| 배치 | 세로 스택: CollapsibleSectionLabel(header) → SectionContent |
+| header–SectionContent 간격 | `0pt` |
+| 루트 패딩 / 배경 / 테두리 | 없음 |
+| header 폭 | 루트 전체 폭 |
+| SectionContent | `open=true`일 때만 표시, 루트 전체 폭 |
+
+### Internal/CollapsibleSectionLabel
+
+| Part | 값 |
+|---|---|
+| 최소 높이 | `32pt` (min-height — 내용이 크면 성장) |
+| 좌우 패딩 | `10pt` |
+| radius | `8pt` (`radius/8`) |
+| 루트 gap | `4pt` (centerContent ↔ trailingContent) |
+| centerContent | flex-1, 내부 gap `8pt`, min-height `24pt` |
+| leadingContent 슬롯 | `20×20pt` |
+| chevron | `16×16pt`, label 텍스트 바로 우측, 항상 표시 |
+| trailingContent 슬롯 | 높이 `20pt` 래퍼, 우측 정렬, shrink 없음 |
+| 텍스트 overflow | 1줄, ellipsis (텍스트만 가변폭 HUG) |
+
+## 3. Variant 별 컬러 토큰
+
+open 상태에 따른 컬러 변화 없음 (color variant만 컬러를 결정한다).
+
+### CollapsibleSectionLabel 텍스트
+
+| color | Token | Figma Variable | Raw |
+|---|---|---|---|
+| `neutral-dark` | `textNeutral` | `color/text/neutral` | `#000000D9` |
+| `neutral-light` | `textNeutralLighter` | `color/text/neutral/lighter` | `#00000066` |
+
+### CollapsibleSectionLabel chevron
+
+| color | Token | Figma Variable | Raw |
+|---|---|---|---|
+| `neutral-dark` | `iconNeutralHeavier` | `color/icon/neutral/heavier` | `#000000D9` |
+| `neutral-light` | `iconNeutral` | `color/icon/neutral` | `#00000066` |
+
+## 4. Typography
+
+### Case A — Typography Token 사용
+
+| 위치 | Token | Figma Style 이름 |
+|---|---|---|
+| CollapsibleSectionLabel 텍스트 | `BTSemanticToken.textMedium(weight: .bold)` | `Typography/text/medium-bold` (14 / 700 / lh 18 / ls 0) |
+
+### Case B — Custom Typography
+
+없음.
+
+## 5. State 별 시각 동작
+
+| State | 시각 변화 | 비고 |
+|---|---|---|
+| `open=true` (expanded) | SectionContent 표시. chevron = `chevron-small-down` | Figma description: "open: true(ChevronSmallDown)" |
+| `open=false` (collapsed) | SectionContent 숨김. chevron = `chevron-small-right` | Figma description: "false(ChevronSmallRight)" |
+
+CollapsibleSectionLabel CS의 variant 축은 `color` × `open`뿐 — pressed/hover/disabled 시각 variant 없음.
+
+## 6. Asset
+
+| 위치 | 조건 | Figma asset | 코드 자산 |
+|---|---|---|---|
+| chevron | `open=true` | chevron-small-down 형상 (Figma 렌더는 chevron-small-right 90° 회전 인스턴스) | `BezierIcon.chevronSmallDown` |
+| chevron | `open=false` | chevron-small-right 형상 | `BezierIcon.chevronSmallRight` |
+| leadingContent 기본 예시 | `hasLeadingContent=true` | `icon/folder` (SLOT 대표 예시 콘텐츠 — 소비자 주입 영역) | 소비자 주입 |
+| trailingContent 기본 예시 | `hasTrailingContent=true` | `IconButton` 20×20 (SLOT 대표 예시 콘텐츠 — 소비자 주입 영역) | 소비자 주입 |
+
+## 7. 디자이너 가이드라인 (Figma component description 인용)
+
+### CollapsibleSection
+
+- 접기/펼치기 가능한 인터랙티브 섹션 컴포넌트.
+- CollapsibleSectionLabel: color(neutralDark/neutralLight) · leadingIcon · label · trailingContent
+- open: true(expanded) / false(collapsed, SectionContent 숨김)
+- 정적 그룹핑만 필요하면 Section 사용.
+
+### Internal/CollapsibleSectionLabel
+
+- Used within CollapsibleSection only. Do not place standalone. CollapsibleSection 전용 header bar. SectionLabel과 동일한 머리 영역 역할이며, chevron이 항상 표시된다.
+- color: neutralDark(--color-text-neutral) / neutralLight(--color-text-neutral-lighter)
+- open: true(ChevronSmallDown) / false(ChevronSmallRight)
+- hasLeadingContent / leadingContent: 좌측 아이콘 슬롯 표시 (기본값 false)
+- hasTrailingContent / trailingContent: 우측 액션 영역 슬롯 표시
+- label: 헤더 텍스트
+
+## 8. Figma 외 · 협의 사항
+
+Figma에 없는 구현 아키텍처 결정은 아래에 분리 표기한다. SSOT 값이 아니다.
+
+1. **상태 소유**: UIKit `BezierCollapsibleSection`은 `isOpen`을 컴포넌트가 소유하고 헤더 탭 시 스스로 토글 후 `onOpenChange`로 통지한다 (`UISwitch.isOn` 관례). 프로그래매틱 변경은 `isOpen` setter(비애니메이션) 또는 `setOpen(_:animated:)`. SwiftUI `SUBezierCollapsibleSection`은 `Binding<Bool>` 제어형 단일 모드 (SwiftUI 관례 — 소비자가 `@State` 보유).
+2. **헤더 pressed 피드백**: Mobile CS에 state 축이 없으나 헤더는 인터랙티브 요소이므로 `BezierBaseItem` pressed 관례와 정렬한다 — pressed 배경 `fillNeutralLighter`(radius 8, full-size 유지) + 콘텐츠 press scale(`BezierPressFeedback`, Reduce Motion 시 생략).
+3. **접기/펼치기 애니메이션**: Figma에 명세 없음. UIKit은 `UIView.animate` easeInOut 0.25s로 SectionContent 표시/숨김 + 알파 전환, SwiftUI는 동일 duration의 easeInOut. Reduce Motion 시 애니메이션 생략. chevron은 상태별 아이콘 교체 (회전 애니메이션 명세 없음).
+4. **라벨 비공개**: Figma `Internal/` 그룹 + "Do not place standalone" description에 따라 라벨 뷰는 internal (`BezierSectionLabel`이 public인 것은 `BezierSectionLayout` supplementary 구성 요구 때문이며 CollapsibleSection에는 해당 경로가 없음).
+5. **Section 패밀리 공유 재사용**: 라벨 color 축은 `BezierSectionLabelColor`, 공통 레이아웃 수치는 `BezierSectionConstant.label*`을 그대로 재사용한다 (composition — Figma 실측상 두 라벨의 레이아웃 수치가 동일). chevron 등 CollapsibleSection 전용 수치만 `BezierCollapsibleSectionConstant`에 둔다.
+6. **items API**: `BezierSection`과 동형 — `items` / `setItems(_:)` / `addItem(_:)` (UIKit), 데이터 주도 init (SwiftUI).
+7. **라벨 필수**: 헤더는 필수 파트(CS에 hasLabel 축 없음) — `labelText`는 non-optional.
+8. **disabled 미제공**: Mobile CS에 disabled variant 없음 — 스타일·API 미제공.
+
+## 9. Variant 매트릭스
+
+```
+CollapsibleSection:      open=true = 4281:10, open=false = 4281:23  (총 2)
+CollapsibleSectionLabel: color=neutral-dark, open=true  = 4279:7
+                         color=neutral-dark, open=false = 4279:16
+                         color=neutral-light, open=true  = 4279:25
+                         color=neutral-light, open=false = 4279:34  (총 4)
+```

--- a/Sources/BezierSwift/MasterComponent/BezierCollapsibleSection/SUBezierCollapsibleSection.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierCollapsibleSection/SUBezierCollapsibleSection.swift
@@ -1,0 +1,329 @@
+//
+//  SUBezierCollapsibleSection.swift
+//  BezierSwift
+//
+
+import SwiftUI
+
+/// 헤더 탭으로 콘텐츠를 접고 펼치는 인터랙티브 섹션 컨테이너 (SwiftUI). 데이터 컬렉션을 받아 헤더(라벨·chevron) + 행 목록을 그리며 행에는 `SUBezierSectionItem`을 넣는다. 펼침 상태는 `isOpen` 바인딩으로 소비자가 소유한다 (Figma `CollapsibleSection`의 `open` 프로퍼티 대응). 정적 그룹핑만 필요하면 `SUBezierSection`을 사용한다. UIKit에서는 `BezierCollapsibleSection`을 사용한다.
+public struct SUBezierCollapsibleSection<
+  Data: RandomAccessCollection,
+  ID: Hashable,
+  Row: View,
+  LabelLeading: View,
+  LabelTrailing: View
+>: View, Themeable {
+  @Environment(\.colorScheme) public var colorScheme
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+  @Binding private var isOpen: Bool
+  private let data: Data
+  private let id: KeyPath<Data.Element, ID>
+  private let labelText: String
+  private let labelColor: BezierSectionLabelColor
+  private let labelLeading: LabelLeading
+  private let labelTrailing: LabelTrailing
+  private let rowContent: (Data.Element) -> Row
+
+  /// 데이터 컬렉션·식별 keyPath·펼침 상태 바인딩·헤더로 섹션을 만든다. `rowContent`로 각 원소의 행 뷰를, `labelLeading`/`labelTrailing`으로 헤더 좌·우 슬롯을 구성한다.
+  public init(
+    _ data: Data,
+    id: KeyPath<Data.Element, ID>,
+    isOpen: Binding<Bool>,
+    labelText: String,
+    labelColor: BezierSectionLabelColor = .neutralDark,
+    @ViewBuilder labelLeading: () -> LabelLeading,
+    @ViewBuilder labelTrailing: () -> LabelTrailing,
+    @ViewBuilder rowContent: @escaping (Data.Element) -> Row
+  ) {
+    self.data = data
+    self.id = id
+    self._isOpen = isOpen
+    self.labelText = labelText
+    self.labelColor = labelColor
+    self.labelLeading = labelLeading()
+    self.labelTrailing = labelTrailing()
+    self.rowContent = rowContent
+  }
+
+  public var body: some View {
+    VStack(alignment: .leading, spacing: BezierSectionConstant.labelToContentSpacing) {
+      self.header
+
+      if self.isOpen {
+        self.rows
+      }
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .clipped()
+  }
+
+  // MARK: - Header
+
+  private var header: some View {
+    Button(action: self.toggle) {
+      self.headerContent
+    }
+    .buttonStyle(SUBezierCollapsibleSectionLabelStyle())
+  }
+
+  private var headerContent: some View {
+    HStack(spacing: 0) {
+      HStack(spacing: BezierSectionConstant.labelLeadingSpacing) {
+        self.labelLeadingView
+
+        Text(self.labelText)
+          .applyBezierFontStyle(
+            BezierSectionConstant.labelTypography,
+            semanticColorToken: self.labelColor.textColor
+          )
+          .lineLimit(1)
+          .truncationMode(.tail)
+
+        self.chevronView
+      }
+
+      Spacer(minLength: BezierSectionConstant.labelTrailingSpacing)
+
+      self.labelTrailingView
+    }
+  }
+
+  private var chevronView: some View {
+    BezierCollapsibleSectionConstant.chevronIcon(isOpen: self.isOpen).image
+      .renderingMode(.template)
+      .resizable()
+      .scaledToFit()
+      .frame(
+        width: BezierCollapsibleSectionConstant.chevronLength,
+        height: BezierCollapsibleSectionConstant.chevronLength
+      )
+      .foregroundColor(self.palette(self.labelColor.chevronColor))
+  }
+
+  @ViewBuilder
+  private var labelLeadingView: some View {
+    if LabelLeading.self != EmptyView.self {
+      self.labelLeading
+        .frame(
+          width: BezierSectionConstant.labelLeadingContentLength,
+          height: BezierSectionConstant.labelLeadingContentLength
+        )
+    }
+  }
+
+  @ViewBuilder
+  private var labelTrailingView: some View {
+    if LabelTrailing.self != EmptyView.self {
+      self.labelTrailing
+        .frame(height: BezierSectionConstant.labelTrailingContentHeight)
+        .layoutPriority(1)
+    }
+  }
+
+  private func toggle() {
+    if self.reduceMotion {
+      self.isOpen.toggle()
+    } else {
+      withAnimation(
+        .easeInOut(duration: BezierCollapsibleSectionConstant.openAnimationDuration)
+      ) {
+        self.isOpen.toggle()
+      }
+    }
+  }
+
+  // MARK: - Rows
+
+  private var rows: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      ForEach(self.data, id: self.id) { element in
+        self.rowContent(element)
+      }
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+  }
+}
+
+// MARK: - Label Style (pressed 배경 + press scale)
+
+private struct SUBezierCollapsibleSectionLabelStyle: ButtonStyle {
+  func makeBody(configuration: Configuration) -> some View {
+    configuration.label
+      .modifier(SUBezierCollapsibleSectionLabelContainer(isPressed: configuration.isPressed))
+  }
+}
+
+private struct SUBezierCollapsibleSectionLabelContainer: ViewModifier, Themeable {
+  @Environment(\.colorScheme) var colorScheme
+
+  let isPressed: Bool
+
+  func body(content: Content) -> some View {
+    content
+      .bezierPressScale(isPressed: self.isPressed)
+      .padding(.horizontal, BezierSectionConstant.labelHorizontalPadding)
+      .frame(minHeight: BezierSectionConstant.labelHeight)
+      .frame(maxWidth: .infinity)
+      .background(
+        self.isPressed
+          ? self.palette(BezierCollapsibleSectionConstant.labelPressedBackgroundColor)
+          : Color.clear
+      )
+      .clipShape(RoundedRectangle(cornerRadius: BezierSectionConstant.labelCornerRadius))
+      .contentShape(Rectangle())
+  }
+}
+
+// MARK: - Convenience init
+
+extension SUBezierCollapsibleSection where LabelLeading == EmptyView {
+  /// 헤더 좌측 슬롯 없이 만드는 편의 이니셜라이저.
+  public init(
+    _ data: Data,
+    id: KeyPath<Data.Element, ID>,
+    isOpen: Binding<Bool>,
+    labelText: String,
+    labelColor: BezierSectionLabelColor = .neutralDark,
+    @ViewBuilder labelTrailing: () -> LabelTrailing,
+    @ViewBuilder rowContent: @escaping (Data.Element) -> Row
+  ) {
+    self.init(
+      data,
+      id: id,
+      isOpen: isOpen,
+      labelText: labelText,
+      labelColor: labelColor,
+      labelLeading: { EmptyView() },
+      labelTrailing: labelTrailing,
+      rowContent: rowContent
+    )
+  }
+}
+
+extension SUBezierCollapsibleSection where LabelLeading == EmptyView, LabelTrailing == EmptyView {
+  /// 헤더 좌·우 슬롯 없이 만드는 편의 이니셜라이저.
+  public init(
+    _ data: Data,
+    id: KeyPath<Data.Element, ID>,
+    isOpen: Binding<Bool>,
+    labelText: String,
+    labelColor: BezierSectionLabelColor = .neutralDark,
+    @ViewBuilder rowContent: @escaping (Data.Element) -> Row
+  ) {
+    self.init(
+      data,
+      id: id,
+      isOpen: isOpen,
+      labelText: labelText,
+      labelColor: labelColor,
+      labelLeading: { EmptyView() },
+      labelTrailing: { EmptyView() },
+      rowContent: rowContent
+    )
+  }
+}
+
+extension SUBezierCollapsibleSection where Data.Element: Identifiable, ID == Data.Element.ID {
+  /// 원소가 `Identifiable`일 때 `id` keyPath를 생략하는 편의 이니셜라이저.
+  public init(
+    _ data: Data,
+    isOpen: Binding<Bool>,
+    labelText: String,
+    labelColor: BezierSectionLabelColor = .neutralDark,
+    @ViewBuilder labelLeading: () -> LabelLeading,
+    @ViewBuilder labelTrailing: () -> LabelTrailing,
+    @ViewBuilder rowContent: @escaping (Data.Element) -> Row
+  ) {
+    self.init(
+      data,
+      id: \.id,
+      isOpen: isOpen,
+      labelText: labelText,
+      labelColor: labelColor,
+      labelLeading: labelLeading,
+      labelTrailing: labelTrailing,
+      rowContent: rowContent
+    )
+  }
+}
+
+extension SUBezierCollapsibleSection
+where Data.Element: Identifiable, ID == Data.Element.ID, LabelLeading == EmptyView, LabelTrailing == EmptyView {
+  /// 원소가 `Identifiable`이고 헤더 슬롯이 없을 때 쓰는 편의 이니셜라이저.
+  public init(
+    _ data: Data,
+    isOpen: Binding<Bool>,
+    labelText: String,
+    labelColor: BezierSectionLabelColor = .neutralDark,
+    @ViewBuilder rowContent: @escaping (Data.Element) -> Row
+  ) {
+    self.init(
+      data,
+      id: \.id,
+      isOpen: isOpen,
+      labelText: labelText,
+      labelColor: labelColor,
+      labelLeading: { EmptyView() },
+      labelTrailing: { EmptyView() },
+      rowContent: rowContent
+    )
+  }
+}
+
+// MARK: - Preview
+
+struct SUBezierCollapsibleSection_Previews: PreviewProvider {
+  private struct Host: View {
+    @State private var isFirstOpen = true
+    @State private var isSecondOpen = false
+
+    var body: some View {
+      ScrollView {
+        LazyVStack(spacing: 20) {
+          SUBezierCollapsibleSection(
+            ["태그 관리", "고객 노트", "첨부파일"],
+            id: \.self,
+            isOpen: self.$isFirstOpen,
+            labelText: "고객 정보"
+          ) { title in
+            SUBezierBaseItem(
+              title: title,
+              onTap: {},
+              leading: { Circle().fill(Color.gray) },
+              trailing: { EmptyView() }
+            )
+          }
+
+          SUBezierCollapsibleSection(
+            ["멤버 초대", "멤버 차단"],
+            id: \.self,
+            isOpen: self.$isSecondOpen,
+            labelText: "멤버",
+            labelColor: .neutralLight,
+            labelTrailing: {
+              BezierIcon.plus.image
+                .renderingMode(.template)
+                .resizable()
+                .scaledToFit()
+                .frame(width: 16, height: 16)
+                .foregroundColor(.secondary)
+            }
+          ) { title in
+            SUBezierBaseItem(
+              title: title,
+              onTap: {},
+              leading: { Circle().fill(Color.gray) },
+              trailing: { EmptyView() }
+            )
+          }
+        }
+        .padding()
+      }
+    }
+  }
+
+  static var previews: some View {
+    Host()
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierCollapsibleSection/SUBezierCollapsibleSection.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierCollapsibleSection/SUBezierCollapsibleSection.swift
@@ -65,6 +65,7 @@ public struct SUBezierCollapsibleSection<
       self.headerContent
     }
     .buttonStyle(SUBezierCollapsibleSectionLabelStyle())
+    .accessibilityLabel(self.labelText)
   }
 
   private var headerContent: some View {


### PR DESCRIPTION
## MOB-6356

https://linear.app/channel/issue/MOB-6356

V3 CollapsibleSection 컴포넌트를 UIKit + SwiftUI로 구현합니다.

## 구현 내용

### CollapsibleSection — `BezierCollapsibleSection` / `SUBezierCollapsibleSection`

- 헤더 탭으로 SectionContent를 접고 펼치는 인터랙티브 섹션 — Figma `CollapsibleSection`(`4281:36`)의 `open` 프로퍼티가 `isOpen`에 대응
- 상태 소유
  - UIKit: 컴포넌트가 `isOpen` 소유, 헤더 탭 시 자체 토글 후 `onOpenChange` 통지 (`UISwitch.isOn` 관례). 프로그래매틱 변경은 `isOpen` setter(즉시) / `setOpen(_:animated:)`(애니메이션)
  - SwiftUI: `Binding<Bool>` 제어형 단일 모드 — 소비자가 `@State` 보유
- 접기/펼치기 전환: easeInOut 0.25s (Figma에 애니메이션 명세 없음 — SPEC §8 협의), Reduce Motion 시 생략. UIKit은 `clipsToBounds` 콘텐츠 컨테이너의 `isHidden`+alpha 전환, SwiftUI는 조건부 렌더 + `withAnimation`
- 행 API는 `BezierSection` 동형 — UIKit `items`/`setItems(_:)`/`addItem(_:)`, SwiftUI 데이터 주도 init (Identifiable/keyPath × 슬롯 유무 편의 init 4종)

### 헤더 — internal `BezierCollapsibleSectionLabel` (Section 패밀리 composition 재사용)

- Figma `Internal/CollapsibleSectionLabel`(`4279:6229`, color × open 4 variant). "Do not place standalone" description에 따라 **internal** — public 표면은 컨테이너뿐
- 공유 축·수치는 Section 것을 그대로 composition 재사용: `BezierSectionLabelColor`(neutralDark/neutralLight), `BezierSectionConstant.label*`(min-height 32 / 좌우 패딩 10 / radius 8 / 루트 gap 4 / center gap 8 / leading 20×20 / trailing 높이 20). CollapsibleSection 전용 delta(chevron 16pt, 애니메이션, pressed 색)만 `BezierCollapsibleSectionConstant`에 신설 — Section 코드는 무수정
- chevron: `open=true → BezierIcon.chevronSmallDown` / `open=false → chevronSmallRight`, 색은 dark=`iconNeutralHeavier` / light=`iconNeutral` (variant별 Figma 실측 바인딩)
- 텍스트: `textMedium(weight: .bold)`, dark=`textNeutral` / light=`textNeutralLighter`, 1줄 ellipsis — **모바일 Figma는 웹 spec의 closed 상태 `text-neutral-heaviest` delta가 없음** (open/closed 색 동일, 실측 확인)
- pressed 피드백: 배경 `fillNeutralLighter`(full-size, radius 8) + 콘텐츠 0.97 scale (`BezierPressFeedback` 재사용, Reduce Motion 존중) — Mobile CS에 state 축이 없어 BaseItem pressed 관례 정렬 (SPEC §8)
- 다크모드: UIKit은 `traitCollectionDidChange`에서 텍스트·chevron tint·pressed 배경 재주입

### Examples

- `CollapsibleSectionCatalog` 신설 (사이드바 V3 Components 그룹) — labelColor/행 수 매트릭스, SwiftUI 바인딩 토글 데모, 헤더 슬롯(leading/trailing) 데모, UIKit `setOpen` 프로그래매틱 제어 토글(양방향 동기화) 포함
- UIKit representable은 `sizeThatFits`로 접힘/펼침 높이를 SwiftUI에 전파, 매트릭스 @State는 update 클로저에서 재주입

## Spec 검증

figma-component-spec 3단계 사이클로 검증했습니다 (Figma = SSOT):

- Phase 1: Figma 실측 기반 `SPEC.md` 작성 (CollapsibleSection `4281:36` / Internal/CollapsibleSectionLabel `4279:6229`, 4 variant 전수)
- Phase 2: Properties / Layout / Color / Typography / Asset / Spec Noise / Implementation Reference 7종 검증 전부 통과 (Noise 지적 1건 — §8 문구의 Figma 외 문서 귀속 표현 — 수정 반영)
- Phase 3: UIKit·SwiftUI 구현–SPEC 전 항목 대조 검증 완료 (clean build 2종 — 패키지 `BezierSwift` 스킴 + Examples 앱 — BUILD SUCCEEDED)
- Figma에 없는 구현 결정(상태 소유 방식, pressed 피드백, 애니메이션 파라미터, 라벨 internal 처리, Section 상수 재사용, labelText 필수)은 `SPEC.md` §8에 협의 사항으로 분리 기록
- 비차단 관찰 1건: Figma master CS의 neutral-dark 2개 variant에서 label 텍스트가 opacity 100% override로 렌더되는 디자이너 측 quirk 확인 (실사용 인스턴스는 정상 0.85 — 구현은 토큰 `textNeutral` #000000D9 기준)

## 스크린샷

시뮬레이터(iPhone 16 / iOS 18.6) 검증 완료 — 캡처 파일 기준:

| 파일 | 검증 내용 |
|---|---|
| `01-light-open-swiftui.png` | 라이트 · SwiftUI 펼침 + 슬롯 샘플 접힘 + UIKit 펼침 (초기 상태) |
| `02-light-closed-swiftui.png` | 라이트 · SwiftUI 접힘 (chevron-right, 행 숨김, 하위 레이아웃 재배치) |
| `03-label-slots-open.png` | labelLeading(folder 20×20) + labelTrailing(plus) 슬롯 + 펼침 |
| `04-uikit-collapsed-sync.png` | UIKit 헤더 탭 접힘 — `sizeThatFits` 높이 전파 + `onOpenChange`→토글 OFF 역방향 동기화 |
| `05-uikit-setopen-programmatic.png` | 토글 ON → `setOpen` 프로그래매틱 펼침 + 높이 재전파 |
| `06-labelcolor-neutrallight.png` | 라이트 · neutralLight (SwiftUI·UIKit 동시 반영 — 매트릭스 재주입) |
| `07-dark-mixed.png` | 다크 · neutralDark · 접힘+펼침 혼합 (UIKit traitCollectionDidChange 재주입 포함) |
| `08-collapse-animation-midframe.png` | 접힘 애니메이션(0.25s) 중간 프레임 — 행 페이드 + 높이 축소 진행 중 |
| `09-pressed.png` | 헤더 long-press 중 — `fillNeutralLighter` pressed 배경(radius 8) + 콘텐츠 0.97 scale |
| `10-dark-neutrallight.png` | 다크 · neutralLight |

## 테스트

- 패키지 `BezierSwift` 스킴 + Examples 앱 clean build 통과 (iPhone 16 Pro 시뮬레이터 destination)
- 시뮬레이터(iPhone 16 / iOS 18.6) 시각 검증 완료: 라이트/다크 × 접힘/펼침 × labelColor 조합, 접기/펼치기 애니메이션 중간 프레임, 헤더 pressed 피드백, UIKit 높이 전파·양방향 상태 동기화 — 렌더링 결함 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * UIKit/SwiftUI에서 접기·펼치기 섹션을 제공하며, 열림 상태와 애니메이션(모션 감소 반영)을 지원합니다.
  * 헤더 라벨 색상 및 좌/우 슬롯, 누름 피드백, chevron 전환을 포함하고 행을 동적으로 추가/교체할 수 있습니다.
* **문서 및 예제**
  * 컴포넌트 명세 문서와 SwiftUI 프리뷰/예제 카탈로그 항목을 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->