### PR TITLE
[MOB-6355] BezierDropdownMenu 컴포넌트 구현 (UIKit + SwiftUI)

### DIFF
--- a/Examples/BezierExamples/BezierExamples/App/CatalogRegistry.swift
+++ b/Examples/BezierExamples/BezierExamples/App/CatalogRegistry.swift
@@ -148,6 +148,12 @@ enum CatalogRegistry {
       section: .v3Components,
       destination: AnyView(TextInputCatalog())
     ),
+    CatalogItem(
+      id: "dropdown-menu",
+      title: "DropdownMenu",
+      section: .v3Components,
+      destination: AnyView(DropdownMenuCatalog())
+    ),
     // MARK: - Legacy Components
     CatalogItem(
       id: "legacy-button",

--- a/Examples/BezierExamples/BezierExamples/Components/DropdownMenuCatalog.swift
+++ b/Examples/BezierExamples/BezierExamples/Components/DropdownMenuCatalog.swift
@@ -1,0 +1,240 @@
+import SwiftUI
+import UIKit
+import BezierSwift
+
+private enum DropdownMenuLeadingKind: String, CaseIterable {
+  case none
+  case icon
+  case custom
+}
+
+struct DropdownMenuCatalog: View {
+  @State private var leadingKind: DropdownMenuLeadingKind = .icon
+  @State private var isDestructiveGroupShown = true
+  @State private var showsTrigger = true
+  @State private var showsGroupLabel = true
+  @State private var hasDescription = false
+  @State private var showsShortcut = true
+  @State private var isEnabled = true
+
+  var body: some View {
+    CatalogScreen(title: "DropdownMenu") {
+      self.controls
+      CatalogSection(.swiftUI) { self.swiftUIPreview }
+      CatalogSection(.uiKit) { self.uiKitPreview }
+    }
+  }
+
+  private var controls: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Picker("leading", selection: self.$leadingKind) {
+        ForEach(DropdownMenuLeadingKind.allCases, id: \.self) { kind in
+          Text(kind.rawValue).tag(kind)
+        }
+      }
+      .pickerStyle(.segmented)
+
+      Toggle("showsTrigger", isOn: self.$showsTrigger)
+      Toggle("group label", isOn: self.$showsGroupLabel)
+      Toggle("destructive group", isOn: self.$isDestructiveGroupShown)
+      Toggle("hasDescription", isOn: self.$hasDescription)
+      Toggle("shortcut trailing", isOn: self.$showsShortcut)
+      Toggle("isEnabled", isOn: self.$isEnabled)
+    }
+    .font(.caption)
+  }
+
+  // MARK: - SwiftUI
+
+  private var swiftUIPreview: some View {
+    Group {
+      if self.showsTrigger {
+        SUBezierDropdownMenu {
+          SUBezierIconButton(icon: BezierIcon.moreVertical.image, action: {})
+        } content: {
+          self.menuContent
+        }
+      } else {
+        SUBezierDropdownMenu {
+          self.menuContent
+        }
+      }
+    }
+    .disabled(!self.isEnabled)
+    .padding(24)
+    .frame(maxWidth: .infinity)
+    .background(Color(uiColor: .secondarySystemBackground))
+  }
+
+  @ViewBuilder
+  private var menuContent: some View {
+    SUBezierDropdownMenuGroup(
+      labelText: self.showsGroupLabel ? "편집" : nil,
+      showsDivider: self.isDestructiveGroupShown
+    ) {
+      SUBezierDropdownMenuItem(
+        title: "이름 변경",
+        description: self.hasDescription ? "팀 전체에 공유됩니다" : nil,
+        leading: self.swiftUILeading(icon: .edit),
+        onTap: {}
+      )
+      SUBezierDropdownMenuItem(
+        title: "복제",
+        leading: self.swiftUILeading(icon: .linkCopy),
+        onTap: {},
+        trailing: {
+          if self.showsShortcut {
+            Text("⌘D")
+              .font(.caption)
+              .foregroundStyle(.secondary)
+          }
+        }
+      )
+    }
+
+    if self.isDestructiveGroupShown {
+      SUBezierDropdownMenuGroup {
+        SUBezierDropdownMenuItem(
+          variant: .destructive,
+          title: "삭제",
+          description: self.hasDescription ? "복구할 수 없어요" : nil,
+          leading: self.swiftUILeading(icon: .trash),
+          onTap: {}
+        )
+      }
+    }
+  }
+
+  private func swiftUILeading(icon: BezierIcon) -> BezierDropdownMenuItemLeading<AnyView> {
+    switch self.leadingKind {
+    case .none:
+      return .none
+    case .icon:
+      return .icon(icon)
+    case .custom:
+      return .custom(AnyView(Circle().fill(Color.orange.opacity(0.4))))
+    }
+  }
+
+  // MARK: - UIKit
+
+  private var uiKitPreview: some View {
+    DropdownMenuUIKitRepresentable(
+      leadingKind: self.leadingKind,
+      isDestructiveGroupShown: self.isDestructiveGroupShown,
+      showsTrigger: self.showsTrigger,
+      showsGroupLabel: self.showsGroupLabel,
+      hasDescription: self.hasDescription,
+      showsShortcut: self.showsShortcut,
+      isEnabled: self.isEnabled
+    )
+    .padding(24)
+    .frame(maxWidth: .infinity)
+    .background(Color(uiColor: .secondarySystemBackground))
+  }
+}
+
+private struct DropdownMenuUIKitRepresentable: UIViewRepresentable {
+  let leadingKind: DropdownMenuLeadingKind
+  let isDestructiveGroupShown: Bool
+  let showsTrigger: Bool
+  let showsGroupLabel: Bool
+  let hasDescription: Bool
+  let showsShortcut: Bool
+  let isEnabled: Bool
+
+  // BezierDropdownMenu는 240pt 고정 폭이라 wrapper에서 center로 배치한다.
+  func makeUIView(context: Context) -> UIView {
+    let wrapper = UIView()
+    let menu = BezierDropdownMenu()
+    menu.translatesAutoresizingMaskIntoConstraints = false
+    wrapper.addSubview(menu)
+    NSLayoutConstraint.activate([
+      menu.topAnchor.constraint(equalTo: wrapper.topAnchor),
+      menu.bottomAnchor.constraint(equalTo: wrapper.bottomAnchor),
+      menu.centerXAnchor.constraint(equalTo: wrapper.centerXAnchor),
+    ])
+    return wrapper
+  }
+
+  func updateUIView(_ wrapper: UIView, context: Context) {
+    guard let menu = wrapper.subviews.compactMap({ $0 as? BezierDropdownMenu }).first else { return }
+
+    if self.showsTrigger {
+      let trigger = BezierIconButton()
+      trigger.icon = BezierIcon.moreVertical.uiImage
+      menu.trigger = trigger
+    } else {
+      menu.trigger = nil
+    }
+
+    var contents: [UIView] = []
+
+    let renameItem = BezierDropdownMenuItem(
+      title: "이름 변경",
+      description: self.hasDescription ? "팀 전체에 공유됩니다" : nil,
+      leading: self.uiKitLeading(icon: .edit),
+      onTap: {}
+    )
+    renameItem.isEnabled = self.isEnabled
+
+    let duplicateItem = BezierDropdownMenuItem(
+      title: "복제",
+      leading: self.uiKitLeading(icon: .linkCopy),
+      onTap: {}
+    )
+    duplicateItem.isEnabled = self.isEnabled
+    if self.showsShortcut {
+      let shortcutLabel = UILabel()
+      shortcutLabel.text = "⌘D"
+      shortcutLabel.font = .preferredFont(forTextStyle: .caption1)
+      shortcutLabel.textColor = .secondaryLabel
+      duplicateItem.trailingContent = shortcutLabel
+    }
+
+    contents.append(
+      BezierDropdownMenuGroup(
+        labelText: self.showsGroupLabel ? "편집" : nil,
+        showsDivider: self.isDestructiveGroupShown,
+        items: [renameItem, duplicateItem]
+      )
+    )
+
+    if self.isDestructiveGroupShown {
+      let deleteItem = BezierDropdownMenuItem(
+        variant: .destructive,
+        title: "삭제",
+        description: self.hasDescription ? "복구할 수 없어요" : nil,
+        leading: self.uiKitLeading(icon: .trash),
+        onTap: {}
+      )
+      deleteItem.isEnabled = self.isEnabled
+      contents.append(BezierDropdownMenuGroup(items: [deleteItem]))
+    }
+
+    menu.contents = contents
+  }
+
+  func sizeThatFits(_ proposal: ProposedViewSize, uiView: UIView, context: Context) -> CGSize? {
+    let fitting = uiView.systemLayoutSizeFitting(
+      CGSize(width: BezierOverlayConstant.width, height: UIView.layoutFittingCompressedSize.height),
+      withHorizontalFittingPriority: .fittingSizeLevel,
+      verticalFittingPriority: .fittingSizeLevel
+    )
+    return CGSize(width: proposal.width ?? fitting.width, height: fitting.height)
+  }
+
+  private func uiKitLeading(icon: BezierIcon) -> BezierDropdownMenuItemLeading<UIView> {
+    switch self.leadingKind {
+    case .none:
+      return .none
+    case .icon:
+      return .icon(icon)
+    case .custom:
+      let circle = UIView()
+      circle.backgroundColor = UIColor.orange.withAlphaComponent(0.4)
+      circle.layer.cornerRadius = 12
+      return .custom(circle)
+    }
+  }
+}

