### PR TITLE
[MOB-6528] 에이전트 작업 규칙 문서 신설 + CatalogRegistry 충돌 구조 해소

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,97 @@
+# BezierSwift
+
+Channel 디자인 시스템의 iOS 라이브러리. 컴포넌트 1종을 **UIKit + SwiftUI 쌍**으로 제공한다.
+SPM 단일 패키지, iOS 16+, 외부 의존성 없음. 소비자는 `ch-desk-ios`.
+
+이 문서는 에이전트 작업 규칙이다. 사람 대상 기여 절차(Examples 카탈로그 등록 등)는
+[`CONTRIBUTING.md`](CONTRIBUTING.md)에 있다.
+
+## 저장소 구조
+
+```text
+Sources/BezierSwift/
+  MasterComponent/{Component}/   컴포넌트 1종 = 1 디렉토리
+  Foundation/Color/{V1,V3}/      BCSemanticToken(V3) · SemanticColor(V1)
+  Foundation/Typography/{V1,V3}/ BTSemanticToken(V3) · BezierFont(V1)
+  Icons/BezierIcon.swift         아이콘 enum
+  Util/                          BezierPressFeedback, ColorUtils
+Examples/BezierExamples/         시각 검증 앱 (별도 xcodeproj)
+Tests/BezierSwiftTests/          단위 테스트
+```
+
+## 명명 규칙
+
+- SwiftUI `SUBezier*` / UIKit `Bezier*`(prefix 없음) / V1 잔존 `LegacyBezier*`
+- 컴포넌트 1종 = `MasterComponent/{Bezier{Name}}/` 아래 4파일
+  - `{Name}.swift` — UIKit 구현
+  - `SU{Name}.swift` — SwiftUI 구현
+  - `{Name}Spec.swift` — size/variant enum과 상수
+  - `SPEC.md` — Figma 실측 SSOT ([`docs/spec-template.md`](docs/spec-template.md) 형식)
+- enum case의 약어는 전부 대문자 — `headingXLarge`, `textXXSmall` (Swift API Design Guidelines)
+
+**예외 (V1 시절 네이밍이라 규칙과 어긋남 — 새 코드에서 따라하지 말 것)**
+`BezierDialog`·`LegacyBezierButton`·`LegacyBezierToast`는 파일명이 `Bezier*`지만 UIKit이
+아니라 SwiftUI `View`다.
+
+**SPEC.md 불요 대상** — 누락이 아니므로 새로 만들지 말 것
+`BezierBaseInput`(internal 공유 레이어, `BezierTextInput/SPEC.md`가 커버) ·
+`BezierDialog`·`LegacyBezier*`(V1 잔존)
+
+## 토큰 규칙 (위반 시 리뷰 반려)
+
+- **Semantic 토큰만 사용·노출한다** — 색은 `BCSemanticToken`, 타이포는 `BTSemanticToken`.
+  Global 토큰(`BCGlobalToken`은 public, `BTGlobalToken`은 internal)은 Semantic의 내부
+  구현 세부사항이다. 컴포넌트 구현과 public API 표면에 쓰지 않는다
+- **`fill*` 토큰은 alpha가 내장돼 있다** — 추가 opacity를 곱하지 말 것.
+  SPEC의 "fill-neutral-heavy (opacity 0.15)"는 토큰 자체의 속성 설명이지 곱할 값이 아니다.
+  곱하면 SwiftUI `.opacity()`(곱셈)와 UIKit `.withAlphaComponent()`(고정)가 서로 다른
+  결과를 내 두 구현이 어긋난다
+- **아이콘은 `BezierIcon` enum을 우선 사용한다** — Figma의 raw asset(SVG)도 SSOT의
+  일부다. SF Symbol로 임의 대체하면 SSOT 위반. 매칭 자산이 없으면 Figma export를 추가한다
+
+## API 표면 규칙
+
+- **배치는 컨테이너 책임** — public `resizing`/`isFullWidth` 류 프로퍼티를 만들지 않는다.
+  UIKit은 스택·제약이 intrinsic size를 이기므로 무수정으로 해결되고, SwiftUI 내부에서
+  stretch가 필요하면 internal init 오버로드로만 처리해 public 표면을 바꾸지 않는다
+- **public 심볼에는 `///` doc comment 필수.** 선택 축 enum은 선언부에 대응하는 Figma
+  property를 적고, 각 case에 "언제 쓰는지"(Selection Rules)를 1~2줄 적는다.
+  Figma에 대응이 없는 축은 "코드 전용 축"으로 명시한다 — 억지 매핑보다 낫다
+
+## 주석 정책
+
+주석은 **비정상 코드**(회피 hack·workaround·비자명한 invariant)의 *왜*를 설명할 때만 단다.
+SPEC 참조(`// SPEC §5`)·동작 설명·정상 코드의 의도는 주석이 아니라 PR description으로 쓴다.
+public API의 `///` doc comment는 이 정책의 예외로 필수다.
+
+## 빌드·테스트
+
+```bash
+xcrun simctl list devices booted          # UDID 확인 (없으면 simctl boot)
+UDID=<booted-udid>
+
+xcodebuild -scheme BezierSwift -destination "platform=iOS Simulator,id=$UDID" clean build
+xcodebuild -scheme BezierSwift -destination "platform=iOS Simulator,id=$UDID" test
+xcodebuild -project Examples/BezierExamples/BezierExamples.xcodeproj -scheme BezierExamples \
+           -destination "platform=iOS Simulator,id=$UDID" clean build
+```
+
+- **`swift test` 불가** — UIKit 의존성 때문에 링크되지 않는다. 반드시 `xcodebuild`
+- **destination은 booted UDID(`id=`)로 지정** — `name=`은 SPM 스킴에서 tvOS/visionOS
+  placeholder까지 끌어들여 "Unable to find a device"로 실패한다
+- **최종 검증은 clean build** — incremental cache가 타입 회귀를 가린다
+- **판정은 원본 출력의 `BUILD SUCCEEDED`로** — 래퍼(`rtk` 등)의 요약은 destination 에러를
+  성공으로 오판한 전례가 있다. `... 2>&1 | grep -E "error:|BUILD SUCCEEDED|BUILD FAILED"`
+- doc comment/주석만 바꾼 작업은 빌드 대신 `git diff`로 검증한다(추가분이 전부 `///`이고
+  삭제가 0이면 코드 무변경이 증명된다). 컴파일에 영향이 없어 빌드는 우회 증명일 뿐이다
+
+## 상세 문서 (해당 작업을 할 때만 읽을 것)
+
+| 문서 | 언제 |
+|---|---|
+| [`docs/agent/uikit-pitfalls.md`](docs/agent/uikit-pitfalls.md) | UIKit 컴포넌트 구현 |
+| [`docs/agent/swiftui-pitfalls.md`](docs/agent/swiftui-pitfalls.md) | SwiftUI 컴포넌트 구현 |
+| [`docs/agent/examples-pitfalls.md`](docs/agent/examples-pitfalls.md) | Examples 카탈로그 작성 |
+| [`docs/agent/testing.md`](docs/agent/testing.md) | 테스트 작성·시뮬레이터 검증 |
+| [`docs/spec-template.md`](docs/spec-template.md) | SPEC.md 작성 |
+| [`CONTRIBUTING.md`](CONTRIBUTING.md) | 카탈로그 등록 절차·Examples 아키텍처 |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Contributing
 
