### PR TITLE
[MOB-6345] BezierFormGroup 컴포넌트 구현 (UIKit + SwiftUI)

### DIFF
--- a/Examples/BezierExamples/BezierExamples/App/CatalogRegistry.swift
+++ b/Examples/BezierExamples/BezierExamples/App/CatalogRegistry.swift
@@ -160,6 +160,12 @@ enum CatalogRegistry {
       section: .v3Components,
       destination: AnyView(DropdownMenuCatalog())
     ),
+    CatalogItem(
+      id: "form-group",
+      title: "FormGroup",
+      section: .v3Components,
+      destination: AnyView(FormGroupCatalog())
+    ),
     // MARK: - Legacy Components
     CatalogItem(
       id: "legacy-button",

--- a/Examples/BezierExamples/BezierExamples/Components/FormGroupCatalog.swift
+++ b/Examples/BezierExamples/BezierExamples/Components/FormGroupCatalog.swift
@@ -1,0 +1,123 @@
+import SwiftUI
+import UIKit
+import BezierSwift
+
+struct FormGroupCatalog: View {
+  @State private var isEnabled = true
+  @State private var hasError = false
+  @State private var spacing = BezierFormGroupConstant.contentSpacing
+  @State private var firstChecked = false
+  @State private var secondChecked = true
+
+  var body: some View {
+    CatalogScreen(title: "FormGroup") {
+      self.controls
+      CatalogSection(.swiftUI) { self.swiftUIPreview }
+      CatalogSection(.uiKit) { self.uiKitPreview }
+    }
+  }
+
+  private var controls: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Toggle("isEnabled", isOn: self.$isEnabled)
+      Toggle("hasError", isOn: self.$hasError)
+      Picker("spacing", selection: self.$spacing) {
+        Text("spacing 4 (기본)").tag(CGFloat(4))
+        Text("spacing 12").tag(CGFloat(12))
+      }
+      .pickerStyle(.segmented)
+    }
+    .font(.caption)
+  }
+
+  private var headerChecked: BezierCheckboxChecked {
+    switch (self.firstChecked, self.secondChecked) {
+    case (true, true): return .checked
+    case (false, false): return .unchecked
+    default: return .indeterminate
+    }
+  }
+
+  private var swiftUIPreview: some View {
+    SUBezierFormGroup(spacing: self.spacing) {
+      SUBezierCheckbox(
+        label: "전체 선택",
+        checked: self.headerChecked,
+        hasError: self.hasError,
+        onCheckedChange: { newValue in
+          let isChecked = newValue == .checked
+          self.firstChecked = isChecked
+          self.secondChecked = isChecked
+        }
+      )
+      SUBezierCheckbox(
+        label: "마케팅 정보 수신 동의",
+        checked: self.firstChecked ? .checked : .unchecked,
+        hasError: self.hasError,
+        onCheckedChange: { self.firstChecked = $0 == .checked }
+      )
+      SUBezierCheckbox(
+        label: "이용약관 동의",
+        checked: self.secondChecked ? .checked : .unchecked,
+        hasError: self.hasError,
+        onCheckedChange: { self.secondChecked = $0 == .checked }
+      )
+    }
+    .disabled(!self.isEnabled)
+    .frame(maxWidth: .infinity, alignment: .leading)
+  }
+
+  private var uiKitPreview: some View {
+    FormGroupUIKitRepresentable(spacing: self.spacing, hasError: self.hasError)
+      .disabled(!self.isEnabled)
+  }
+}
+
+private struct FormGroupUIKitRepresentable: UIViewRepresentable {
+  let spacing: CGFloat
+  let hasError: Bool
+
+  func makeUIView(context: Context) -> BezierFormGroup {
+    let header = BezierCheckbox(label: "전체 선택", checked: .indeterminate)
+    let first = BezierCheckbox(label: "마케팅 정보 수신 동의", checked: .unchecked)
+    let second = BezierCheckbox(label: "이용약관 동의", checked: .checked)
+
+    header.onCheckedChange = { [weak first, weak second] newValue in
+      let childChecked: BezierCheckboxChecked = newValue == .checked ? .checked : .unchecked
+      first?.checked = childChecked
+      second?.checked = childChecked
+    }
+    let syncHeader: (BezierCheckboxChecked) -> Void = { [weak header, weak first, weak second] _ in
+      guard let first, let second else { return }
+      switch (first.checked, second.checked) {
+      case (.checked, .checked): header?.checked = .checked
+      case (.unchecked, .unchecked): header?.checked = .unchecked
+      default: header?.checked = .indeterminate
+      }
+    }
+    first.onCheckedChange = syncHeader
+    second.onCheckedChange = syncHeader
+
+    return BezierFormGroup(items: [header, first, second])
+  }
+
+  func updateUIView(_ formGroup: BezierFormGroup, context: Context) {
+    formGroup.spacing = self.spacing
+    for case let checkbox as BezierCheckbox in formGroup.items {
+      checkbox.hasError = self.hasError
+      // root가 UIControl이 아니라 SwiftUI의 isEnabled 자동 동기화가 nested control까지 닿지 않음
+      // → environment 값을 직접 주입 (.disabled() modifier와 일관)
+      checkbox.isEnabled = context.environment.isEnabled
+    }
+  }
+
+  func sizeThatFits(_ proposal: ProposedViewSize, uiView: BezierFormGroup, context: Context) -> CGSize? {
+    let width = proposal.width ?? 320
+    let fitting = uiView.systemLayoutSizeFitting(
+      CGSize(width: width, height: UIView.layoutFittingCompressedSize.height),
+      withHorizontalFittingPriority: .required,
+      verticalFittingPriority: .fittingSizeLevel
+    )
+    return CGSize(width: width, height: fitting.height)
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierFormGroup/BezierFormGroup.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierFormGroup/BezierFormGroup.swift
@@ -1,0 +1,88 @@
+//
+//  BezierFormGroup.swift
+//  BezierSwift
+//
+
+import UIKit
+
+/// 독립 상태 컨트롤 여러 개를 묶을 때의 간격·정렬을 정의하는 레이아웃 그룹 (UIKit). 컨트롤을 세로로 4pt 간격·좌측 정렬로 쌓는다. 그룹 라벨을 렌더링하지 않으며(그룹 설명 텍스트는 상위 폼 필드 영역 책임), 선택 상태도 소유하지 않는다 — 각 컨트롤이 자기 상태를 관리한다. 현재 스코프의 자식은 `BezierCheckbox` 전용으로, 입력·동의 폼의 체크박스 묶음이나 「전체 선택」(indeterminate) 헤더를 포함한 그룹에 쓴다. 목록에서 항목을 고르는 다중선택 리스트에는 쓰지 않는다. SwiftUI에서는 `SUBezierFormGroup`을 사용한다.
+public final class BezierFormGroup: UIView {
+  // MARK: - Public Properties
+
+  /// 컨트롤 간 세로 간격 (기본값 4pt).
+  public var spacing: CGFloat = BezierFormGroupConstant.contentSpacing {
+    didSet { if oldValue != self.spacing { self.contentStackView.spacing = self.spacing } }
+  }
+
+  /// 현재 표시 중인 컨트롤 뷰 배열. 읽기 전용이며 `setItems(_:)`/`addItem(_:)`으로 변경한다.
+  public private(set) var items: [UIView] = []
+
+  // MARK: - Subviews
+
+  private let contentStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    stackView.alignment = .leading
+    stackView.distribution = .fill
+    stackView.spacing = BezierFormGroupConstant.contentSpacing
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    return stackView
+  }()
+
+  // MARK: - Init
+
+  /// 초기 컨트롤 배열과 간격을 지정해 생성한다. 컨트롤은 이후 `setItems(_:)`/`addItem(_:)`으로 교체·추가할 수 있다.
+  public init(
+    spacing: CGFloat = BezierFormGroupConstant.contentSpacing,
+    items: [UIView] = []
+  ) {
+    self.spacing = spacing
+    self.items = items
+    super.init(frame: .zero)
+    self.setUp()
+  }
+
+  public required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    self.setUp()
+  }
+
+  // MARK: - Setup
+
+  private func setUp() {
+    self.translatesAutoresizingMaskIntoConstraints = false
+    self.shouldGroupAccessibilityChildren = true
+
+    self.addSubview(self.contentStackView)
+    NSLayoutConstraint.activate([
+      self.contentStackView.topAnchor.constraint(equalTo: self.topAnchor),
+      self.contentStackView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+      self.contentStackView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+      self.contentStackView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+    ])
+
+    self.contentStackView.spacing = self.spacing
+    self.rebuildItems()
+  }
+
+  // MARK: - Items
+
+  /// 컨트롤 배열을 통째로 교체한다.
+  public func setItems(_ items: [UIView]) {
+    self.items = items
+    self.rebuildItems()
+  }
+
+  /// 컨트롤을 끝에 하나 추가한다.
+  public func addItem(_ item: UIView) {
+    self.items.append(item)
+    self.contentStackView.addArrangedSubview(item)
+  }
+
+  // MARK: - Rebuild
+
+  private func rebuildItems() {
+    self.contentStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+    self.items.forEach { self.contentStackView.addArrangedSubview($0) }
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierFormGroup/BezierFormGroupSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierFormGroup/BezierFormGroupSpec.swift
@@ -1,0 +1,13 @@
+//
+//  BezierFormGroupSpec.swift
+//  BezierSwift
+//
+
+import Foundation
+
+// MARK: - Constant
+
+public enum BezierFormGroupConstant {
+  /// 컨트롤 간 세로 간격. Figma `FormGroup`의 `content` SLOT itemSpacing(4pt)에 대응.
+  public static let contentSpacing: CGFloat = 4
+}

--- a/Sources/BezierSwift/MasterComponent/BezierFormGroup/SPEC.md
+++ b/Sources/BezierSwift/MasterComponent/BezierFormGroup/SPEC.md
@@ -1,0 +1,64 @@
+# BezierFormGroup SPEC
+
+> **SSOT**: [Figma · Mobile-Components / FormGroup (5071:692)](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=5071-692) — component key `b35c73ce1d4571e4222b4f0c59828db013f9f112`
+> **Design spec doc**: [team-design / bezier-v3 / components / FormGroup-spec.md](https://github.com/channel-io/team-design/blob/main/bezier-v3/components/FormGroup-spec.md) (보조 참조 — 값 충돌 시 Figma 파일 우선)
+
+체크박스·스위치 등 독립 상태 컨트롤 여러 개를 묶을 때의 간격·정렬을 정의하는 레이아웃 그룹 컴포넌트 (Figma component description 1행).
+
+## 1. Component Properties
+
+단일 COMPONENT (COMPONENT_SET 아님) — variant/property 축 없음.
+
+| Property | 값 | 비고 |
+|---|---|---|
+| **content** | SLOT | Checkbox 인스턴스 전용 (`preferredValues` = Checkbox CS `4838:126`, `allowPreferredValuesOnly: true`) |
+
+총 instance: 단일 COMPONENT `5071:692` 1개
+
+## 2. Layout Spec
+
+| Part | 값 |
+|---|---|
+| 루트 (FormGroup) | 세로 오토레이아웃, HUG×HUG, 좌측 정렬, 패딩 없음 — `content` 슬롯 하나만 포함 |
+| `content` SLOT | 세로 오토레이아웃, itemSpacing `4pt`, HUG×HUG, 좌측 정렬, 패딩 없음 |
+
+기본 슬롯 콘텐츠 실측: Checkbox 인스턴스 3개 (각 높이 40pt, y = 0/44/88 → 간격 4pt, 전체 166×128pt).
+
+## 3. 컬러 토큰
+
+없음 — FormGroup 자체 레이어(루트·`content`)에는 fill·border·shadow·radius가 하나도 없다. 순수 레이아웃 컨테이너.
+
+## 4. Typography
+
+이 컴포넌트에 텍스트 없음 (Figma 텍스트 노드는 전부 자식 Checkbox 인스턴스 내부 소유).
+
+## 5. State 별 시각 동작
+
+Figma에 state variant 축 없음 — FormGroup 자체는 시각 상태가 없는 정적 컨테이너다. disabled/hasError 등은 각 자식 Checkbox가 개별 표현한다.
+
+## 6. 디자이너 가이드라인 (Figma component description 인용)
+
+- 체크박스·스위치 등 독립 상태 컨트롤 여러 개를 묶을 때의 간격·정렬을 정의하는 레이아웃 그룹 컴포넌트.
+- 라벨은 소유하지 않는다 — 그룹 전체를 설명하는 라벨이 필요하면 상위 FormField의 FormLabel을 사용한다.
+- 📱 Mobile 스코프(DL-090): 자식은 Checkbox(DL-084) 전용 — 입력·동의 그룹 목적. 「전체 선택」 indeterminate 헤더(DL-089)도 이 스코프에 포함. 다중선택 리스트(ListItem trailing check)는 대상 아님 — ListItem/MultiSelect 사용.
+- direction: vertical 고정(DL-092) — 내부(bezier-compose·cht-desk-android·cht-desk-ios 전수 조사, 가로 배치 0건) + 업계(Material Design 3·Apple HIG 모두 세로 리스트 컨벤션) 근거로 확정. horizontal은 web 전용.
+- spacing: 4dp(최종 확정, DL-094) — 40dp 터치 타깃 자체 패딩(16dp 시각 여백)과 별개로, 인접 타깃 간 최소 간격(Google 접근성 가이드 「8dp 이상」 권장의 절반)을 확보하기 위한 명시적 gap. FormGroup-spec.md §4/§6 참조.
+- content: SLOT — Checkbox 인스턴스만 추가/삭제 가능(restrict to Checkbox).
+
+## 7. 매핑되는 코드 심볼
+
+| 정의 | 파일 |
+|---|---|
+| UIKit 구현 | `BezierFormGroup.swift` |
+| SwiftUI 구현 | `SUBezierFormGroup.swift` |
+| constant | `BezierFormGroupSpec.swift` |
+
+## 8. Figma 외 · 협의 사항
+
+Figma에 없는 구현 아키텍처 결정은 아래에 분리 표기한다. SSOT 값이 아니다.
+
+1. **자식 API는 뷰 일반형**: Figma SLOT은 Checkbox 전용으로 제한되지만, 코드 API는 `UIView` 배열(UIKit) / `@ViewBuilder`(SwiftUI)로 받고 Checkbox 타입 하드 의존을 두지 않는다. Checkbox 전용 스코프는 doc comment로 안내한다.
+2. **spacing 노출**: team-design spec §10 [Mobile]이 `spacing` prop(기본 4dp)을 제안 — 코드도 `spacing` 파라미터(기본값 `BezierFormGroupConstant.contentSpacing` = 4pt)로 노출한다. direction은 vertical 고정이라 prop을 만들지 않는다(동 §10).
+3. **접근성 그룹핑**: 웹 `role="group"` 대응(team-design spec §3 [Mobile]) — UIKit은 `shouldGroupAccessibilityChildren = true`, SwiftUI는 `.accessibilityElement(children: .contain)` 적용. 라벨은 렌더링하지 않는다.
+4. **상태 비소유**: 선택 상태(value/onChange 류) prop을 만들지 않는다 — 각 자식 컨트롤이 자기 상태를 소유한다 (team-design spec §9 Anti-pattern #1).
+5. **componentTheme 미보유**: 자체 컬러 레이어가 없어 `BezierComponentable`을 채택하지 않는다. 자식 Checkbox의 테마는 소비자가 각 자식에 직접 지정한다.

--- a/Sources/BezierSwift/MasterComponent/BezierFormGroup/SUBezierFormGroup.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierFormGroup/SUBezierFormGroup.swift
@@ -1,0 +1,47 @@
+//
+//  SUBezierFormGroup.swift
+//  BezierSwift
+//
+
+import SwiftUI
+
+/// 독립 상태 컨트롤 여러 개를 묶을 때의 간격·정렬을 정의하는 레이아웃 그룹 (SwiftUI). 컨트롤을 세로로 4pt 간격·좌측 정렬로 쌓는다. 그룹 라벨을 렌더링하지 않으며(그룹 설명 텍스트는 상위 폼 필드 영역 책임), 선택 상태도 소유하지 않는다 — 각 컨트롤이 자기 상태를 관리한다. 현재 스코프의 자식은 `SUBezierCheckbox` 전용으로, 입력·동의 폼의 체크박스 묶음이나 「전체 선택」(indeterminate) 헤더를 포함한 그룹에 쓴다. 목록에서 항목을 고르는 다중선택 리스트에는 쓰지 않는다. UIKit에서는 `BezierFormGroup`을 사용한다.
+public struct SUBezierFormGroup<Content: View>: View {
+  private let spacing: CGFloat
+  private let content: Content
+
+  /// 간격과 컨트롤 목록을 지정해 생성한다. `content`의 각 뷰가 세로로 `spacing` 간격으로 쌓인다.
+  public init(
+    spacing: CGFloat = BezierFormGroupConstant.contentSpacing,
+    @ViewBuilder content: () -> Content
+  ) {
+    self.spacing = spacing
+    self.content = content()
+  }
+
+  public var body: some View {
+    VStack(alignment: .leading, spacing: self.spacing) {
+      self.content
+    }
+    .accessibilityElement(children: .contain)
+  }
+}
+
+struct SUBezierFormGroup_Previews: PreviewProvider {
+  static var previews: some View {
+    VStack(alignment: .leading, spacing: 32) {
+      SUBezierFormGroup {
+        SUBezierCheckbox(label: "전체 선택", checked: .indeterminate, onCheckedChange: { _ in })
+        SUBezierCheckbox(label: "마케팅 정보 수신 동의", checked: .checked, onCheckedChange: { _ in })
+        SUBezierCheckbox(label: "이용약관 동의", checked: .unchecked, onCheckedChange: { _ in })
+      }
+
+      SUBezierFormGroup {
+        SUBezierCheckbox(label: "이메일 알림", checked: .unchecked, onCheckedChange: { _ in })
+        SUBezierCheckbox(label: "SMS 알림", checked: .unchecked, onCheckedChange: { _ in })
+      }
+      .disabled(true)
+    }
+    .padding()
+  }
+}

--- a/Tests/BezierSwiftTests/BezierFormGroupTests.swift
+++ b/Tests/BezierSwiftTests/BezierFormGroupTests.swift
@@ -1,0 +1,103 @@
+import Testing
+import UIKit
+@testable import BezierSwift
+
+@Suite("BezierFormGroup 레이아웃 그룹", .serialized)
+@MainActor
+struct BezierFormGroupTests {
+  @Test("기본 간격은 4pt다")
+  func defaultSpacing() {
+    let formGroup = BezierFormGroup()
+
+    #expect(BezierFormGroupConstant.contentSpacing == 4)
+    #expect(formGroup.spacing == BezierFormGroupConstant.contentSpacing)
+    #expect(Self.contentStackView(in: formGroup)?.spacing == BezierFormGroupConstant.contentSpacing)
+  }
+
+  @Test("items 순서대로 세로 스택에 쌓인다")
+  func itemsStackInOrder() throws {
+    let items = Self.makeItems(3)
+    let formGroup = BezierFormGroup(items: items)
+
+    let stackView = try #require(Self.contentStackView(in: formGroup))
+    #expect(stackView.axis == .vertical)
+    #expect(stackView.alignment == .leading)
+    #expect(stackView.arrangedSubviews == items)
+  }
+
+  @Test("setItems는 전체 교체, addItem은 끝에 추가한다")
+  func setAndAddItems() throws {
+    let formGroup = BezierFormGroup(items: Self.makeItems(2))
+
+    formGroup.setItems(Self.makeItems(4))
+    #expect(formGroup.items.count == 4)
+
+    let appended = UIView()
+    formGroup.addItem(appended)
+    #expect(formGroup.items.count == 5)
+
+    let stackView = try #require(Self.contentStackView(in: formGroup))
+    #expect(stackView.arrangedSubviews.count == 5)
+    #expect(stackView.arrangedSubviews.last === appended)
+  }
+
+  @Test("spacing 변경이 스택 간격에 반영된다")
+  func spacingUpdates() {
+    let formGroup = BezierFormGroup(items: Self.makeItems(2))
+
+    formGroup.spacing = 12
+    #expect(Self.contentStackView(in: formGroup)?.spacing == 12)
+  }
+
+  @Test("40pt 행 3개가 4pt 간격으로 배치된다 (y = 0/44/88, 전체 높이 128)")
+  func rowsLayoutWithDefaultSpacing() {
+    let items = Self.makeItems(3, width: 160, height: 40)
+    let formGroup = BezierFormGroup(items: items)
+
+    let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 480))
+    window.addSubview(formGroup)
+    NSLayoutConstraint.activate([
+      formGroup.topAnchor.constraint(equalTo: window.topAnchor),
+      formGroup.leadingAnchor.constraint(equalTo: window.leadingAnchor),
+    ])
+    window.layoutIfNeeded()
+
+    #expect(items[0].frame.minY == 0)
+    #expect(items[1].frame.minY == 44)
+    #expect(items[2].frame.minY == 88)
+    #expect(formGroup.bounds.height == 128)
+  }
+
+  @Test("VoiceOver 그룹핑이 켜져 있다")
+  func accessibilityGrouping() {
+    let formGroup = BezierFormGroup()
+
+    #expect(formGroup.shouldGroupAccessibilityChildren)
+  }
+
+  // MARK: - Helpers
+
+  private static func makeItems(_ count: Int) -> [UIView] {
+    (0..<count).map { _ in UIView() }
+  }
+
+  private static func makeItems(_ count: Int, width: CGFloat, height: CGFloat) -> [UIView] {
+    (0..<count).map { _ in
+      let view = UIView()
+      view.translatesAutoresizingMaskIntoConstraints = false
+      NSLayoutConstraint.activate([
+        view.widthAnchor.constraint(equalToConstant: width),
+        view.heightAnchor.constraint(equalToConstant: height),
+      ])
+      return view
+    }
+  }
+
+  private static func contentStackView(in view: UIView) -> UIStackView? {
+    for subview in view.subviews {
+      if let stackView = subview as? UIStackView { return stackView }
+      if let found = self.contentStackView(in: subview) { return found }
+    }
+    return nil
+  }
+}


### PR DESCRIPTION
## MOB-6345

https://linear.app/channel/issue/MOB-6345

V3 FormGroup 컴포넌트를 UIKit + SwiftUI로 구현합니다.

## 구현 내용

### FormGroup — `BezierFormGroup` / `SUBezierFormGroup`

- 독립 상태 컨트롤 여러 개를 묶을 때의 간격·정렬을 정의하는 **순수 레이아웃 그룹** — 세로 스택, 간격 4pt(기본), 좌측 정렬, 자체 컬러/텍스트/상태 없음
- **라벨 미소유**: 그룹 라벨을 렌더링하지 않고 label prop도 만들지 않음 — 그룹 설명 텍스트는 상위 폼 필드 영역 책임 (웹 `FormGroup.types.ts`에도 label prop 없음, spec §1)
- **상태 비소유**: value/onChange 류 prop 없음 — 각 자식 컨트롤이 자기 상태를 소유 (spec §9 Anti-pattern #1)
- **direction prop 없음**: 모바일은 vertical 고정 (DL-092) — spec §10 [Mobile] 제안대로 `spacing` 파라미터만 노출 (기본값 `BezierFormGroupConstant.contentSpacing` = 4pt, DL-094 확정값)
- 자식 API는 뷰 일반형 — UIKit `items: [UIView]` + `setItems(_:)`/`addItem(_:)`, SwiftUI `@ViewBuilder content`. Checkbox 타입 하드 의존 없음, 현재 스코프(자식 = Checkbox 전용, 입력·동의 그룹 + 「전체 선택」 indeterminate 헤더, DL-090)는 doc comment로 안내
- 접근성 그룹핑: 웹 `role="group"` 대응 — UIKit `shouldGroupAccessibilityChildren = true`, SwiftUI `.accessibilityElement(children: .contain)`
- 자체 컬러 레이어가 없어 `BezierComponentable` 미채택 (다크모드 재주입 대상 없음)

### Examples

- FormGroup 카탈로그 추가 — SwiftUI/UIKit 각각 「전체 선택」(indeterminate) 헤더 + 체크박스 2개 동기화 데모, isEnabled/hasError 토글, spacing 4↔12 세그먼트

## Spec 검증

figma-component-spec 3단계 사이클로 검증했습니다 (Figma = SSOT):

- Phase 1: Figma 실측 기반 `SPEC.md` 작성 (FormGroup `5071:692`, 단일 COMPONENT — variant 축 없음, content SLOT은 Checkbox 전용 restrict)
- Phase 2: Properties / Layout / Color / Typography / Asset / Spec Noise / Implementation Reference 7종 병렬 검증 전부 통과
  - Layout: content SLOT gap 4pt·좌측 정렬·HUG×HUG, 기본 콘텐츠 Checkbox 3개(높이 40, y=0/44/88, 전체 166×128) 전수 일치
  - Color/Typography/Asset: FormGroup 자체 레이어 소유 시각 속성·텍스트·자산 0건 확인 (전부 자식 Checkbox 소유)
- Phase 3: UIKit·SwiftUI Implementation Validator로 구현–SPEC 일치 확인 (Critical/Minor 불일치 0건)
- Figma에 없는 구현 결정(자식 뷰 일반형 API, spacing 노출, 접근성 그룹핑 방식, 상태 비소유, BezierComponentable 미채택)은 `SPEC.md` §8에 협의 사항으로 분리 기록

## 스크린샷

> 시뮬레이터 검증 후 첨부 예정

| 기본 (SwiftUI) | 기본 (UIKit) | 전체 선택 인터랙션 | spacing 12 |
|---|---|---|---|
| _추가 예정_ | _추가 예정_ | _추가 예정_ | _추가 예정_ |

| disabled | hasError | dark (SwiftUI) | dark (UIKit) |
|---|---|---|---|
| _추가 예정_ | _추가 예정_ | _추가 예정_ | _추가 예정_ |

## 테스트

- `BezierFormGroupTests` — 기본 간격 4pt, 스택 구성(세로·leading·순서), setItems/addItem, spacing 반영, UIWindow 실측 배치(y=0/44/88, 높이 128), VoiceOver 그룹핑 — `xcodebuild test` 통과
- 패키지(`BezierSwift`)·Examples(`BezierExamples`) clean build 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - UIKit과 SwiftUI에서 여러 컨트롤을 세로로 묶어 표시할 수 있는 `FormGroup` 컴포넌트를 추가했습니다.
  - 항목 추가·교체와 간격 설정을 지원하며, 접근성 그룹으로 올바르게 인식됩니다.
  - 체크박스 그룹에서 전체 선택, 해제 및 부분 선택 상태를 지원합니다.
  - 비활성화 및 오류 상태를 미리 확인할 수 있습니다.

- **문서 및 예제**
  - 카탈로그에 FormGroup 예제를 추가해 레이아웃과 상태별 동작을 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->