--- a/Examples/BezierExamples/BezierExamples/Components/DropdownMenuCatalog.swift
+++ b/Examples/BezierExamples/BezierExamples/Components/DropdownMenuCatalog.swift
@@ -163,6 +163,7 @@ private struct DropdownMenuUIKitRepresentable: UIViewRepresentable {
     if self.showsTrigger {
       let trigger = BezierIconButton()
       trigger.icon = BezierIcon.moreVertical.uiImage
+      trigger.isEnabled = self.isEnabled
       menu.trigger = trigger
     } else {
       menu.trigger = nil

--- a/Sources/BezierSwift/MasterComponent/BezierBaseItem/BezierBaseItem.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBaseItem/BezierBaseItem.swift
@@ -51,6 +51,13 @@ public final class BezierBaseItem: UIControl, BezierComponentable {
     didSet { self.updateSlot(container: self.trailingContainer, old: oldValue, new: self.trailingContent, fill: true) }
   }
 
+  // MARK: - Internal Style
+
+  /// 파생 `*Item` 컴포넌트가 composition 시 주입하는 내부 스타일. 기본값은 BaseItem 자체 스펙과 동일하다.
+  var style = BezierBaseItemStyle() {
+    didSet { self.applyStyle() }
+  }
+
   // MARK: - State
 
   public override var isHighlighted: Bool {
@@ -155,7 +162,7 @@ public final class BezierBaseItem: UIControl, BezierComponentable {
 
   private func setUp() {
     self.translatesAutoresizingMaskIntoConstraints = false
-    self.layer.cornerRadius = BezierBaseItemConstant.cornerRadius
+    self.layer.cornerRadius = self.style.cornerRadius
     self.layer.masksToBounds = true
 
     self.setUpLeading()
@@ -268,12 +275,23 @@ public final class BezierBaseItem: UIControl, BezierComponentable {
     self.minHeightConstraint?.constant = self.size.minHeight
     self.directionalLayoutMargins = NSDirectionalEdgeInsets(
       top: self.size.verticalPadding,
-      leading: BezierBaseItemConstant.horizontalPadding,
+      leading: self.style.horizontalPadding,
       bottom: self.size.verticalPadding,
-      trailing: BezierBaseItemConstant.horizontalPadding
+      trailing: self.style.horizontalPadding
+    )
+    self.centerStackView.directionalLayoutMargins = NSDirectionalEdgeInsets(
+      top: 0,
+      leading: self.style.centerLeadingInset,
+      bottom: 0,
+      trailing: 0
     )
     self.refreshText()
     self.setNeedsLayout()
+  }
+
+  private func applyStyle() {
+    self.layer.cornerRadius = self.style.cornerRadius
+    self.refreshSize()
   }
 
   private func refreshText() {
@@ -281,7 +299,7 @@ public final class BezierBaseItem: UIControl, BezierComponentable {
       self.titleLabel.attributedText = BezierBaseItemConstant.titleTypography.attributedString(
         self,
         text: self.title,
-        semanticColorToken: BezierBaseItemConstant.titleColor,
+        semanticColorToken: self.style.titleColor,
         alignment: .left,
         lineBreakMode: .byTruncatingTail
       )
@@ -291,8 +309,10 @@ public final class BezierBaseItem: UIControl, BezierComponentable {
       self.titleLabel.isHidden = true
     }
 
-    // SPEC §2: description은 medium·large만 지원 (small variant엔 description 노드 자체가 없음)
-    if self.size != .small, let itemDescription = self.itemDescription, !itemDescription.isEmpty {
+    // SPEC §2: description은 medium·large만 지원 (small variant엔 description 노드 자체가 없음).
+    // 파생 스펙이 small에서 description을 정의하는 경우(DropdownMenuItem)만 style로 허용을 주입한다.
+    let supportsDescription = self.size != .small || self.style.allowsSmallDescription
+    if supportsDescription, let itemDescription = self.itemDescription, !itemDescription.isEmpty {
       self.descriptionLabel.attributedText = BezierBaseItemConstant.descriptionTypography.attributedString(
         self,
         text: itemDescription,

--- a/Sources/BezierSwift/MasterComponent/BezierBaseItem/BezierBaseItemSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBaseItem/BezierBaseItemSpec.swift
@@ -39,6 +39,17 @@ public enum BezierBaseItemSize: CaseIterable {
   }
 }
 
+// MARK: - Style (internal)
+
+/// 파생 `*Item` 컴포넌트가 BaseItem을 composition으로 소유할 때 주입하는 내부 스타일. 기본값은 BaseItem 자체(Figma `_BaseItem`) 스펙과 동일하며, public API로는 노출하지 않는다.
+struct BezierBaseItemStyle {
+  var horizontalPadding: CGFloat = BezierBaseItemConstant.horizontalPadding
+  var cornerRadius: CGFloat = BezierBaseItemConstant.cornerRadius
+  var centerLeadingInset: CGFloat = BezierBaseItemConstant.centerLeadingInset
+  var titleColor: BCSemanticToken = BezierBaseItemConstant.titleColor
+  var allowsSmallDescription: Bool = false
+}
+
 // MARK: - Constant
 
 public enum BezierBaseItemConstant {

--- a/Sources/BezierSwift/MasterComponent/BezierBaseItem/SUBezierBaseItem.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBaseItem/SUBezierBaseItem.swift
@@ -17,6 +17,7 @@ public struct SUBezierBaseItem<Leading: View, CenterSlot: View, Trailing: View>:
   private let leading: Leading
   private let centerSlot: CenterSlot
   private let trailing: Trailing
+  private let style: BezierBaseItemStyle
 
   /// 텍스트·크기·탭 동작과 함께 leading·centerSlot·trailing 세 슬롯 뷰를 지정해 생성한다. `description`은 `size`가 `.small`이면 무시되고, `onTap`이 `nil`이면 정적인 행이 된다.
   public init(
@@ -28,6 +29,30 @@ public struct SUBezierBaseItem<Leading: View, CenterSlot: View, Trailing: View>:
     @ViewBuilder centerSlot: () -> CenterSlot,
     @ViewBuilder trailing: () -> Trailing
   ) {
+    self.init(
+      style: BezierBaseItemStyle(),
+      size: size,
+      title: title,
+      description: description,
+      onTap: onTap,
+      leading: leading,
+      centerSlot: centerSlot,
+      trailing: trailing
+    )
+  }
+
+  /// 파생 `*Item` 컴포넌트가 composition 시 내부 스타일을 주입하는 이니셜라이저. public API로는 노출하지 않는다.
+  init(
+    style: BezierBaseItemStyle,
+    size: BezierBaseItemSize = .medium,
+    title: String,
+    description: String? = nil,
+    onTap: (() -> Void)? = nil,
+    @ViewBuilder leading: () -> Leading,
+    @ViewBuilder centerSlot: () -> CenterSlot,
+    @ViewBuilder trailing: () -> Trailing
+  ) {
+    self.style = style
     self.size = size
     self.title = title
     self.itemDescription = description
@@ -41,9 +66,11 @@ public struct SUBezierBaseItem<Leading: View, CenterSlot: View, Trailing: View>:
     Group {
       if let onTap = self.onTap {
         Button(action: onTap) { self.row }
-          .buttonStyle(SUBezierBaseItemStyle(size: self.size))
+          .buttonStyle(SUBezierBaseItemStyle(size: self.size, style: self.style))
       } else {
-        self.row.modifier(SUBezierBaseItemContainer(size: self.size, isPressed: false))
+        self.row.modifier(
+          SUBezierBaseItemContainer(size: self.size, style: self.style, isPressed: false)
+        )
       }
     }
     .opacity(self.isEnabled ? 1 : BezierBaseItemConstant.disabledOpacity)
@@ -66,6 +93,10 @@ public struct SUBezierBaseItem<Leading: View, CenterSlot: View, Trailing: View>:
     }
   }
 
+  private var supportsDescription: Bool {
+    self.size != .small || self.style.allowsSmallDescription
+  }
+
   private var centerView: some View {
     VStack(alignment: .leading, spacing: 0) {
       HStack(spacing: BezierBaseItemConstant.titleRowSpacing) {
@@ -73,7 +104,7 @@ public struct SUBezierBaseItem<Leading: View, CenterSlot: View, Trailing: View>:
           Text(self.title)
             .applyBezierFontStyle(
               BezierBaseItemConstant.titleTypography,
-              semanticColorToken: BezierBaseItemConstant.titleColor
+              semanticColorToken: self.style.titleColor
             )
             .lineLimit(1)
             .truncationMode(.tail)
@@ -82,7 +113,7 @@ public struct SUBezierBaseItem<Leading: View, CenterSlot: View, Trailing: View>:
         Spacer(minLength: 0)
       }
 
-      if self.size != .small, let itemDescription = self.itemDescription, !itemDescription.isEmpty {
+      if self.supportsDescription, let itemDescription = self.itemDescription, !itemDescription.isEmpty {
         Text(itemDescription)
           .applyBezierFontStyle(
             BezierBaseItemConstant.descriptionTypography,
@@ -92,7 +123,7 @@ public struct SUBezierBaseItem<Leading: View, CenterSlot: View, Trailing: View>:
           .frame(maxWidth: .infinity, alignment: .leading)
       }
     }
-    .padding(.leading, BezierBaseItemConstant.centerLeadingInset)
+    .padding(.leading, self.style.centerLeadingInset)
     .frame(maxWidth: .infinity, alignment: .leading)
   }
 
@@ -142,6 +173,7 @@ private struct SUBezierBaseItemContainer: ViewModifier, Themeable {
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
   let size: BezierBaseItemSize
+  let style: BezierBaseItemStyle
   let isPressed: Bool
 
   private var contentScale: CGFloat {
@@ -152,7 +184,7 @@ private struct SUBezierBaseItemContainer: ViewModifier, Themeable {
     content
       // 콘텐츠만 축소 — 배경은 full-size 유지 (press scale 피드백)
       .scaleEffect(self.contentScale)
-      .padding(.horizontal, BezierBaseItemConstant.horizontalPadding)
+      .padding(.horizontal, self.style.horizontalPadding)
       .padding(.vertical, self.size.verticalPadding)
       .frame(minHeight: self.size.minHeight)
       .frame(maxWidth: .infinity, alignment: .leading)
@@ -161,7 +193,7 @@ private struct SUBezierBaseItemContainer: ViewModifier, Themeable {
           ? self.palette(BezierBaseItemConstant.pressedBackgroundColor)
           : Color.clear
       )
-      .clipShape(RoundedRectangle(cornerRadius: BezierBaseItemConstant.cornerRadius))
+      .clipShape(RoundedRectangle(cornerRadius: self.style.cornerRadius))
       .contentShape(Rectangle())
       .animation(.spring(response: 0.34, dampingFraction: 0.62), value: self.isPressed)
   }
@@ -171,10 +203,13 @@ private struct SUBezierBaseItemContainer: ViewModifier, Themeable {
 
 private struct SUBezierBaseItemStyle: ButtonStyle {
   let size: BezierBaseItemSize
+  let style: BezierBaseItemStyle
 
   func makeBody(configuration: Configuration) -> some View {
     configuration.label
-      .modifier(SUBezierBaseItemContainer(size: self.size, isPressed: configuration.isPressed))
+      .modifier(
+        SUBezierBaseItemContainer(size: self.size, style: self.style, isPressed: configuration.isPressed)
+      )
   }
 }
 

--- a/Sources/BezierSwift/MasterComponent/BezierDropdownMenu/BezierDropdownMenu.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierDropdownMenu/BezierDropdownMenu.swift
@@ -1,0 +1,117 @@
+//
+//  BezierDropdownMenu.swift
+//  BezierSwift
+//
+
+import UIKit
+
+/// 트리거 뒤에 액션 목록을 감췄다가 항목 선택 시 곧바로 실행하는 컨텍스트 메뉴 (UIKit). 선택적 트리거 슬롯 + `BezierOverlay` 패널로 구성된 240pt 고정 폭 컴포넌트로, 패널 콘텐츠에는 `BezierDropdownMenuGroup`/`BezierDropdownMenuItem`을 넣는다. 열림/닫힘·앵커 포지셔닝·외부 탭 닫힘은 사용처 책임이다. SwiftUI에서는 `SUBezierDropdownMenu`를 사용한다.
+public final class BezierDropdownMenu: UIView, BezierComponentable {
+  // MARK: - BezierComponentable
+
+  public var colorTheme: BezierColorTheme { .systemBezierColorTheme() }
+  public var componentTheme: BezierComponentTheme = .normal {
+    didSet { self.overlay.componentTheme = self.componentTheme }
+  }
+
+  // MARK: - Public Properties
+
+  /// 메뉴를 여는 트리거 뷰. 패널 위에 우측 정렬로 배치되며, `nil`이면 트리거 행 없이 패널만 표시한다 — 화면의 기존 요소를 트리거로 외부 제어할 때 비운다 (기본값 `nil`).
+  public var trigger: UIView? {
+    didSet {
+      guard oldValue !== self.trigger else { return }
+      oldValue?.removeFromSuperview()
+      self.refreshTrigger()
+    }
+  }
+
+  /// 패널에 표시할 콘텐츠 뷰 배열(그룹 또는 항목). 교체하면 목록을 다시 만든다.
+  public var contents: [UIView] = [] {
+    didSet { self.rebuildContents() }
+  }
+
+  // MARK: - Subviews
+
+  private let rootStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    stackView.alignment = .fill
+    stackView.distribution = .fill
+    stackView.spacing = BezierDropdownMenuConstant.triggerSpacing
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    return stackView
+  }()
+
+  private let triggerRow = UIView()
+
+  private let contentStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    stackView.alignment = .fill
+    stackView.distribution = .fill
+    stackView.spacing = 0
+    return stackView
+  }()
+
+  private let overlay = BezierOverlay()
+
+  // MARK: - Init
+
+  /// 트리거·패널 콘텐츠(그룹/항목 배열)로 메뉴를 만든다.
+  public init(trigger: UIView? = nil, contents: [UIView] = []) {
+    self.trigger = trigger
+    self.contents = contents
+    super.init(frame: .zero)
+    self.setUp()
+  }
+
+  public required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    self.setUp()
+  }
+
+  // MARK: - Setup
+
+  private func setUp() {
+    self.translatesAutoresizingMaskIntoConstraints = false
+
+    self.overlay.content = self.contentStackView
+
+    self.rootStackView.addArrangedSubview(self.triggerRow)
+    self.rootStackView.addArrangedSubview(self.overlay)
+    self.addSubview(self.rootStackView)
+
+    NSLayoutConstraint.activate([
+      self.rootStackView.topAnchor.constraint(equalTo: self.topAnchor),
+      self.rootStackView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+      self.rootStackView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+      self.rootStackView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+    ])
+
+    self.refreshTrigger()
+    self.rebuildContents()
+  }
+
+  // MARK: - Refresh
+
+  private func refreshTrigger() {
+    guard let trigger = self.trigger else {
+      self.triggerRow.isHidden = true
+      return
+    }
+    trigger.translatesAutoresizingMaskIntoConstraints = false
+    self.triggerRow.addSubview(trigger)
+    NSLayoutConstraint.activate([
+      trigger.topAnchor.constraint(equalTo: self.triggerRow.topAnchor),
+      trigger.bottomAnchor.constraint(equalTo: self.triggerRow.bottomAnchor),
+      trigger.trailingAnchor.constraint(equalTo: self.triggerRow.trailingAnchor),
+      trigger.leadingAnchor.constraint(greaterThanOrEqualTo: self.triggerRow.leadingAnchor),
+    ])
+    self.triggerRow.isHidden = false
+  }
+
+  private func rebuildContents() {
+    self.contentStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+    self.contents.forEach { self.contentStackView.addArrangedSubview($0) }
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierDropdownMenu/BezierDropdownMenuGroup.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierDropdownMenu/BezierDropdownMenuGroup.swift
@@ -1,0 +1,115 @@
+//
+//  BezierDropdownMenuGroup.swift
+//  BezierSwift
+//
+
+import UIKit
+
+/// `BezierDropdownMenu` 오버레이 안에서 항목을 카테고리별로 묶는 그룹 컨테이너 (UIKit). 선택적 라벨 + 항목 목록 + 선택적 하단 구분선으로 구성된다. 단일 그룹이면 그룹 없이 `BezierDropdownMenuItem`을 직접 나열한다. SwiftUI에서는 `SUBezierDropdownMenuGroup`을 사용한다.
+public final class BezierDropdownMenuGroup: UIView, BezierComponentable {
+  // MARK: - BezierComponentable
+
+  public var colorTheme: BezierColorTheme { .systemBezierColorTheme() }
+  public var componentTheme: BezierComponentTheme = .normal {
+    didSet {
+      self.sectionLabel.componentTheme = self.componentTheme
+      self.divider.componentTheme = self.componentTheme
+    }
+  }
+
+  // MARK: - Public Properties
+
+  /// 그룹 라벨 텍스트. `nil`이면 라벨을 숨긴다 (기본값 `nil`) — 복수 그룹일 때만 지정한다.
+  public var labelText: String? {
+    didSet { if oldValue != self.labelText { self.refreshLabel() } }
+  }
+
+  /// 그룹 하단 구분선 표시 여부 (기본값 `false`).
+  public var showsDivider: Bool = false {
+    didSet { self.divider.isHidden = !self.showsDivider }
+  }
+
+  /// 현재 표시 중인 항목 뷰 배열. 교체하면 목록을 다시 만든다.
+  public var items: [UIView] = [] {
+    didSet { self.rebuildItems() }
+  }
+
+  // MARK: - Subviews
+
+  private let rootStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    stackView.alignment = .fill
+    stackView.distribution = .fill
+    stackView.spacing = 0
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    return stackView
+  }()
+
+  private let sectionLabel = BezierSectionLabel(text: "", color: .neutralLight)
+
+  private let itemsStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    stackView.alignment = .fill
+    stackView.distribution = .fill
+    stackView.spacing = 0
+    return stackView
+  }()
+
+  private let divider = BezierDivider()
+
+  // MARK: - Init
+
+  /// 라벨 텍스트·구분선 여부·초기 항목 배열로 그룹을 만든다.
+  public init(
+    labelText: String? = nil,
+    showsDivider: Bool = false,
+    items: [UIView] = []
+  ) {
+    self.labelText = labelText
+    self.showsDivider = showsDivider
+    self.items = items
+    super.init(frame: .zero)
+    self.setUp()
+  }
+
+  public required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    self.setUp()
+  }
+
+  // MARK: - Setup
+
+  private func setUp() {
+    self.translatesAutoresizingMaskIntoConstraints = false
+
+    self.rootStackView.addArrangedSubview(self.sectionLabel)
+    self.rootStackView.addArrangedSubview(self.itemsStackView)
+    self.rootStackView.addArrangedSubview(self.divider)
+    self.addSubview(self.rootStackView)
+
+    NSLayoutConstraint.activate([
+      self.rootStackView.topAnchor.constraint(equalTo: self.topAnchor),
+      self.rootStackView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+      self.rootStackView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+      self.rootStackView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+    ])
+
+    self.divider.isHidden = !self.showsDivider
+    self.refreshLabel()
+    self.rebuildItems()
+  }
+
+  // MARK: - Refresh
+
+  private func refreshLabel() {
+    self.sectionLabel.text = self.labelText ?? ""
+    self.sectionLabel.isHidden = (self.labelText?.isEmpty ?? true)
+  }
+
+  private func rebuildItems() {
+    self.itemsStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+    self.items.forEach { self.itemsStackView.addArrangedSubview($0) }
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierDropdownMenu/BezierDropdownMenuItem.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierDropdownMenu/BezierDropdownMenuItem.swift
@@ -43,12 +43,20 @@ public final class BezierDropdownMenuItem: UIView, BezierComponentable {
 
   /// 제목 우측에 인라인으로 붙는 슬롯 뷰(높이 24, 초과 시 잘린다). `nil`이면 비운다.
   public var centerSlot: UIView? {
-    didSet { self.baseItem.centerSlot = self.centerSlot.map { self.makeFixedHeightSlot($0) } }
+    didSet {
+      self.baseItem.centerSlot = self.centerSlot.map {
+        self.makeFixedHeightSlot($0, alignment: .leading)
+      }
+    }
   }
 
   /// 우측 슬롯 뷰(높이 24) — 단축키 텍스트·배지 등 읽기 전용 보조 정보 전용. `nil`이면 비운다.
   public var trailingContent: UIView? {
-    didSet { self.baseItem.trailingContent = self.trailingContent.map { self.makeFixedHeightSlot($0) } }
+    didSet {
+      self.baseItem.trailingContent = self.trailingContent.map {
+        self.makeFixedHeightSlot($0, alignment: .trailing)
+      }
+    }
   }
 
   /// 항목 탭 핸들러. `nil`이면 비인터랙티브(pressed 없음)가 된다.
@@ -119,17 +127,35 @@ public final class BezierDropdownMenuItem: UIView, BezierComponentable {
 
   // MARK: - Slot
 
-  private func makeFixedHeightSlot(_ view: UIView) -> UIView {
+  private enum SlotAlignment {
+    case leading
+    case trailing
+  }
+
+  // 슬롯 컨테이너는 intrinsic width가 없어 BaseItem 행의 여분 폭이 hugging 설정과 무관하게
+  // 이 컨테이너로 분배될 수 있다 (시뮬레이터 실측). 콘텐츠를 컨테이너 안에서 슬롯 방향으로
+  // 정렬해 컨테이너가 늘어나도 시각 결과가 Figma(trailing 우측 끝·centerSlot label 옆)와 같게 한다.
+  private func makeFixedHeightSlot(_ view: UIView, alignment: SlotAlignment) -> UIView {
     let container = UIView()
     container.clipsToBounds = true
+    container.setContentHuggingPriority(.required, for: .horizontal)
+    container.setContentCompressionResistancePriority(.required, for: .horizontal)
     view.translatesAutoresizingMaskIntoConstraints = false
     container.addSubview(view)
-    NSLayoutConstraint.activate([
+
+    var constraints = [
       container.heightAnchor.constraint(equalToConstant: BezierDropdownMenuItemConstant.slotHeight),
-      view.leadingAnchor.constraint(equalTo: container.leadingAnchor),
-      view.trailingAnchor.constraint(equalTo: container.trailingAnchor),
       view.centerYAnchor.constraint(equalTo: container.centerYAnchor),
-    ])
+    ]
+    switch alignment {
+    case .leading:
+      constraints.append(view.leadingAnchor.constraint(equalTo: container.leadingAnchor))
+      constraints.append(view.trailingAnchor.constraint(lessThanOrEqualTo: container.trailingAnchor))
+    case .trailing:
+      constraints.append(view.trailingAnchor.constraint(equalTo: container.trailingAnchor))
+      constraints.append(view.leadingAnchor.constraint(greaterThanOrEqualTo: container.leadingAnchor))
+    }
+    NSLayoutConstraint.activate(constraints)
     return container
   }
 

--- a/Sources/BezierSwift/MasterComponent/BezierDropdownMenu/BezierDropdownMenuItem.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierDropdownMenu/BezierDropdownMenuItem.swift
@@ -1,0 +1,164 @@
+//
+//  BezierDropdownMenuItem.swift
+//  BezierSwift
+//
+
+import UIKit
+
+/// `BezierDropdownMenu` 안에 넣는 단일 액션 항목 (UIKit). leading(아이콘/커스텀) · 제목 · description · centerSlot · trailing으로 구성되며 탭·pressed·disabled 상호작용을 지원한다. 메뉴 밖 일반 리스트 행에는 `BezierBaseItem`을 쓴다. SwiftUI에서는 `SUBezierDropdownMenuItem`을 사용한다.
+public final class BezierDropdownMenuItem: UIView, BezierComponentable {
+  // MARK: - BezierComponentable
+
+  public var colorTheme: BezierColorTheme { .systemBezierColorTheme() }
+  public var componentTheme: BezierComponentTheme = .normal {
+    didSet {
+      self.baseItem.componentTheme = self.componentTheme
+      self.refreshAppearance()
+    }
+  }
+
+  // MARK: - Public Properties
+
+  /// 항목 색 변형(neutral/destructive) (기본값 `.neutral`).
+  public var variant: BezierDropdownMenuItemVariant = .neutral {
+    didSet { if oldValue != self.variant { self.refreshAppearance() } }
+  }
+
+  /// 항목 제목. 빈 문자열이면 제목을 숨긴다.
+  public var title: String {
+    get { self.baseItem.title }
+    set { self.baseItem.title = newValue }
+  }
+
+  /// 제목 아래 보조 설명. `nil`/빈 문자열이면 숨긴다. 스캔 속도를 해치므로 꼭 필요할 때만 한 줄 이내로 쓴다.
+  public var itemDescription: String? {
+    get { self.baseItem.itemDescription }
+    set { self.baseItem.itemDescription = newValue }
+  }
+
+  /// leading 콘텐츠 유형(none/icon/custom) (기본값 `.none`). icon의 색은 `variant`가 결정한다.
+  public var leading: BezierDropdownMenuItemLeading<UIView> = .none {
+    didSet { self.refreshLeading() }
+  }
+
+  /// 제목 우측에 인라인으로 붙는 슬롯 뷰(높이 24, 초과 시 잘린다). `nil`이면 비운다.
+  public var centerSlot: UIView? {
+    didSet { self.baseItem.centerSlot = self.centerSlot.map { self.makeFixedHeightSlot($0) } }
+  }
+
+  /// 우측 슬롯 뷰(높이 24) — 단축키 텍스트·배지 등 읽기 전용 보조 정보 전용. `nil`이면 비운다.
+  public var trailingContent: UIView? {
+    didSet { self.baseItem.trailingContent = self.trailingContent.map { self.makeFixedHeightSlot($0) } }
+  }
+
+  /// 항목 탭 핸들러. `nil`이면 비인터랙티브(pressed 없음)가 된다.
+  public var onTap: (() -> Void)? {
+    get { self.baseItem.onTap }
+    set { self.baseItem.onTap = newValue }
+  }
+
+  /// 항목 활성 여부. `false`면 흐리게(opacity 0.4) 표시되고 입력이 차단된다 (기본값 `true`).
+  public var isEnabled: Bool {
+    get { self.baseItem.isEnabled }
+    set { self.baseItem.isEnabled = newValue }
+  }
+
+  // MARK: - Subviews
+
+  private let baseItem: BezierBaseItem
+
+  private let leadingIconImageView: UIImageView = {
+    let imageView = UIImageView()
+    imageView.contentMode = .scaleAspectFit
+    return imageView
+  }()
+
+  // MARK: - Init
+
+  /// variant·제목·description·leading·탭 핸들러로 항목을 만든다. centerSlot·trailing 슬롯은 생성 후 프로퍼티로 지정한다.
+  public init(
+    variant: BezierDropdownMenuItemVariant = .neutral,
+    title: String,
+    description: String? = nil,
+    leading: BezierDropdownMenuItemLeading<UIView> = .none,
+    onTap: (() -> Void)? = nil
+  ) {
+    self.variant = variant
+    self.leading = leading
+    self.baseItem = BezierBaseItem(
+      size: .small,
+      title: title,
+      description: description,
+      onTap: onTap
+    )
+    super.init(frame: .zero)
+    self.setUp()
+  }
+
+  public required init?(coder: NSCoder) {
+    self.baseItem = BezierBaseItem(size: .small, title: "")
+    super.init(coder: coder)
+    self.setUp()
+  }
+
+  // MARK: - Setup
+
+  private func setUp() {
+    self.translatesAutoresizingMaskIntoConstraints = false
+    self.addSubview(self.baseItem)
+    NSLayoutConstraint.activate([
+      self.baseItem.topAnchor.constraint(equalTo: self.topAnchor),
+      self.baseItem.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+      self.baseItem.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+      self.baseItem.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+    ])
+
+    self.refreshLeading()
+    self.refreshAppearance()
+  }
+
+  // MARK: - Slot
+
+  private func makeFixedHeightSlot(_ view: UIView) -> UIView {
+    let container = UIView()
+    container.clipsToBounds = true
+    view.translatesAutoresizingMaskIntoConstraints = false
+    container.addSubview(view)
+    NSLayoutConstraint.activate([
+      container.heightAnchor.constraint(equalToConstant: BezierDropdownMenuItemConstant.slotHeight),
+      view.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+      view.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+      view.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+    ])
+    return container
+  }
+
+  // MARK: - Trait
+
+  public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    self.refreshAppearance()
+  }
+
+  // MARK: - Refresh
+
+  private func refreshLeading() {
+    switch self.leading {
+    case .none:
+      self.baseItem.leadingContent = nil
+    case .icon(let icon):
+      self.leadingIconImageView.image = icon.uiImage?.withRenderingMode(.alwaysTemplate)
+      self.baseItem.leadingContent = self.leadingIconImageView
+    case .custom(let view):
+      self.baseItem.leadingContent = view
+    }
+    self.refreshAppearance()
+  }
+
+  private func refreshAppearance() {
+    self.baseItem.style = BezierDropdownMenuItemConstant.baseItemStyle(variant: self.variant)
+    if case .icon = self.leading {
+      self.leadingIconImageView.tintColor = self.variant.iconColor.palette(self)
+    }
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierDropdownMenu/BezierDropdownMenuSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierDropdownMenu/BezierDropdownMenuSpec.swift
@@ -1,0 +1,69 @@
+//
+//  BezierDropdownMenuSpec.swift
+//  BezierSwift
+//
+
+import CoreGraphics
+
+// MARK: - Item Variant
+
+/// 드롭다운 메뉴 항목의 색 변형. Figma `Internal/DropdownMenuItem`의 `variant` 프로퍼티에 대응 (case 이름 = Figma 값).
+public enum BezierDropdownMenuItemVariant: CaseIterable {
+  /// 일반 액션 항목에 쓰는 기본값.
+  case neutral
+  /// 삭제·초기화 등 되돌릴 수 없는 파괴적 액션 전용. 텍스트·아이콘을 red로 강조한다. 해당 항목은 별도 그룹으로 분리해 목록 맨 아래에 배치한다.
+  case destructive
+
+  var titleColor: BCSemanticToken {
+    switch self {
+    case .neutral: return .textNeutral
+    case .destructive: return .textAccentRed
+    }
+  }
+
+  var iconColor: BCSemanticToken {
+    switch self {
+    case .neutral: return .iconNeutralHeavy
+    case .destructive: return .iconAccentRed
+    }
+  }
+}
+
+// MARK: - Item Leading
+
+/// 드롭다운 메뉴 항목의 leading(좌측) 콘텐츠 유형. Figma `Internal/DropdownMenuItem`의 `leadingType` 프로퍼티에 대응 (case 이름 = Figma 값). `Content`는 custom 슬롯에 넣을 뷰 타입이다.
+public enum BezierDropdownMenuItemLeading<Content> {
+  /// leading 없이 텍스트만 시작하는 항목.
+  case none
+  /// `BezierIcon` 자산을 leading 아이콘으로 표시한다. 색은 `variant`가 결정한다 (Figma `leadingIconSource`).
+  case icon(BezierIcon)
+  /// 임의의 뷰를 24×24 leading 슬롯에 배치한다 (Figma `leadingContent` SLOT).
+  case custom(Content)
+
+  var hasLeadingContent: Bool {
+    if case .none = self { return false }
+    return true
+  }
+}
+
+// MARK: - Constant
+
+public enum BezierDropdownMenuConstant {
+  public static let triggerSpacing: CGFloat = 4
+}
+
+public enum BezierDropdownMenuItemConstant {
+  public static let horizontalPadding: CGFloat = 10
+  public static let cornerRadius: CGFloat = 16
+  public static let slotHeight: CGFloat = 24
+
+  static func baseItemStyle(variant: BezierDropdownMenuItemVariant) -> BezierBaseItemStyle {
+    BezierBaseItemStyle(
+      horizontalPadding: self.horizontalPadding,
+      cornerRadius: self.cornerRadius,
+      centerLeadingInset: 0,
+      titleColor: variant.titleColor,
+      allowsSmallDescription: true
+    )
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierDropdownMenu/SPEC.md
+++ b/Sources/BezierSwift/MasterComponent/BezierDropdownMenu/SPEC.md
@@ -220,7 +220,7 @@ Figma에 없는 구현 아키텍처 결정은 아래에 분리 표기한다. SSO
 
 ## 10. Variant 매트릭스
 
-```
+```text
 DropdownMenu           = 2070:19                       (총 1 — 축 없음)
 Internal/DropdownMenuItem (4676:12682, 18):
   variant=neutral,     leadingType=none,   state=default|pressed|disabled = 4676:12586 | 4676:12590 | 4676:12594

--- a/Sources/BezierSwift/MasterComponent/BezierDropdownMenu/SPEC.md
+++ b/Sources/BezierSwift/MasterComponent/BezierDropdownMenu/SPEC.md
@@ -1,0 +1,234 @@
+# BezierDropdownMenu SPEC
+
+> **SSOT**: [Figma · Mobile-Components / DropdownMenu (2070:19)](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=2070-19) · [Internal/DropdownMenuItem (4676:12682)](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=4676-12682) · [Internal/DropdownMenuGroup (4648:12424)](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=4648-12424) · [Internal/DropdownMenuGroupLabel (4648:113)](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=4648-113)
+> **Design spec doc**: [team-design / bezier-v3 / components / DropdownMenu-spec.md](https://github.com/channel-io/team-design/blob/main/bezier-v3/components/DropdownMenu-spec.md) · [BaseOverlay.md](https://github.com/channel-io/team-design/blob/main/bezier-v3/components/BaseOverlay.md) · [BaseItem.md](https://github.com/channel-io/team-design/blob/main/bezier-v3/components/BaseItem.md) · [BaseGroupLabel.md](https://github.com/channel-io/team-design/blob/main/bezier-v3/components/BaseGroupLabel.md) (보조 참조 — 값 충돌 시 Figma 파일 우선)
+
+명시적인 트리거 뒤에 액션 목록을 감췄다가, 항목을 선택하면 곧바로 그 액션을 실행하는 컨텍스트 메뉴 컴포넌트.
+
+## 1. Component Properties
+
+### DropdownMenu (COMPONENT `2070:19`)
+
+| Property | 값 | 비고 |
+|---|---|---|
+| **trigger** | SLOT (`2372:442`) | 임의 트리거 배치 (overlay 밖, 기본 콘텐츠 IconButton 인스턴스는 슬롯 예시). 코드 API에서의 생략(옵셔널) 처리는 §9-10 협의 참조 |
+| **content** | SLOT (overlay 내부 `content`) | DropdownMenu 항목 영역. 기본 콘텐츠 Internal/DropdownMenuGroup |
+
+variant / state / boolean 축 없음 — 단일 정적 COMPONENT (열림 상태 1종만 정의).
+
+총 instance: 1개 (`DropdownMenu` = `2070:19`)
+
+### Internal/DropdownMenuItem (CS `4676:12682`)
+
+| Figma property key | Type | Default | 옵션 / 값 | 구현 매핑 |
+|---|---|---|---|---|
+| `variant` | VARIANT | neutral | neutral / destructive | `BezierDropdownMenuItemVariant` |
+| `leadingType` | VARIANT | — | none / icon / custom | `BezierDropdownMenuItemLeading` (`.none` / `.icon` / `.custom`) |
+| `state` | VARIANT | default | default / pressed / disabled | 인터랙션 상태 (§6) |
+| `content` | TEXT | "Label" | 문자열 | title |
+| `hasDescription` | BOOLEAN | false | on / off | description 유무 |
+| `description` | TEXT | "Description text" | 문자열 | description |
+| `hasCenterSlot` | BOOLEAN | true | on / off | centerSlot 유무 (기본 슬롯은 빈 placeholder, 폭 ≈0) |
+| `centerSlot` | SLOT | — | 임의 콘텐츠 | centerSlot |
+| `hasTrailingContent` | BOOLEAN | false | on / off | trailing 유무 |
+| `trailingContent` | SLOT | — | 임의 콘텐츠 | trailingContent |
+| `leadingIconSource` | INSTANCE_SWAP | — | 아이콘 인스턴스 (leadingType=icon) | `.icon(BezierIcon)` |
+| `leadingContent` | SLOT | — | 임의 콘텐츠 (leadingType=custom) | `.custom(뷰)` |
+
+총 instance: `variant(2) × leadingType(3) × state(3) = 18개`
+
+> `leadingType=custom`도 Mobile CS 실측상 `centerContent`(label·centerSlot·description)를 그대로 유지하고 leading 슬롯(24×24)만 자유 콘텐츠로 개방한다 (`5215:12087` 등 실측 — leadingContent가 SLOT).
+
+### Internal/DropdownMenuGroup (COMPONENT `4648:12424`)
+
+| Figma property key | Type | Default | 옵션 / 값 | 구현 매핑 |
+|---|---|---|---|---|
+| `hasLabel` | BOOLEAN | false | on / off | 그룹 라벨 유무 (복수 그룹일 때만 켠다) |
+| `showDivider` | BOOLEAN | false | on / off | 그룹 하단 구분선 |
+| `content` | SLOT (`4648:12427`) | — | Internal/DropdownMenuItem 배치 | items |
+
+라벨 텍스트 편집은 내부 `Internal/DropdownMenuGroupLabel` 인스턴스 프로퍼티로 (CS 레벨 label TEXT prop 없음).
+
+### Internal/DropdownMenuGroupLabel (CS `4648:113`)
+
+| Property | 값 | 비고 |
+|---|---|---|
+| **color** | `neutral-light` (`4648:109`) / `neutral-dark` (`4648:111`) | 텍스트 색. Group 내 기본값 neutral-light |
+| **label** | TEXT ("Group Label") | 라벨 텍스트 |
+
+## 2. Layout Spec
+
+### DropdownMenu 루트 (`2070:19`)
+
+| Part | 값 |
+|---|---|
+| 루트 배치 | 세로 스택: trigger → overlay, gap `4pt` |
+| 루트 폭 | `240pt` FIXED |
+| trigger 슬롯 행 | 폭 FILL(240pt), 콘텐츠 우측 정렬(justify-end), 높이 HUG |
+| overlay | `overlay`(`5078:2253`) 인스턴스 — 폭 `240pt` FIXED · padding `10pt` 균일 · corner radius `32pt`(`radius/32`) · content 폭 `220pt` |
+
+### Internal/DropdownMenuItem
+
+| Part | 값 |
+|---|---|
+| min height | `40pt` (description 시 콘텐츠 기반 `52pt` = 6+24+16+6) |
+| padding | 상하 `6pt` / 좌우 `10pt` |
+| corner radius | `16pt` (`radius/16`), overflow clip |
+| 루트 gap | `10pt` (contentWrapper ↔ trailingContent), 세로 중앙 정렬 |
+| labelWrapper gap | `10pt` (leading ↔ centerContent) |
+| labelRow gap | `4pt` (label ↔ centerSlot) |
+| leading | `24×24pt` 정방형 (icon / custom 공통) |
+| centerSlot | 폭 HUG × 높이 `24pt` FIXED, 세로 중앙 (초과 콘텐츠 clip은 §9-9 협의) |
+| trailingContent | 높이 `24pt` FIXED, 세로 중앙 (마스터 placeholder 100×24 — 슬롯 콘텐츠 폭은 소비 측 결정) |
+| description 들여쓰기 | leading 있으면 `34pt`(= 24 + 10), 없으면 `0` |
+| label overflow | 1줄 ellipsis (Figma nowrap — 구현은 truncate) |
+
+### Internal/DropdownMenuGroup
+
+| Part | 값 |
+|---|---|
+| 배치 | 세로 스택: GroupLabel(optional) → content → divider(optional), gap `0` |
+| divider | `Divider` 인스턴스 — 선 `1pt` × 폭 FILL, 좌우 인셋 `6pt`, 상하 여백 `6pt` (총 높이 13pt) |
+
+### Internal/DropdownMenuGroupLabel
+
+| Part | 값 |
+|---|---|
+| 최소 높이 | `32pt` |
+| 좌우 패딩 | `10pt` |
+| corner radius | `8pt` |
+| 텍스트 overflow | 1줄, ellipsis |
+
+## 3. 컬러 토큰 (Figma 사용처 기준)
+
+### DropdownMenu 루트 / overlay
+
+| 영역 | Token | Figma Variable | Raw |
+|---|---|---|---|
+| overlay 배경 | `surfaceHighest` | `color/surface/highest` | `#FFFFFF` |
+| overlay shadow | `elevationLarge` | `color/elevation/large` | `#00000038` |
+
+### Internal/DropdownMenuItem — variant × state
+
+| 위치 | variant=neutral | variant=destructive |
+|---|---|---|
+| label 텍스트 | `textNeutral` (`color/text/neutral`, `#000000D9`) | `textAccentRed` (`color/text/accent/red`, `#E1535D`) |
+| leading 아이콘 (leadingType=icon) | `iconNeutralHeavy` (`color/icon/neutral/heavy`, `#00000099`) | `iconAccentRed` (`color/icon/accent/red`, `#E1535D`) |
+| description 텍스트 | `textNeutralLighter` (`color/text/neutral/lighter`, `#00000066`) | 동일 (variant 무관 고정) |
+
+| state | 배경 | 기타 |
+|---|---|---|
+| default | 없음 (투명) | — |
+| pressed | `fillNeutralLighter` (`color/fill/neutral/lighter`, `#00000008`) | — |
+| disabled | 없음 | 본체 opacity `opacity/disabled` = 0.4 |
+
+### Internal/DropdownMenuGroup
+
+| 영역 | Token | Figma Variable | Raw |
+|---|---|---|---|
+| divider 선 | `borderNeutral` | `color/border/neutral` | `#00000014` |
+
+### Internal/DropdownMenuGroupLabel
+
+| color | Token | Figma Variable | Raw |
+|---|---|---|---|
+| `neutral-light` | `textNeutralLighter` | `color/text/neutral/lighter` | `#00000066` |
+| `neutral-dark` | `textNeutral` | `color/text/neutral` | `#000000D9` |
+
+## 4. Typography
+
+### Case A — Typography Token 사용 (전부 토큰)
+
+| 위치 | Token (`BTSemanticToken`) | Figma Style |
+|---|---|---|
+| item label | `.textXLarge(weight: .regular)` | `Typography/text/xlarge` (Inter Regular, size 16, lineHeight 24, letterSpacing `text/letter-spacing/tight` −0.1) |
+| item description | `.captionMedium(weight: .regular)` | `Typography/caption/medium` (Inter Regular, size 12, lineHeight 16, letterSpacing `caption/letter-spacing` 0) |
+| group label | `.textMedium(weight: .bold)` | `Typography/text/medium-bold` (Inter Bold, size 14, lineHeight 18, letterSpacing `text/letter-spacing` 0) |
+
+### Case B — Custom Typography
+
+없음 (모든 텍스트가 토큰 사용).
+
+## 5. Elevation
+
+| Effect Style | 구성 |
+|---|---|
+| `Elevation/Mobile/3` (overlay) | DROP_SHADOW · color `color/elevation/large` · offset (0, `elevation/4` = 4) · blur `elevation/20` = 20 · spread 0 |
+
+## 6. State 별 시각 동작 (Internal/DropdownMenuItem)
+
+| State | 시각 변화 | 인터랙션 |
+|---|---|---|
+| `default` | 배경 없음 | 활성 |
+| `pressed` | 배경 `fillNeutralLighter` | 활성 (탭 진행 중) |
+| `disabled` | 본체 opacity 0.4, 배경 없음 | 입력 차단 |
+
+DropdownMenu / DropdownMenuGroup / DropdownMenuGroupLabel에는 state variant 축 없음 (정적 컨테이너).
+
+## 7. 디자이너 가이드라인 (Figma component description 인용)
+
+> DropdownMenu 마스터(`2070:19`)의 component description은 공란 — 인용 항목 없음 (trigger가 SLOT이라는 것은 §1의 구조 실측).
+
+### Internal/DropdownMenuItem
+
+- Used within DropdownMenu only. Do not place standalone.
+- `leadingType=icon`: `leadingIconSource`로 아이콘 교체 / `leadingType=custom`: leadingContent SLOT에 임의 콘텐츠 배치.
+- `variant=destructive`: 삭제·초기화 등 파괴적 액션 전용.
+- `hasTrailingContent`(옵션): true 시 우측 콘텐츠 영역 표시 (단축키·배지 등).
+- `hasCenterSlot`(옵션): true 시 label 옆 centerSlot에 부가 콘텐츠(배지 등) 표시.
+- `hasDescription`(옵션): true 시 label 아래 보조 설명 텍스트 표시 (권장하지 않음 — 식별력 저하 방지, 꼭 필요할 때만).
+
+### Internal/DropdownMenuGroup
+
+- Used within DropdownMenu only. Do not place standalone. DropdownMenu 오버레이 내 항목을 카테고리별로 묶는 그룹 컨테이너.
+- `hasLabel`: 그룹 라벨 표시 여부 (기본 false, 복수 그룹일 때만 켠다).
+- `showDivider`: true 시 그룹 하단에 구분선 표시.
+- 단일 그룹일 때는 DropdownMenuGroup 없이 DropdownMenuItem을 직접 나열할 것.
+
+### overlay (`5078:2253` — 내장 쉘)
+
+- position: 기본 bottom-start, 화면 밖이면 flip, 가장자리 마진 16px (코드 구현 참고용) · backdrop 없음 · 외부 탭 시 닫힘.
+
+## 8. 매핑되는 코드 심볼
+
+| 정의 | 파일 |
+|---|---|
+| UIKit 메뉴 컨테이너 | `BezierDropdownMenu.swift` |
+| UIKit 메뉴 그룹 | `BezierDropdownMenuGroup.swift` |
+| UIKit 메뉴 아이템 | `BezierDropdownMenuItem.swift` |
+| SwiftUI 메뉴 컨테이너 | `SUBezierDropdownMenu.swift` |
+| SwiftUI 메뉴 그룹 | `SUBezierDropdownMenuGroup.swift` |
+| SwiftUI 메뉴 아이템 | `SUBezierDropdownMenuItem.swift` |
+| variant / leading / constant | `BezierDropdownMenuSpec.swift` |
+
+> 재사용 심볼 실재 확인: `BezierOverlay` / `SUBezierOverlay` / `BezierOverlayConstant`(width 240 · padding 10 · cornerRadius 32 · elevation `.mEv3`), `BezierBaseItem` / `SUBezierBaseItem`(레이아웃·pressed·press scale·disabled), `BezierSectionLabel` / `SUBezierSectionLabel` + `BezierSectionLabelColor.neutralLight`(그룹 라벨 — 레이아웃·타이포·색 Figma GroupLabel과 동일), `BezierDivider` / `SUBezierDivider`(sideIndent·parallelIndent 기본 true = 6/6 인셋), `BCSemanticToken`(.textNeutral / .textAccentRed / .textNeutralLighter / .iconNeutralHeavy / .iconAccentRed / .fillNeutralLighter / .surfaceHighest / .borderNeutral), `BTSemanticToken`(.textXLarge / .captionMedium / .textMedium), `BOGlobalToken.disabled` = 0.4, `BezierIcon`.
+
+## 9. Figma 외 · 협의 사항 (구현 결정)
+
+Figma에 없는 구현 아키텍처 결정은 아래에 분리 표기한다. SSOT 값이 아니다.
+
+1. **컴포지션 구조 (MOB-6355 핸드오프)**: DropdownMenuItem은 `BezierBaseItem`/`SUBezierBaseItem`을 소유(composition)해 구현한다 (상속 금지). 오버레이 패널은 `BezierOverlay`/`SUBezierOverlay` 재사용, 그룹 라벨은 `BezierSectionLabel(color: .neutralLight)` 재사용, 그룹 divider는 `BezierDivider()` 재사용.
+2. **BaseItem 내부 스타일 주입**: Figma DropdownMenuItem은 BaseItem 대비 좌우 패딩 10(↔6)·corner radius 16(↔8)·center 좌측 인셋 0(↔2)·small에서 description 지원(↔미지원)·label 색 variant 분기가 다르다. 이를 위해 BaseItem에 **internal** 스타일 주입(`BezierBaseItemStyle`)을 추가한다 — public API 불변 (배치·스타일 커스터마이즈의 public 노출 금지 원칙 유지).
+3. **description + leading 동시 사용 시 leading 세로 정렬**: Figma는 de-nest 구조(leading이 label 행에 정렬, y=6). 구현은 BaseItem nest 구조를 따라 leading이 행 전체 세로 중앙(y=14)에 온다 — BaseItem composition 협의(#1)에 따른 의도적 수용. label·description·trailing의 x/y 좌표는 Figma와 동일하며, 차이는 이 8pt 하나뿐이다 (description 자체가 Figma 가이드라인상 비권장 구성).
+4. **프레젠테이션 스코프 제외**: 열림/닫힘 상태·앵커 포지셔닝·외부 탭 닫힘은 사용처 책임 (BezierOverlay SPEC §9-1과 동일 결정 — Figma도 열림 상태 1종의 정적 구조만 정의). trigger 슬롯은 Figma 구조(트리거-패널 한 세트, gap 4)를 그대로 제공한다.
+5. **state 축은 런타임 상태**: Figma `state`(default/pressed/disabled)는 API 옵션이 아니라 런타임 인터랙션 상태로 구현 — pressed는 터치 추적, disabled는 UIKit `isEnabled` / SwiftUI `.disabled()`.
+6. **pressed press-scale**: BaseItem의 press scale 피드백(0.97, 오버슈트 복귀)을 그대로 상속한다 (BaseItem SPEC §7 협의 — Figma 외).
+7. **`hasLabel`/`showDivider`/`has*` boolean 표현**: 코드 API는 UIKit `labelText: String?`(nil = 미표시)·`showsDivider: Bool`, 슬롯 계열은 옵셔널/`EmptyView` 분기로 표현 (BezierSection §8-5와 동일 관례).
+8. **그룹 divider 배치**: Figma 모델 그대로 Group의 `showsDivider`로 그룹 최하단에 표시한다 (web 코드의 형제 `<DropdownMenuSeparator>` 모델과 다름 — Mobile Figma가 SSOT).
+9. **trailing/centerSlot 높이 24 고정**: Figma 슬롯이 FIXED 24 높이이므로 구현은 높이 24 컨테이너(초과 시 clip)로 감싼다. 콘텐츠는 소비 측 책임 (인터랙티브 컨트롤 배치 금지 가이드는 design doc 참조).
+10. **trigger 슬롯 생략(옵셔널)**: 코드 API에서 trigger는 옵셔널 — 생략하면 트리거 행 없이 패널만 표시하고, 화면의 기존 요소를 트리거로 외부 제어한다 (출처: design doc DropdownMenu-spec.md §3 Mobile "trigger — Optional" + MOB-6355 핸드오프. Figma 노드 description에는 없는 협의 사항).
+
+## 10. Variant 매트릭스
+
+```
+DropdownMenu           = 2070:19                       (총 1 — 축 없음)
+Internal/DropdownMenuItem (4676:12682, 18):
+  variant=neutral,     leadingType=none,   state=default|pressed|disabled = 4676:12586 | 4676:12590 | 4676:12594
+  variant=neutral,     leadingType=icon,   state=default|pressed|disabled = 4676:12598 | 4676:12604 | 4676:12610
+  variant=neutral,     leadingType=custom, state=default|pressed|disabled = 4676:12616 | 4676:12621 | 4676:12626
+  variant=destructive, leadingType=none,   state=default|pressed|disabled = 4676:12631 | 4676:12635 | 4676:12639
+  variant=destructive, leadingType=icon,   state=default|pressed|disabled = 4676:12643 | 4676:12649 | 4676:12655
+  variant=destructive, leadingType=custom, state=default|pressed|disabled = 4676:12661 | 4676:12666 | 4676:12671
+Internal/DropdownMenuGroup      = 4648:12424           (총 1 — property만)
+Internal/DropdownMenuGroupLabel = color=neutral-light 4648:109, color=neutral-dark 4648:111 (총 2)
+```

--- a/Sources/BezierSwift/MasterComponent/BezierDropdownMenu/SUBezierDropdownMenu.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierDropdownMenu/SUBezierDropdownMenu.swift
@@ -1,0 +1,71 @@
+//
+//  SUBezierDropdownMenu.swift
+//  BezierSwift
+//
+
+import SwiftUI
+
+/// 트리거 뒤에 액션 목록을 감췄다가 항목 선택 시 곧바로 실행하는 컨텍스트 메뉴 (SwiftUI). 선택적 트리거 슬롯 + `SUBezierOverlay` 패널로 구성된 240pt 고정 폭 컴포넌트로, 패널 콘텐츠에는 `SUBezierDropdownMenuGroup`/`SUBezierDropdownMenuItem`을 넣는다. 열림/닫힘·앵커 포지셔닝·외부 탭 닫힘은 사용처 책임이다. UIKit에서는 `BezierDropdownMenu`를 사용한다.
+public struct SUBezierDropdownMenu<Trigger: View, Content: View>: View {
+  private let trigger: Trigger
+  private let content: Content
+
+  /// 트리거·패널 콘텐츠 빌더로 메뉴를 만든다. 트리거는 패널 위에 우측 정렬로 배치된다.
+  public init(
+    @ViewBuilder trigger: () -> Trigger,
+    @ViewBuilder content: () -> Content
+  ) {
+    self.trigger = trigger()
+    self.content = content()
+  }
+
+  public var body: some View {
+    VStack(alignment: .leading, spacing: BezierDropdownMenuConstant.triggerSpacing) {
+      self.triggerRow
+
+      SUBezierOverlay {
+        self.content
+      }
+    }
+    .frame(width: BezierOverlayConstant.width)
+  }
+
+  @ViewBuilder
+  private var triggerRow: some View {
+    if Trigger.self != EmptyView.self {
+      HStack(spacing: 0) {
+        Spacer(minLength: 0)
+        self.trigger
+      }
+    }
+  }
+}
+
+// MARK: - Convenience init (trigger 생략)
+
+extension SUBezierDropdownMenu where Trigger == EmptyView {
+  /// 트리거 없이 패널만 만드는 편의 이니셜라이저 — 화면의 기존 요소를 트리거로 외부 제어할 때 쓴다.
+  public init(@ViewBuilder content: () -> Content) {
+    self.init(trigger: { EmptyView() }, content: content)
+  }
+}
+
+struct SUBezierDropdownMenu_Previews: PreviewProvider {
+  static var previews: some View {
+    SUBezierDropdownMenu {
+      Circle()
+        .fill(Color.gray.opacity(0.2))
+        .frame(width: 32, height: 32)
+    } content: {
+      SUBezierDropdownMenuGroup(showsDivider: true) {
+        SUBezierDropdownMenuItem(title: "편집", leading: .icon(.edit), onTap: {})
+        SUBezierDropdownMenuItem(title: "복제", leading: .icon(.linkCopy), onTap: {})
+      }
+      SUBezierDropdownMenuGroup {
+        SUBezierDropdownMenuItem(variant: .destructive, title: "삭제", leading: .icon(.trash), onTap: {})
+      }
+    }
+    .padding()
+    .background(Color.gray.opacity(0.15))
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierDropdownMenu/SUBezierDropdownMenuGroup.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierDropdownMenu/SUBezierDropdownMenuGroup.swift
@@ -1,0 +1,53 @@
+//
+//  SUBezierDropdownMenuGroup.swift
+//  BezierSwift
+//
+
+import SwiftUI
+
+/// `SUBezierDropdownMenu` 오버레이 안에서 항목을 카테고리별로 묶는 그룹 컨테이너 (SwiftUI). 선택적 라벨 + 항목 목록 + 선택적 하단 구분선으로 구성된다. 단일 그룹이면 그룹 없이 `SUBezierDropdownMenuItem`을 직접 나열한다. UIKit에서는 `BezierDropdownMenuGroup`을 사용한다.
+public struct SUBezierDropdownMenuGroup<Content: View>: View {
+  private let labelText: String?
+  private let showsDivider: Bool
+  private let content: Content
+
+  /// 라벨 텍스트·구분선 여부·항목 빌더로 그룹을 만든다. 라벨은 복수 그룹일 때만 지정한다.
+  public init(
+    labelText: String? = nil,
+    showsDivider: Bool = false,
+    @ViewBuilder content: () -> Content
+  ) {
+    self.labelText = labelText
+    self.showsDivider = showsDivider
+    self.content = content()
+  }
+
+  public var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      if let labelText = self.labelText, !labelText.isEmpty {
+        SUBezierSectionLabel(labelText, color: .neutralLight)
+      }
+
+      self.content
+
+      if self.showsDivider {
+        SUBezierDivider()
+      }
+    }
+  }
+}
+
+struct SUBezierDropdownMenuGroup_Previews: PreviewProvider {
+  static var previews: some View {
+    VStack(spacing: 0) {
+      SUBezierDropdownMenuGroup(labelText: "편집", showsDivider: true) {
+        SUBezierDropdownMenuItem(title: "이름 변경", onTap: {})
+        SUBezierDropdownMenuItem(title: "복제", onTap: {})
+      }
+      SUBezierDropdownMenuGroup {
+        SUBezierDropdownMenuItem(variant: .destructive, title: "삭제", onTap: {})
+      }
+    }
+    .padding()
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierDropdownMenu/SUBezierDropdownMenuItem.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierDropdownMenu/SUBezierDropdownMenuItem.swift
@@ -1,0 +1,173 @@
+//
+//  SUBezierDropdownMenuItem.swift
+//  BezierSwift
+//
+
+import SwiftUI
+
+/// `SUBezierDropdownMenu` 안에 넣는 단일 액션 항목 (SwiftUI). leading(아이콘/커스텀) · 제목 · description · centerSlot · trailing으로 구성되며 탭·pressed·disabled를 지원한다. 메뉴 밖 일반 리스트 행에는 `SUBezierBaseItem`을 쓴다. UIKit에서는 `BezierDropdownMenuItem`을 사용한다.
+public struct SUBezierDropdownMenuItem<CenterSlot: View, Trailing: View>: View, Themeable {
+  @Environment(\.colorScheme) public var colorScheme
+
+  private let variant: BezierDropdownMenuItemVariant
+  private let title: String
+  private let itemDescription: String?
+  private let leading: BezierDropdownMenuItemLeading<AnyView>
+  private let onTap: (() -> Void)?
+  private let centerSlot: CenterSlot
+  private let trailing: Trailing
+
+  /// variant·제목·description·leading·탭 핸들러와 centerSlot·trailing 슬롯 빌더로 항목을 만든다. `trailing`에는 단축키 텍스트·배지 등 읽기 전용 보조 정보만 넣는다.
+  public init(
+    variant: BezierDropdownMenuItemVariant = .neutral,
+    title: String,
+    description: String? = nil,
+    leading: BezierDropdownMenuItemLeading<AnyView> = .none,
+    onTap: (() -> Void)? = nil,
+    @ViewBuilder centerSlot: () -> CenterSlot,
+    @ViewBuilder trailing: () -> Trailing
+  ) {
+    self.variant = variant
+    self.title = title
+    self.itemDescription = description
+    self.leading = leading
+    self.onTap = onTap
+    self.centerSlot = centerSlot()
+    self.trailing = trailing()
+  }
+
+  public var body: some View {
+    switch self.leading {
+    case .none:
+      SUBezierBaseItem(
+        style: BezierDropdownMenuItemConstant.baseItemStyle(variant: self.variant),
+        size: .small,
+        title: self.title,
+        description: self.itemDescription,
+        onTap: self.onTap,
+        leading: { EmptyView() },
+        centerSlot: { self.centerSlotView },
+        trailing: { self.trailingView }
+      )
+    case .icon(let icon):
+      SUBezierBaseItem(
+        style: BezierDropdownMenuItemConstant.baseItemStyle(variant: self.variant),
+        size: .small,
+        title: self.title,
+        description: self.itemDescription,
+        onTap: self.onTap,
+        leading: { self.iconView(icon) },
+        centerSlot: { self.centerSlotView },
+        trailing: { self.trailingView }
+      )
+    case .custom(let view):
+      SUBezierBaseItem(
+        style: BezierDropdownMenuItemConstant.baseItemStyle(variant: self.variant),
+        size: .small,
+        title: self.title,
+        description: self.itemDescription,
+        onTap: self.onTap,
+        leading: { view },
+        centerSlot: { self.centerSlotView },
+        trailing: { self.trailingView }
+      )
+    }
+  }
+
+  private func iconView(_ icon: BezierIcon) -> some View {
+    icon.image
+      .renderingMode(.template)
+      .resizable()
+      .scaledToFit()
+      .foregroundColor(self.palette(self.variant.iconColor))
+  }
+
+  @ViewBuilder
+  private var centerSlotView: some View {
+    if CenterSlot.self != EmptyView.self {
+      self.centerSlot
+        .frame(height: BezierDropdownMenuItemConstant.slotHeight)
+        .clipped()
+    }
+  }
+
+  @ViewBuilder
+  private var trailingView: some View {
+    if Trailing.self != EmptyView.self {
+      self.trailing
+        .frame(height: BezierDropdownMenuItemConstant.slotHeight)
+        .clipped()
+    }
+  }
+}
+
+// MARK: - Convenience init (centerSlot 생략)
+
+extension SUBezierDropdownMenuItem where CenterSlot == EmptyView {
+  /// centerSlot 없이 trailing 슬롯만으로 만드는 편의 이니셜라이저.
+  public init(
+    variant: BezierDropdownMenuItemVariant = .neutral,
+    title: String,
+    description: String? = nil,
+    leading: BezierDropdownMenuItemLeading<AnyView> = .none,
+    onTap: (() -> Void)? = nil,
+    @ViewBuilder trailing: () -> Trailing
+  ) {
+    self.init(
+      variant: variant,
+      title: title,
+      description: description,
+      leading: leading,
+      onTap: onTap,
+      centerSlot: { EmptyView() },
+      trailing: trailing
+    )
+  }
+}
+
+extension SUBezierDropdownMenuItem where CenterSlot == EmptyView, Trailing == EmptyView {
+  /// centerSlot·trailing 없이 만드는 편의 이니셜라이저.
+  public init(
+    variant: BezierDropdownMenuItemVariant = .neutral,
+    title: String,
+    description: String? = nil,
+    leading: BezierDropdownMenuItemLeading<AnyView> = .none,
+    onTap: (() -> Void)? = nil
+  ) {
+    self.init(
+      variant: variant,
+      title: title,
+      description: description,
+      leading: leading,
+      onTap: onTap,
+      centerSlot: { EmptyView() },
+      trailing: { EmptyView() }
+    )
+  }
+}
+
+struct SUBezierDropdownMenuItem_Previews: PreviewProvider {
+  static var previews: some View {
+    VStack(spacing: 0) {
+      SUBezierDropdownMenuItem(title: "편집", leading: .icon(.edit), onTap: {})
+      SUBezierDropdownMenuItem(
+        title: "복제",
+        leading: .icon(.linkCopy),
+        onTap: {},
+        trailing: {
+          Text("⌘D").font(.caption).foregroundColor(.secondary)
+        }
+      )
+      SUBezierDropdownMenuItem(
+        title: "내보내기",
+        description: "팀 전체에 공유됩니다",
+        leading: .icon(.arrowRightUpSmall),
+        onTap: {}
+      )
+      SUBezierDropdownMenuItem(title: "비활성 항목", leading: .icon(.lock), onTap: {})
+        .disabled(true)
+      SUBezierDropdownMenuItem(variant: .destructive, title: "삭제", leading: .icon(.trash), onTap: {})
+    }
+    .padding()
+  }
+}


### PR DESCRIPTION
## MOB-6355

https://linear.app/channel/issue/MOB-6355

V3 DropdownMenu 컴포넌트 패밀리(DropdownMenu / DropdownMenuGroup / DropdownMenuItem)를 UIKit + SwiftUI로 구현합니다.

## 구현 내용

### 컴포지션 구조 (재구현 없음 — 기존 V3 컴포넌트 조합)

```
BezierDropdownMenu (trigger 슬롯 + gap 4)
└── BezierOverlay                     ← 재사용 (240pt · padding 10 · radius 32 · mEv3)
    └── BezierDropdownMenuGroup ×N
        ├── BezierSectionLabel        ← 재사용 (color: .neutralLight — Figma GroupLabel과 동일 스펙)
        ├── BezierDropdownMenuItem ×N
        │   └── BezierBaseItem        ← composition 소유 (상속 금지, MOB-6355 핸드오프)
        └── BezierDivider             ← 재사용 (showsDivider 시 그룹 하단)
```

### DropdownMenu — `BezierDropdownMenu` / `SUBezierDropdownMenu`

- 선택적 `trigger` 슬롯(패널 위 우측 정렬, Figma justify-end) + `BezierOverlay` 패널, gap 4
- trigger 생략 시 패널만 표시 — 화면의 기존 요소를 트리거로 외부 제어 (design doc §3 Mobile "trigger — Optional")
- 열림/닫힘·앵커 포지셔닝·외부 탭 닫힘은 사용처 책임 (BezierOverlay SPEC §9-1과 동일 스코프 결정 — Figma도 열림 상태 1종의 정적 구조만 정의)

### DropdownMenuGroup — `BezierDropdownMenuGroup` / `SUBezierDropdownMenuGroup`

- `labelText`(nil = 미표시, 복수 그룹일 때만) + 항목 목록 + `showsDivider`(그룹 하단 구분선)
- 라벨 = `BezierSectionLabel(color: .neutralLight)` 재사용 — Figma `Internal/DropdownMenuGroupLabel`과 레이아웃(32/10/8)·타이포(`textMedium bold`)·색(`textNeutralLighter`) 완전 일치 실측 확인
- divider = `BezierDivider()` 재사용 (sideIndent·parallelIndent 기본 = Figma divider 인스턴스의 6/1/6 + 좌우 6과 동일)

### DropdownMenuItem — `BezierDropdownMenuItem` / `SUBezierDropdownMenuItem`

- `BezierBaseItem`/`SUBezierBaseItem`을 **composition(소유)** — pressed 배경(`fillNeutralLighter`)·press scale(0.97 + 오버슈트 복귀)·disabled(opacity 0.4)·min-height 40·슬롯 gap 10·labelRow gap 4·ellipsis 전부 BaseItem에 위임
- variant `neutral` / `destructive` — 텍스트 `textNeutral`/`textAccentRed`, leading 아이콘 `iconNeutralHeavy`/`iconAccentRed` (UIKit은 traitCollectionDidChange에서 tint 재주입)
- leading `none` / `icon(BezierIcon)` / `custom(뷰)` — Figma `leadingType` 3축, 24×24
- `centerSlot`·`trailingContent` 슬롯: Figma FIXED 높이 24 컨테이너(초과 시 clip)로 감쌈
- description: Figma `hasDescription` 지원 (40 → 52pt, 들여쓰기 34/0) — 비권장 가이드는 doc comment에 명시
- BaseItem에 **internal** `BezierBaseItemStyle` 주입 추가 (public API 불변): DropdownMenuItem은 좌우 패딩 10(↔6)·radius 16(↔8)·center 인셋 0(↔2)·small description 허용(↔미지원)·variant별 title 색이 BaseItem 기본과 달라, 상수 하드코딩 대신 스타일 주입으로 해소
  - SwiftUI는 internal init 오버로드 방식 (V3 Button의 internal init 관례와 동일)

### SwiftUI 빈 슬롯 처리

- leading 유무를 `SUBezierDropdownMenuItem` body에서 분기 — `.none`이면 리터럴 `EmptyView`가 `SUBezierBaseItem`의 `Leading.self != EmptyView.self` 체크에 걸리도록 하여 빈 24×24 박스를 방지 (핸드오프 ⚠️ 항목)

## Spec 검증

figma-component-spec 3단계 사이클로 검증했습니다 (Figma = SSOT):

- Phase 1: Figma 실측 기반 `SPEC.md` 작성 (DropdownMenu `2070:19` / Internal/DropdownMenuItem `4676:12682` 18v / Internal/DropdownMenuGroup `4648:12424` / Internal/DropdownMenuGroupLabel `4648:113`)
- Phase 2: Properties / Layout / Color / Typography / Asset / Spec Noise / Implementation Reference 7종 병렬 검증 — Properties(hasCenterSlot 기본값·leadingContent SLOT·GroupLabel label TEXT)와 Noise(trigger 외부 제어 문구의 출처 오귀속) 지적을 반영해 전부 통과
- Phase 3: UIKit·SwiftUI Implementation Validator로 구현–SPEC 일치 확인
- Figma에 없는 구현 결정(BaseItem composition·internal 스타일 주입·description+leading 시 leading 세로 정렬 nest 수용(8pt)·프레젠테이션 스코프 제외·trigger 옵셔널)은 `SPEC.md` §9에 협의 사항으로 분리 기록

## 시뮬레이터 검증 (iPhone 16 / iOS 18.6, 라이트·다크)

캡처 원본은 로컬 `Screenshots-MOB-6355/`(미커밋)에 보관 — 필요 시 코멘트로 첨부합니다.

| 파일 | 확인 내용 | 결과 |
|---|---|---|
| `01-catalog-default-light` | 트리거(우측 정렬)+gap 4+240pt 패널, 그룹 라벨, divider, destructive red, ⌘D trailing (SwiftUI) | ✅ |
| `02-catalog-uikit-light` | 동일 구성 UIKit — SwiftUI와 좌표 일치 (item 220×40, label x=44 실측) | ✅ |
| `03/04-description-*` | hasDescription: 40→52pt, desc 들여쓰기 34, desc 색 variant 무관 고정 (양 패러다임) | ✅ |
| `05-leading-none-light` | leading 생략 시 빈 24pt 박스 없음 (SwiftUI EmptyView 분기) | ✅ |
| `06-leading-custom-light` | custom leading 24×24 슬롯 | ✅ |
| `07-disabled-light` | disabled 아이템 opacity 0.4 + 입력 차단 | ✅ |
| `08-pressed-swiftui-light` | pressed 배경(fillNeutralLighter, radius 16) + press scale 0.97 | ✅ |
| `09/10-dark-*` | 다크 모드 — UIKit `traitCollectionDidChange` 토큰 재주입 포함 전 색 적응 | ✅ |

접근성 프레임 실측으로 BezierBaseItemStyle 주입값 검증: item 폭 220 · minHeight 40(desc 52) · 좌측 패딩 10 · leading 24 + gap 10(label x=44) · trailing 우측 끝(패딩 10 앞) — Figma 실측값과 일치.

**검증 중 발견·수정한 결함 1건**: UIKit에서 trailing/centerSlot 래퍼 컨테이너(intrinsic width 없음)가 행의 여분 폭을 흡수해 ⌘D가 라벨 옆에 붙는 문제 → 슬롯 컨테이너를 정렬 지정 방식(trailing=우측 고정·centerSlot=좌측 고정)으로 수정 (`2db7be0`). 수정 후 재실측으로 우측 정렬 확인.

## 테스트

- `xcodebuild -scheme BezierSwift` / `-scheme BezierExamples` clean build 통과
- Examples 카탈로그 (DropdownMenu) 추가 — leading 3축 × trigger/label/divider/description/shortcut/disabled 토글

🤖 Generated with [Claude Code](https://claude.com/claude-code)