+> 명명·토큰·API 표면·빌드·PR 등 에이전트 작업 규칙은 [`CLAUDE.md`](CLAUDE.md)에 있다. 카탈로그 작성 중 만나는 함정은 [`docs/agent/examples-pitfalls.md`](docs/agent/examples-pitfalls.md) 참조.
+
 ## Example App에 새 컴포넌트 카탈로그 등록
 
 V3 컴포넌트(SwiftUI `SU*` + UIKit) 또는 Foundation 토큰을 추가할 때, 시각 검증용 catalog를 `Examples/BezierExamples`에 함께 등록한다.
@@ -27,15 +29,12 @@ V3 컴포넌트(SwiftUI `SU*` + UIKit) 또는 Foundation 토큰을 추가할 때
    - SwiftUI/UIKit 양쪽 섹션이 같은 `@State`를 구독하도록 작성 — 컨트롤은 한 번만.
    - UIKit 컴포넌트는 `UIKitWrap { make } update: { ... }` 패턴으로 임베드. `update` 클로저에서 모든 property를 다시 설정해야 state 변경이 반영됨.
 
-2. `Examples/BezierExamples/BezierExamples/App/CatalogRegistry.swift`의 `all` 배열에 `CatalogItem` 추가. `section`은 컴포넌트 세대에 따라 `.v3Components` 또는 `.legacyComponents` 선택:
+2. `Examples/BezierExamples/BezierExamples/App/CatalogRegistry.swift`의 섹션 배열에 한 줄로 추가. 컴포넌트 세대에 따라 `v3Components` 또는 `legacyComponents` 배열을 고른다:
    ```swift
-   CatalogItem(
-     id: "{component-id}",
-     title: "{Component}",
-     section: .v3Components,
-     destination: AnyView({Component}Catalog())
-   ),
+   .init(id: "{component-id}", title: "{Component}", section: .v3Components, destination: AnyView({Component}Catalog())),
    ```
+
+   **`title` 알파벳순 위치에 삽입한다** — 배열 끝에 붙이면 병렬 PR이 같은 줄에서 충돌한다. 항목을 여러 줄로 펼치지 않는 것도 같은 이유다. `id`는 kebab-case이며 중복되면 `BezierExamplesTests`가 실패한다.
 
 3. 시뮬레이터에서 다음을 확인:
    - [ ] Foundation/Components 사이드바에 새 항목 표시
@@ -46,7 +45,7 @@ V3 컴포넌트(SwiftUI `SU*` + UIKit) 또는 Foundation 토큰을 추가할 때
 
 ### Foundation 토큰 catalog 추가
 
-`Examples/BezierExamples/BezierExamples/Foundation/{Token}Catalog.swift` 파일 생성. 기존 `ColorTokenCatalog`/`TypographyCatalog` 패턴 참고. `CatalogRegistry.all`에 `section: .v3Foundation`으로 등록.
+`Examples/BezierExamples/BezierExamples/Foundation/{Token}Catalog.swift` 파일 생성. 기존 `ColorTokenCatalog`/`TypographyCatalog` 패턴 참고. 등록은 위와 같되 `CatalogRegistry`의 `v3Foundation` 배열에 `section: .v3Foundation`으로 추가한다.
 
 ## 아키텍처 메모
 

--- a/Examples/BezierExamples/BezierExamples/App/CatalogRegistry.swift
+++ b/Examples/BezierExamples/BezierExamples/App/CatalogRegistry.swift
@@ -1,185 +1,51 @@
 import SwiftUI
 
 enum CatalogRegistry {
-  static let all: [CatalogItem] = [
-    // MARK: - V3 Foundation
-    CatalogItem(
-      id: "color",
-      title: "Color Token",
-      section: .v3Foundation,
-      destination: AnyView(ColorTokenCatalog())
-    ),
-    CatalogItem(
-      id: "typography",
-      title: "Typography",
-      section: .v3Foundation,
-      destination: AnyView(TypographyCatalog())
-    ),
-    CatalogItem(
-      id: "icon",
-      title: "Icon",
-      section: .v3Foundation,
-      destination: AnyView(IconCatalog())
-    ),
-    CatalogItem(
-      id: "dimension",
-      title: "Dimension",
-      section: .v3Foundation,
-      destination: AnyView(DimensionCatalog())
-    ),
-    // MARK: - V3 Components
-    CatalogItem(
-      id: "base-item",
-      title: "BaseItem",
-      section: .v3Components,
-      destination: AnyView(BaseItemCatalog())
-    ),
-    CatalogItem(
-      id: "button",
-      title: "Button",
-      section: .v3Components,
-      destination: AnyView(ButtonCatalog())
-    ),
-    CatalogItem(
-      id: "icon-button",
-      title: "IconButton",
-      section: .v3Components,
-      destination: AnyView(IconButtonCatalog())
-    ),
-    CatalogItem(
-      id: "badge",
-      title: "Badge",
-      section: .v3Components,
-      destination: AnyView(BadgeCatalog())
-    ),
-    CatalogItem(
-      id: "tag",
-      title: "Tag",
-      section: .v3Components,
-      destination: AnyView(TagCatalog())
-    ),
-    CatalogItem(
-      id: "avatar",
-      title: "Avatar",
-      section: .v3Components,
-      destination: AnyView(AvatarCatalog())
-    ),
-    CatalogItem(
-      id: "avatar-group",
-      title: "AvatarGroup",
-      section: .v3Components,
-      destination: AnyView(AvatarGroupCatalog())
-    ),
-    CatalogItem(
-      id: "spinner",
-      title: "Spinner",
-      section: .v3Components,
-      destination: AnyView(SpinnerCatalog())
-    ),
-    CatalogItem(
-      id: "divider",
-      title: "Divider",
-      section: .v3Components,
-      destination: AnyView(DividerCatalog())
-    ),
-    CatalogItem(
-      id: "progress-bar",
-      title: "ProgressBar",
-      section: .v3Components,
-      destination: AnyView(ProgressBarCatalog())
-    ),
-    CatalogItem(
-      id: "modal",
-      title: "Modal",
-      section: .v3Components,
-      destination: AnyView(ModalCatalog())
-    ),
-    CatalogItem(
-      id: "toast",
-      title: "Toast",
-      section: .v3Components,
-      destination: AnyView(ToastCatalog())
-    ),
-    CatalogItem(
-      id: "confirm-modal",
-      title: "ConfirmModal",
-      section: .v3Components,
-      destination: AnyView(ConfirmModalCatalog())
-    ),
-    CatalogItem(
-      id: "banner",
-      title: "Banner",
-      section: .v3Components,
-      destination: AnyView(BannerCatalog())
-    ),
-    CatalogItem(
-      id: "card",
-      title: "Card",
-      section: .v3Components,
-      destination: AnyView(CardCatalog())
-    ),
-    CatalogItem(
-      id: "section",
-      title: "Section",
-      section: .v3Components,
-      destination: AnyView(SectionCatalog())
-    ),
-    CatalogItem(
-      id: "section-item",
-      title: "SectionItem",
-      section: .v3Components,
-      destination: AnyView(SectionItemCatalog())
-    ),
-    CatalogItem(
-      id: "floating-banner",
-      title: "FloatingBanner",
-      section: .v3Components,
-      destination: AnyView(FloatingBannerCatalog())
-    ),
-    CatalogItem(
-      id: "overlay",
-      title: "Overlay",
-      section: .v3Components,
-      destination: AnyView(OverlayCatalog())
-    ),
-    CatalogItem(
-      id: "switch",
-      title: "Switch",
-      section: .v3Components,
-      destination: AnyView(SwitchCatalog())
-    ),
-    CatalogItem(
-      id: "checkbox",
-      title: "Checkbox",
-      section: .v3Components,
-      destination: AnyView(CheckboxCatalog())
-    ),
-    CatalogItem(
-      id: "text-input",
-      title: "TextInput",
-      section: .v3Components,
-      destination: AnyView(TextInputCatalog())
-    ),
-    CatalogItem(
-      id: "dropdown-menu",
-      title: "DropdownMenu",
-      section: .v3Components,
-      destination: AnyView(DropdownMenuCatalog())
-    ),
-    CatalogItem(
-      id: "form-group",
-      title: "FormGroup",
-      section: .v3Components,
-      destination: AnyView(FormGroupCatalog())
-    ),
-    // MARK: - Legacy Components
-    CatalogItem(
-      id: "legacy-button",
-      title: "Legacy Button",
-      section: .legacyComponents,
-      destination: AnyView(LegacyButtonCatalog())
-    ),
+  // MARK: - V3 Foundation
+  // 알파벳순 유지 — 신규 항목은 배열 끝이 아니라 제자리에 삽입할 것 (병렬 PR 충돌 방지)
+  private static let v3Foundation: [CatalogItem] = [
+    .init(id: "color", title: "Color Token", section: .v3Foundation, destination: AnyView(ColorTokenCatalog())),
+    .init(id: "dimension", title: "Dimension", section: .v3Foundation, destination: AnyView(DimensionCatalog())),
+    .init(id: "icon", title: "Icon", section: .v3Foundation, destination: AnyView(IconCatalog())),
+    .init(id: "typography", title: "Typography", section: .v3Foundation, destination: AnyView(TypographyCatalog())),
   ]
+
+  // MARK: - V3 Components
+  // 알파벳순 유지 — 신규 항목은 배열 끝이 아니라 제자리에 삽입할 것 (병렬 PR 충돌 방지)
+  private static let v3Components: [CatalogItem] = [
+    .init(id: "avatar", title: "Avatar", section: .v3Components, destination: AnyView(AvatarCatalog())),
+    .init(id: "avatar-group", title: "AvatarGroup", section: .v3Components, destination: AnyView(AvatarGroupCatalog())),
+    .init(id: "badge", title: "Badge", section: .v3Components, destination: AnyView(BadgeCatalog())),
+    .init(id: "banner", title: "Banner", section: .v3Components, destination: AnyView(BannerCatalog())),
+    .init(id: "base-item", title: "BaseItem", section: .v3Components, destination: AnyView(BaseItemCatalog())),
+    .init(id: "button", title: "Button", section: .v3Components, destination: AnyView(ButtonCatalog())),
+    .init(id: "card", title: "Card", section: .v3Components, destination: AnyView(CardCatalog())),
+    .init(id: "checkbox", title: "Checkbox", section: .v3Components, destination: AnyView(CheckboxCatalog())),
+    .init(id: "confirm-modal", title: "ConfirmModal", section: .v3Components, destination: AnyView(ConfirmModalCatalog())),
+    .init(id: "divider", title: "Divider", section: .v3Components, destination: AnyView(DividerCatalog())),
+    .init(id: "dropdown-menu", title: "DropdownMenu", section: .v3Components, destination: AnyView(DropdownMenuCatalog())),
+    .init(id: "floating-banner", title: "FloatingBanner", section: .v3Components, destination: AnyView(FloatingBannerCatalog())),
+    .init(id: "form-group", title: "FormGroup", section: .v3Components, destination: AnyView(FormGroupCatalog())),
+    .init(id: "icon-button", title: "IconButton", section: .v3Components, destination: AnyView(IconButtonCatalog())),
+    .init(id: "modal", title: "Modal", section: .v3Components, destination: AnyView(ModalCatalog())),
+    .init(id: "overlay", title: "Overlay", section: .v3Components, destination: AnyView(OverlayCatalog())),
+    .init(id: "progress-bar", title: "ProgressBar", section: .v3Components, destination: AnyView(ProgressBarCatalog())),
+    .init(id: "section", title: "Section", section: .v3Components, destination: AnyView(SectionCatalog())),
+    .init(id: "section-item", title: "SectionItem", section: .v3Components, destination: AnyView(SectionItemCatalog())),
+    .init(id: "spinner", title: "Spinner", section: .v3Components, destination: AnyView(SpinnerCatalog())),
+    .init(id: "switch", title: "Switch", section: .v3Components, destination: AnyView(SwitchCatalog())),
+    .init(id: "tag", title: "Tag", section: .v3Components, destination: AnyView(TagCatalog())),
+    .init(id: "text-input", title: "TextInput", section: .v3Components, destination: AnyView(TextInputCatalog())),
+    .init(id: "toast", title: "Toast", section: .v3Components, destination: AnyView(ToastCatalog())),
+  ]
+
+  // MARK: - Legacy Components
+  // 알파벳순 유지 — 신규 항목은 배열 끝이 아니라 제자리에 삽입할 것 (병렬 PR 충돌 방지)
+  private static let legacyComponents: [CatalogItem] = [
+    .init(id: "legacy-button", title: "Legacy Button", section: .legacyComponents, destination: AnyView(LegacyButtonCatalog())),
+  ]
+
+  static let all: [CatalogItem] = v3Foundation + v3Components + legacyComponents
 
   static func items(in section: CatalogSectionKind) -> [CatalogItem] {
     self.all.filter { $0.section == section }

--- a/docs/agent/examples-pitfalls.md
+++ b/docs/agent/examples-pitfalls.md
@@ -1,0 +1,77 @@
+# Examples 카탈로그 함정
+
+`Examples/BezierExamples/BezierExamples/Components/{Name}Catalog.swift`를 작성할 때만 읽으면
+된다. 등록 절차와 화면 구조는 [`CONTRIBUTING.md`](../../CONTRIBUTING.md), 공통 규칙은
+[`CLAUDE.md`](../../CLAUDE.md)에 있다.
+
+## UIKit 브리지
+
+### `UIControl.isEnabled`는 직접 설정해도 되돌려진다
+
+SwiftUI는 `UIViewRepresentable` 안의 `UIControl.isEnabled`를 environment `\.isEnabled`로
+**강제 동기화**한다. factory/update 클로저에서 `isEnabled = false`를 넣어도 즉시 true로
+돌아온다. 데모의 disabled 제어는 representable 바깥에 `.disabled(...)`를 건다.
+
+```swift
+UIKitWrap({ BezierCheckbox() }, update: { ... })
+  .disabled(!self.isEnabled)
+```
+
+순수 UIKit 소비자는 영향이 없다 — representable 경로만 해당한다.
+
+### 폭이 무너지는 두 반대 케이스
+
+`UIKitWrap`은 `systemLayoutSizeFitting(..., withHorizontalFittingPriority: .fittingSizeLevel)`로
+크기를 낸다. 여기서 컴포넌트의 intrinsic width 유무에 따라 정반대 증상이 나온다.
+
+| 증상 | 원인 | 조치 | 실례 |
+|---|---|---|---|
+| 아예 안 보임(width 0) | intrinsic width 없는 full-width 뷰(`BezierDivider`) | 전용 representable에서 `sizeThatFits`가 `proposal.width`를 반환 | `DividerCatalog.swift` |
+| full-width로 안 늘어남 | content를 hug하는 intrinsic width 보유(`BezierBanner`) | `makeUIView`가 빈 `UIView` wrapper를 반환하고 컴포넌트를 leading·trailing·top·bottom pin | `BannerCatalog.swift` |
+
+`.frame(maxWidth: .infinity)`로는 둘 다 해결되지 않는다 — representable의 렌더 크기는
+`sizeThatFits` 반환값이 지배하고 frame modifier는 UIView의 실제 bounds를 강제하지 못한다.
+wrapper 방식에서 컴포넌트 내부 content가 남는 폭을 채우게 하려면 content의 가로
+`setContentHuggingPriority`를 최저(`UILayoutPriority(1)`)로 둔다 — `.defaultLow`로는 부족하다.
+
+`updateUIView`는 wrapper를 받으므로 `wrapper.subviews.compactMap { $0 as? T }.first`로
+컴포넌트를 찾아 갱신한다.
+
+### 매트릭스에서 바뀌는 `@State`는 `update`에서 재주입한다
+
+`makeUIView`는 1회만 호출된다. factory 클로저에만 값을 넘기면 초기값에 고정되어, SwiftUI
+매트릭스는 반영되는데 UIKit 매트릭스만 안 바뀌는 증상이 나온다.
+
+```swift
+UIKitWrap({ BezierIconButton(...) }, update: { (button: BezierIconButton) in
+  button.semantic = self.semantic     // @State는 반드시 여기서 다시 주입
+})
+```
+
+`ForEach`로 고정되는 축(variant/size)은 factory에 둬도 된다. multi-statement factory와 함께
+쓰면 제네릭 `V`가 `UIView`로 폴백되어 프로퍼티를 못 찾는 컴파일 에러가 나므로, update
+클로저의 파라미터 타입을 위처럼 명시한다.
+
+## 레이아웃
+
+### 화면 폭을 넘는 row는 가로 `ScrollView`로 감싼다
+
+`CatalogScreen`은 세로 `ScrollView`만 제공한다. 폭을 초과하는 row가 하나라도 있으면 VStack
+전체가 좌측으로 밀려 **상단 컨트롤까지 화면 밖으로 나가 탭이 안 된다**.
+
+```swift
+ScrollView(.horizontal, showsIndicators: false) { HStack { ... } }
+```
+
+세로·가로 ScrollView는 방향이 달라 공존한다. size가 많아 세그먼트가 폭을 넘으면
+`LabeledSegmented` 대신 `Picker(.menu)`를 쓴다. 실례: `AvatarGroupCatalog.swift`.
+
+## 빌드
+
+- **`import Combine` 명시 필요** — Examples 타겟은 Xcode 26 기본값
+  `SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES`라 `import SwiftUI`만으로는
+  `ObservableObject`/`@Published`가 보이지 않는다 (`CatalogEnvironment.swift` 참조).
+  라이브러리 본체는 이 설정이 꺼져 있어 영향이 없다
+- **파일 추가에 pbxproj 편집이 필요 없다** — `PBXFileSystemSynchronizedRootGroup`이라
+  디렉토리에 `.swift`를 넣으면 타겟에 자동 포함된다. 반대로 **디렉토리를 통째로 지우면**
+  빈 sync group이 남아 빌드가 엉뚱한 에러로 깨지므로, 삭제 시엔 pbxproj의 타겟도 함께 정리한다

--- a/docs/agent/swiftui-pitfalls.md
+++ b/docs/agent/swiftui-pitfalls.md
@@ -1,0 +1,68 @@
+# SwiftUI 구현 함정
+
+SwiftUI 컴포넌트(`MasterComponent/{Component}/SU{Name}.swift`)를 작성·수정할 때만 읽으면
+된다. 공통 규칙은 [`CLAUDE.md`](../../CLAUDE.md)에 있다.
+
+## `Path.addArc`의 `clockwise`는 UIKit과 정반대다
+
+SwiftUI `Path.addArc(center:radius:startAngle:endAngle:clockwise:)`의 `clockwise`는 수학
+좌표계(y-up) 기준이다. 화면은 y-down이므로 `clockwise: true`를 주면 **화면에서는 반시계**로
+그려진다. UIKit `UIBezierPath.addArc`는 화면 좌표 그대로라 `clockwise: true`가 화면상 시계다.
+
+```swift
+// 화면상 시계 방향 호 (135° → 45°, 270°)
+path.addArc(..., clockwise: false)   // SwiftUI
+path.addArc(..., clockwise: true)    // UIKit — 같은 그림, 반대 인자
+```
+
+두 구현을 나란히 놓고 대조할 것. 실례: `SUBezierSpinner.swift` ↔ `BezierSpinner.swift`.
+
+## 그룹 단위 흐림에는 `.compositingGroup()`을 선행한다
+
+`.opacity()`는 **per-view 곱**이라 겹쳐 놓은 서브뷰가 서로 비쳐 보인다. disabled 흐림처럼
+"합성된 결과 전체에 알파를 먹이는" 처리(UIKit의 root `alpha`, Figma의 그룹 flatten과 동치)를
+하려면 `.compositingGroup()`을 `.opacity()` **앞에** 둔다.
+
+```swift
+content
+  .compositingGroup()
+  .opacity(self.isEnabled ? 1 : BezierSwitchConstant.disabledOpacity)
+```
+
+빼먹으면 예를 들어 Switch의 thumb 아래로 트랙이 비친다. 실례: `SUBezierSwitch.swift`,
+`SUBezierCheckbox.swift`, `SUBezierTextInput.swift`.
+
+## 항상 dark인 컴포넌트는 두 채널을 모두 pin한다
+
+라이트/다크와 무관하게 dark 표면을 유지해야 하는 컴포넌트(Toast 등)는 **둘 다** 필요하다.
+
+```swift
+public var colorScheme: ColorScheme { .dark }   // ① @Environment가 아닌 상수 — Themeable.palette()용
+// body:
+content.environment(\.colorScheme, .dark)       // ② applyBezierFontStyle의 자체 @Environment용
+```
+
+`applyBezierFontStyle(_:semanticColorToken:)` 내부의 `BezierTypographyStyle`이 자기
+`@Environment(\.colorScheme)`로 텍스트 색을 해석하기 때문에, ①만 있으면 배경·아이콘은
+dark인데 **텍스트만 주변 스킴을 따라간다**. `.preferredColorScheme`은 window 레벨이라
+스코프가 틀리다 — 쓰지 말 것. 실례: `SUBezierToast.swift`.
+
+UIKit 대응은 `var colorTheme: BezierColorTheme { .dark }` 상수 + `setUp()`에서
+`overrideUserInterfaceStyle = .dark`.
+
+## `EmptyView`는 modifier 체인 전체를 소거한다
+
+슬롯 컨테이너에서 `content`를 그대로 받아 `.background(...)`·`.padding(...)`을 걸면,
+호출부가 `EmptyView`를 넘겼을 때 **컨테이너 자체가 렌더되지 않는다**. 실체가 있는
+컨테이너로 한 번 감싼다.
+
+```swift
+VStack(alignment: .leading, spacing: 0) { self.content }
+  .padding(...)
+  .background(...)
+```
+
+실례: `SUBezierOverlay.swift`.
+
+슬롯이 비었을 때 **여백만 빼고 싶은** 경우는 반대로 타입으로 분기한다 —
+`if Leading.self != EmptyView.self { ... }` (`SUBezierTextInput.swift`).

--- a/docs/agent/testing.md
+++ b/docs/agent/testing.md
@@ -1,0 +1,73 @@
+# 테스트·시각 검증
+
+테스트를 쓰거나 시뮬레이터로 확인할 때만 읽으면 된다. 빌드 명령의 기본 규칙은
+[`CLAUDE.md`](../../CLAUDE.md)에 있다.
+
+## 실행
+
+```bash
+xcrun simctl list devices booted          # UDID 확인
+UDID=<booted-udid>
+
+xcodebuild -scheme BezierSwift -destination "platform=iOS Simulator,id=$UDID" test
+```
+
+`swift test`는 UIKit 의존성 때문에 동작하지 않는다. 테스트 타겟은 `BezierSwiftTests` 하나이고
+소스는 `Tests/BezierSwiftTests/`에 플랫 구조로 둔다.
+
+## 프레임워크
+
+신규 테스트는 **Swift Testing**(`import Testing`)으로 쓴다. 저장소에 XCTest 파일이 2개
+남아 있으나(`ColorUtils*Tests.swift`) 신규 작성 기준은 아니다.
+
+## UIKit 레이아웃 테스트는 `UIWindow`가 필요하다
+
+window 없는 detached 뷰는 제약이 required여도 `frame.width`가 0으로 나오는 아티팩트가 있다.
+반드시 `UIWindow`에 붙인 뒤 `window.layoutIfNeeded()`를 호출해야 실제 압축·크기가 측정된다.
+
+```swift
+let container = UIView(frame: CGRect(x: 0, y: 0, width: containerWidth, height: 40))
+let window = UIWindow(frame: container.bounds)
+window.addSubview(container)
+container.addSubview(stack)
+// 제약 활성화 후
+window.setNeedsLayout()
+window.layoutIfNeeded()
+```
+
+`container.layoutIfNeeded()`만으로는 부족하다. MOB-6018에서 이 차이 때문에 수정 전후 모두
+`frame.width == 0`으로 나와 오판할 뻔했다. 전문은 `BezierBadgeLayoutTests.swift` 참조.
+
+## UIKit을 다루는 Suite는 `@MainActor` + `.serialized`
+
+Swift Testing은 기본 병렬 실행이라 UIView를 백그라운드 스레드에서 만들어 크래시한다
+("Main Thread Checker: UI API called on a background thread").
+
+```swift
+@Suite("BezierBadge Layout - Compression Resistance", .serialized)
+@MainActor
+struct BezierBadgeLayoutTests { ... }
+```
+
+순수 값·Spec 해석 Suite에는 붙이지 않는다 — 저장소도 UIKit 뷰를 인스턴스화하는 Suite에만
+붙이고 있다.
+
+## 시뮬레이터 시각 검증
+
+macOS 화면 캡처·접근성 도구는 쓰지 않는다. 시뮬레이터 자체 기능(`simctl`)과 `idb`가 정확하다.
+
+```bash
+xcrun simctl io $UDID screenshot out.png
+xcrun simctl io $UDID recordVideo --codec h264 out.mp4   # 백그라운드 실행 후 kill -INT로 finalize
+xcrun simctl ui $UDID appearance dark                    # light | dark
+idb ui tap --udid $UDID <x> <y>
+idb ui describe-all --udid $UDID
+```
+
+- **탭 좌표는 pt** = 스크린샷 pixel ÷ scale (iPhone 17 = 402×874, 3x). pixel 좌표를 그대로
+  넣으면 화면 밖이라 무시된다
+- **SwiftUI `Toggle`·세그먼트는 기본 tap을 무시한다** — `idb ui tap ... --duration 0.05` 필요.
+  `NavigationLink` 행은 기본 tap으로 동작
+- 라이트/다크 정합, always-dark 컴포넌트의 이중 pin은 코드만으로 검증되지 않는다. 두 모드를
+  각각 캡처해 비교할 것
+- 애니메이션은 `ffmpeg -ss {t} -frames:v 1`로 프레임을 뽑아 위상을 비교한다

--- a/docs/agent/uikit-pitfalls.md
+++ b/docs/agent/uikit-pitfalls.md
@@ -1,0 +1,70 @@
+# UIKit 구현 함정
+
+UIKit 컴포넌트(`MasterComponent/{Component}/{Name}.swift`)를 작성·수정할 때만 읽으면 된다.
+공통 규칙은 [`CLAUDE.md`](../../CLAUDE.md)에 있다.
+
+## 다크모드 토큰 재주입
+
+Semantic 토큰을 해석한 색은 **정적으로 굳는 경로**와 **시스템이 자동 재해석하는 경로**가
+갈린다. 굳는 경로만 `traitCollectionDidChange(_:)`에서 다시 주입하면 된다.
+
+| 경로 | trait 변경 시 | 조치 |
+|---|---|---|
+| `UIView.backgroundColor`·`tintColor`에 dynamic `UIColor`(`token.palette(self)`) 직접 대입 | 자동 재해석 | 불요 |
+| `CALayer.backgroundColor`·`borderColor`·`shadowColor`·`fillColor` (`CGColor`) | 대입 시점에 1회 해석 후 고정 | **재주입 필요** |
+| 서브컴포넌트의 override 프로퍼티에 해석된 색을 주입 (예: `spinner.fillColorOverride`) | 부모가 해석했으므로 고정 | **재주입 필요** |
+
+```swift
+override func traitCollectionDidChange(_ previous: UITraitCollection?) {
+  super.traitCollectionDidChange(previous)
+  self.refreshAppearance()   // 색 재계산·재주입을 한 곳에 모아둔다
+}
+```
+
+- 저장소 내 28개 파일이 이 패턴을 구현 중이다. `BezierButton.swift`가 대표 예시
+- SwiftUI는 `@Environment(\.colorScheme)`가 자동 전파되므로 이 루프가 없다 — 두 구현의
+  패리티를 볼 때 이 비대칭을 먼저 의심할 것
+- `componentTheme`(normal/inverted)은 trait이 아니라 자동 재해석 대상이 아니다. 변경 시 직접 재적용
+- 색이 상수인 컴포넌트(항상 dark 등)는 재주입이 불필요하다(무해하긴 함)
+
+## CALayer border는 sublayer보다 위에 그려진다
+
+`CALayer` 렌더 순서는 `backgroundColor → contents → sublayers → border`다. 즉
+`view.layer.borderWidth/borderColor`로 그린 테두리는 그 뷰의 **모든 자식보다 항상 위**다.
+자식의 `layer.zPosition`을 올려도 형제 sublayer 간 순서만 바뀔 뿐 부모의 border는 못 이긴다.
+
+border 위로 올라와야 하는 자식(badge·status indicator·overlay)이 있으면 `layer.border` 대신
+**별도 `borderView: UIView`** 를 만든다.
+
+- 서브뷰 순서를 `contentView → borderView → overlayView`로 둔다
+- `borderView`는 부모와 동일 크기로 pin하고 `isUserInteractionEnabled = false`
+- 실례: `BezierAvatar.swift`의 `borderView` (showBorder + status 동시 사용 시 회귀로 발견)
+
+## UICollectionView registration은 `init`에서 만든다
+
+`CellRegistration`/`SupplementaryRegistration`이 dequeue 콜백 실행 중에 생성되면
+`NSInternalInconsistencyException`이 난다. `lazy var`로 두면 첫 dequeue 시점에 초기화되므로
+정확히 이 조건에 걸린다 (MOB-6455 `SectionCatalog` 헤더에서 실제 크래시).
+
+- `[weak self]` 캡처가 필요해 stored `let` 기본값으로 못 만들면 implicitly unwrapped `var` +
+  `init()`에서 생성
+- 캡처가 없으면 stored `let` 기본값으로 두어도 안전
+- 크래시 스택이 `dequeueConfiguredReusableSupplementaryViewWithRegistration:`에서 터져
+  원인 파악이 어렵다 — 이 증상이 보이면 registration 생성 시점부터 확인할 것
+
+## press 피드백은 `BezierPressFeedback`을 재사용한다
+
+`Sources/BezierSwift/Util/BezierPressFeedback.swift` (internal)에 UIKit·SwiftUI 양쪽 헬퍼가 있다.
+새로 만들지 말 것.
+
+```swift
+BezierPressFeedback.apply(isPressed: true, to: self)   // UIKit
+BezierPressFeedback.reset(self)
+```
+
+사용 예시는 `BezierSectionItem.swift`. public 승격과 `BezierBaseItem` 마이그레이션은 MOB-6471에서 다룬다.
+
+## 레이아웃 테스트
+
+UIKit 뷰의 압축·크기 거동은 `UIWindow`에 붙여야 측정이 유효하다. 상세는
+[`testing.md`](testing.md) 참조.

--- a/docs/spec-template.md
+++ b/docs/spec-template.md
@@ -1,0 +1,142 @@
+# SPEC.md 작성 템플릿
+
+컴포넌트 디렉토리의 `SPEC.md`는 **Figma SSOT의 거울**이다. Figma에 직접 매핑되는 정보만
+담고, 디자인 일반론·추측·다른 컴포넌트와의 횡적 비교는 넣지 않는다. 구현 결정은 §9에
+분리해 적는다.
+
+단위는 `pt`. SPEC.md가 필요 없는 대상(internal 공유 레이어·V1 잔존)은
+[`CLAUDE.md`](../CLAUDE.md)의 "SPEC.md 불요 대상" 참조.
+
+---
+
+````markdown
+# {ComponentName} SPEC
+
+> **SSOT**: [Figma · Mobile-Components / {Component} ({node-id})]({Figma URL}) — component key `{key}`
+> **Design spec doc**: [team-design / bezier-v3 / components / {Component}-spec.md](https://github.com/channel-io/team-design/blob/main/bezier-v3/components/{Component}-spec.md) (보조 참조 — 값 충돌 시 Figma 파일 우선)
+
+{한 줄 컴포넌트 설명. Figma component description의 1행을 그대로 가져오기 권장.}
+
+## 1. Component Properties
+
+Figma 컴포넌트가 정의하는 property와 옵션은 다음이 전부다.
+
+| Property | 값 | 비고 |
+|---|---|---|
+| **size** | `xxx` / `yyy` | {역할} |
+| **variant** | `aaa` / `bbb` | {역할} |
+| **state** | `default` / `pressed` / `disabled` / `loading` | {역할} |
+
+총 instance: `... × ... = N개` (Figma 노출 인스턴스 수와 일치 확인)
+
+> Figma에 단일값으로만 존재하는 property는 단일값으로 적는다. "primary는 코드 지원분" 같은
+> 회피 표현 금지. COMPONENT_SET이 아니라 단일 COMPONENT면 "variant 축 없음"으로 명시한다.
+
+## 2. Layout Spec
+
+| Size | Height | Padding | Icon | Spacing |
+|---|---|---|---|---|
+| xxx | N | N | N | N |
+
+- {계산 공식, 예: `iconLength = height - padding × 2`}
+- {cornerRadius 형태 — 고정값 / 높이의 절반 등}
+- {min-width·hug/fill 동작}
+
+## 3. 컬러 토큰
+
+### Background
+
+| Variant | Token | Figma Variable | Raw |
+|---|---|---|---|
+| `aaa` | `tokenName` | `color/...` | `#......` |
+| `bbb` | — *(transparent)* | — | — |
+
+### Foreground
+
+| Variant | Token | Figma Variable | Raw |
+|---|---|---|---|
+
+> Figma 변수에 정의돼 있지만 이 컴포넌트가 쓰지 않는 변수는 적지 않는다(노이즈).
+> 컬러 레이어가 전혀 없으면 "없음 — 순수 레이아웃 컨테이너" 한 줄로 처리한다.
+
+## 4. Typography
+
+텍스트가 없으면 "이 컴포넌트에 텍스트 없음" 한 줄로 처리하고 표는 생략한다.
+
+### Case A — Typography Token 사용
+
+| 위치 | Token | Figma Style 이름 |
+|---|---|---|
+
+### Case B — Custom Typography (토큰 미적용)
+
+5요소를 모두 적는다. iOS는 `letter-spacing`에 `NSAttributedString.Key.kern`이 필요하다.
+
+| 위치 | Font | Size | Weight | Line Height | Letter Spacing | Custom 사유 |
+|---|---|---|---|---|---|---|
+
+> Custom typography는 디자이너의 *의도된 결정*이어야 한다. Figma에 사유가 없으면 디자이너 확인 필요.
+
+## 5. State 별 시각 동작
+
+| State | Variant A | Variant B | 인터랙션 |
+|---|---|---|---|
+| `default` | 기본 | 기본 | 활성 |
+| `pressed` | ... | ... | 활성 |
+| `disabled` | opacity X | opacity X | 비활성 |
+| `loading` | ... | ... | 비활성 (입력 차단) |
+
+state 축이 없으면 "Figma에 state variant 축 없음"으로 명시한다.
+
+## 6. {선택 섹션}
+
+컴포넌트에 해당할 때만 둔다 — `Loading Indicator` / `Elevation` / `Close Icon` /
+`회전 애니메이션` / `Status Overlay 배치` / `인터랙션` 등.
+
+## 7. 디자이너 가이드라인 (Figma component description 인용)
+
+Figma description에 적힌 디자이너 의도를 그대로 옮긴다. 일반론을 임의로 추가하지 않는다.
+
+- {bullet}
+
+## 8. 매핑되는 코드 심볼
+
+| 정의 | 파일 |
+|---|---|
+| UIKit 구현 | `{Name}.swift` |
+| SwiftUI 구현 | `SU{Name}.swift` |
+| size / variant 정의 | `{Name}Spec.swift` |
+
+> 심볼은 실재해야 한다 — prefix를 추측해서 적지 말고 코드 트리를 grep해 확인한 뒤 옮긴다.
+> 코드에 SSOT와 어긋나는 정의가 있으면 그건 코드의 정리 대상이지 SPEC에 반영할 근거가 아니다.
+
+## 9. Figma 외 · 협의 사항
+
+Figma에 없는 구현 아키텍처 결정을 여기에 분리 표기한다. SSOT 값이 아니다.
+
+1. **{결정 이름}**: {내용과 근거. team-design spec의 해당 절을 인용할 것}
+
+## 10. Variant 매트릭스
+
+총 instance: ... × ... = **N개**
+
+```text
+{Property combination} = {Node ID}
+... (전체 또는 패턴 + 일부 샘플)
+```
+````
+
+---
+
+## 자주 빠지는 함정
+
+| 함정 | 회피책 |
+|---|---|
+| 코드의 enum/상수를 "코드 지원분"으로 SPEC에 포함 | Figma에 없으면 적지 마라. SPEC은 Figma의 거울이지 코드의 거울이 아니다 |
+| 미사용 Figma Variable을 "참고로" 기재 | SSOT 영역 밖. 노이즈다 |
+| 심볼명을 추측해서 표기 | grep으로 실재 확인 후 기재 |
+| pressed/active 거동을 한 줄로 뭉뚱그림 | variant마다 다를 수 있다. 분기를 명시 |
+| "보통 ~한다", "~이기 때문이다" 같은 추측·일반론 | 사실만 적는다 |
+| 다른 컴포넌트 상수와의 "일관성" 메모 | 다른 컴포넌트는 별개 SSOT. 횡적 참조 금지 |
+| 단일값 property를 다중값처럼 기재 | Figma에 `semantic = secondary`만 있으면 SPEC도 단일값 |
+| 아이콘 색을 `get_variable_defs` 결과로 판단 | 그건 아이콘 라이브러리가 참조하는 변수 전부다. 실제 렌더색은 export SVG의 `fill`/`fill-opacity`로 확정 |


### PR DESCRIPTION
## 배경

2026-07-27~28 V3 컴포넌트 13종을 에이전트 132개로 병렬 구현한 세션을 전수 집계한 결과, **컴포넌트 작업 에이전트들이 프로젝트 관례를 배우려고 같은 파일을 각자 반복해서 읽는 데 674,860 토큰**을 소비한 것이 확인됐다. 원인은 저장소에 `CLAUDE.md`가 없어 관례가 코드에만 존재했고, 관례 지식 30여 건이 작업자 1인의 개인 메모리에만 있었기 때문이다.

`CatalogRegistry.swift`는 175줄 단일 배열 구조 때문에 컴포넌트 PR마다 100% 충돌해 직전 세션에서만 4번(#154 / #155 / #161 / #162) 수동 해소했다.

MOB-6528의 R1~R3에 해당한다. R4(Banner·FloatingBanner SPEC 작성)·R5(스캐폴드 스크립트)는 별도로 다룬다.

## 변경

### 1. `CLAUDE.md` 신설 + `docs/agent/` 4종

모든 세션에 자동 로드되는 `CLAUDE.md`에는 **항상 필요하고 분량이 작은 것만** 담고(약 2,000 토큰), 상세 함정은 해당 작업 시에만 읽도록 분리했다.

| 파일 | 내용 |
| --- | --- |
| `CLAUDE.md` | 명명 규칙 · 토큰 규칙 · API 표면 규칙 · SSOT · 주석 정책 · 빌드/테스트 · PR |
| `docs/agent/uikit-pitfalls.md` | 다크모드 토큰 재주입 · CALayer border z-order · UICollectionView registration · BezierPressFeedback |
| `docs/agent/swiftui-pitfalls.md` | `Path.addArc` clockwise 반전 · `.compositingGroup()` · always-dark 이중 pin · `EmptyView` 소거 |
| `docs/agent/examples-pitfalls.md` | `UIControl.isEnabled` 강제 동기화 · representable 폭 붕괴 2종 · `@State` 재주입 · `import Combine` |
| `docs/agent/testing.md` | 실행 명령 · `UIWindow` 요구사항 · Swift Testing 설정 · 시뮬레이터 시각 검증 |

`CONTRIBUTING.md`(사람 대상 기여 절차)와 역할을 나누고 중복 서술 없이 상호 참조만 뒀다.

**문서화하며 정정한 사실 3건**

- `BTGlobalToken`은 internal이지만 **`BCGlobalToken`은 public** → 규칙을 "Global 토큰은 internal"이 아니라 "**Semantic 토큰만 사용·노출**"로 서술. 실제로 `MasterComponent/`에서 `BCGlobalToken` 직접 사용은 0파일
- `BezierDialog`·`LegacyBezierButton`·`LegacyBezierToast`는 파일명이 `Bezier*`지만 **UIKit이 아니라 SwiftUI `View`**(V1 시절 네이밍) → 명명 규칙의 예외로 명시
- **SPEC.md 불요 대상**(`BezierBaseInput` = internal 공유 레이어 / `BezierDialog`·`LegacyBezier*` = V1 잔존)을 명시해 다음 작업자가 누락으로 오해하지 않게 함

### 2. `CatalogRegistry` 충돌 구조 해소

단일 `all` 배열(항목당 6줄)을 섹션별 private 배열 3개로 분리하고, 각 배열 내부를 `title` 알파벳순 **1줄 항목**으로 변환했다. `all`은 세 배열의 합이고 `items(in:)` 시그니처·동작은 그대로다.

```swift
private static let v3Components: [CatalogItem] = [
  .init(id: "avatar", title: "Avatar", section: .v3Components, destination: AnyView(AvatarCatalog())),
  .init(id: "avatar-group", title: "AvatarGroup", section: .v3Components, destination: AnyView(AvatarGroupCatalog())),
  ...
]
static let all: [CatalogItem] = v3Foundation + v3Components + legacyComponents
```

알파벳 위치가 다른 컴포넌트끼리는 git이 자동 병합하므로 충돌이 100%에서 인접 항목에 한정된다. **완전 제거가 아니라 충돌 면적 축소다** — Swift에는 런타임 트릭 없이 관용적인 자동 등록 수단이 없어 중앙 목록 자체는 남는다.

**사이드바 표시 순서가 추가순에서 알파벳순으로 바뀐다** (의도된 변경).

### 3. `docs/spec-template.md` 이전

`~/.claude/skills/figma-component-spec/spec-template.md`에만 있던 개인 자산을 저장소로 옮겼다. 스킬 미설치자도 SPEC.md 형식을 알 수 있다. 이전하며 플랫폼 중립 표현을 iOS 기준(`pt`, `{Name}.swift` / `SU{Name}.swift` / `{Name}Spec.swift`)으로 고정하고, 현행 SPEC 22개가 공통으로 쓰는 `## Figma 외 · 협의 사항` 섹션을 템플릿에 반영했다.

## 검증

- **Examples clean build** — `BUILD SUCCEEDED`, error 0 (원본 출력 grep)
- **`BezierExamplesTests`** — `catalogItemIdsAreUnique` / `catalogRegistryHasItemsInAllSections` 통과
- **레지스트리 전수 대조** — 29개 항목의 `(id, title, section, destination)` 조합이 리팩터 전후 동일함을 스크립트로 확인. 세 섹션 모두 알파벳순 정렬 확인
- **시뮬레이터** — 사이드바가 알파벳순으로 렌더되는 것 확인 (iPhone 17 / iOS 26.4)
- **문서 정합성** — 문서의 모든 상대 링크가 실재하고, 인용한 심볼(`BezierPressFeedback`, `BCSemanticToken`, `UIKitWrap` 등)과 파일 경로가 모두 실재함을 grep으로 대조
- `Sources/`·`Tests/`·`Package.swift` 무변경이라 라이브러리 빌드는 불요

효과 측정(새 세션에서 컴포넌트 1종을 작업시켜 `BezierSection*`·`BezierBaseItem*`을 관례 학습 목적으로 읽는지 확인)은 머지 후 별도로 수행한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 저장소 개발 규칙, 명명·토큰·API 작성 기준을 문서화했습니다.
  * 컴포넌트 카탈로그 등록 절차와 섹션별 구성 방식을 업데이트했습니다.
  * SwiftUI·UIKit·Examples 구현 시 주의사항과 테스트·시각 검증 절차를 추가했습니다.
  * 컴포넌트 사양서 작성용 표준 템플릿을 제공했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->