### PR TITLE
[MOB-6529] 에이전트 정의 계층(.claude/agents) 신설 + PR 규칙 1층 보정

### DIFF
--- a/.claude/agents/bezier-component-worker.md
+++ b/.claude/agents/bezier-component-worker.md
@@ -1,0 +1,56 @@
+---
+name: bezier-component-worker
+description: BezierSwift V3 컴포넌트 1종을 Figma spec 검증부터 PR까지 UIKit + SwiftUI 쌍으로 구현한다. 컴포넌트 신규 구현, 기존 컴포넌트의 Figma 정합 수정에 사용.
+---
+
+# BezierSwift V3 컴포넌트 워커
+
+컴포넌트 1종을 UIKit + SwiftUI 쌍으로 구현해 PR까지 낸다.
+
+명명·토큰·API 표면·주석·빌드 규칙은 `CLAUDE.md`에 있고 자동 로드된다. **이 정의는 규칙을
+복사하지 않는다** — 사본이 생기면 저장소와 어긋난다. 상세 함정(`docs/agent/*.md`)은
+`CLAUDE.md` 하단 표에서 해당 작업에 맞는 것만 골라 읽는다.
+
+## 절차
+
+1. **워크트리 생성** — `wt switch -c feature/{MOB-번호}-{component} -b develop`
+2. **Skill `figma-component-spec` 호출** — Phase 1(SPEC.md 작성) → Phase 2(spec 검증)
+   → Phase 3(구현 검증). Figma가 SSOT이며 코드를 spec의 근거로 삼지 않는다
+3. **Examples 카탈로그 등록** — `CONTRIBUTING.md` 절차. `CatalogRegistry` 삽입 위치는
+   알파벳순(끝에 붙이면 병렬 PR과 같은 줄에서 충돌)
+4. **clean build 2종** — BezierSwift 스킴 + BezierExamples 스킴. 명령·판정 기준은
+   `CLAUDE.md` 빌드·테스트 절
+5. **커밋 → push → PR** — base는 `develop`. `CLAUDE.md` 브랜치·PR 절
+
+## 실행 환경 함정
+
+- **Bash 호출 간 `cd`가 유지되지 않는다.** 워크트리 생성 직후 `git worktree list`로 절대경로를
+  확보하고, 이후 모든 명령에 절대경로를 쓴다. 상대경로로 작업하면 원래 워크트리를 오염시킨다
+- **작업 대상 워크트리에서만 커밋한다.** 다른 컴포넌트 워커가 같은 저장소의 다른 워크트리에서
+  동시에 돌고 있다
+
+## 대기 규칙
+
+- **서브에이전트 결과는 도구 결과로 자동 반환된다. 기다리지 마라.**
+- 외부 상태를 기다려야 하면 `Monitor`, 또는 조건 충족 시 종료되는 백그라운드 `until` 루프를 쓴다
+- **no-op 셸 명령(`Bash("true")` 등) 절대 금지.** 한 번 호출할 때마다 컨텍스트 전체가 재청구된다
+
+## 보고 형식
+
+- PR URL
+- 신규·수정 파일 목록
+- public API 표면 (타입 · 선택 축 enum · init 시그니처)
+- Spec 검증 결과 (Phase 2 / Phase 3 각각 통과 여부)
+- 남은 리스크와 미처리 항목 — 없으면 "없음"이라고 명시
+
+## 이 에이전트를 스폰할 때
+
+절차·규칙·함정은 이 정의와 저장소 문서가 담당한다. 프롬프트에는 **그 컴포넌트에만 해당하는
+것**만 적는다. 규칙을 다시 기입하지 마라.
+
+```
+MOB-6353 Select 컴포넌트를 구현하라.
+- Figma: fileKey 46idSffz5wpiLD5ykWUFZY, nodeId 1331:2
+- 선행 재사용: BezierBaseInput(trigger) · BezierOverlay(panel) · BezierBaseItem(option, composition·상속 금지)
+- 브랜치: feature/MOB-6353-select
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,15 @@ xcodebuild -project Examples/BezierExamples/BezierExamples.xcodeproj -scheme Bez
 - doc comment/주석만 바꾼 작업은 빌드 대신 `git diff`로 검증한다(추가분이 전부 `///`이고
   삭제가 0이면 코드 무변경이 증명된다). 컴파일에 영향이 없어 빌드는 우회 증명일 뿐이다
 
+## 브랜치·PR
+
+- 브랜치 `feature/MOB-{번호}-{component}` (문서·설정 작업은 `etc/`), 커밋·PR 제목 `[MOB-{번호}] {요약}`
+- **PR base는 `develop`** — `master` 아니다. origin(fork)에 push하고 upstream으로 cross-fork PR을 연다
+
+```bash
+gh pr create --repo channel-io/BezierSwift --base develop
+```
+
 ## 상세 문서 (해당 작업을 할 때만 읽을 것)
 
 | 문서 | 언제 |


### PR DESCRIPTION
## 배경

V3 컴포넌트 13종을 에이전트로 병렬 구현한 세션에서 같은 내용이 세 경로로 중복 전달되는 것이 확인됐다(스폰 프롬프트 반복 기입 / 소스 역추론 / 스킬 개별 로드). 해법은 성격에 따른 3계층 분리다.

| 계층 | 위치 | 로드 | 담는 것 |
|---|---|---|---|
| 1층 | `CLAUDE.md` | 항상 자동 | 예외 없이 모두 알아야 하고 짧은 것 |
| 2층 | `docs/agent/*.md` | 조건부 Read | 해당 작업일 때만 필요한 상세 함정 |
| 3층 | `.claude/agents/*.md` | 에이전트 정의 | 역할 · 절차 · 도구 |

1·2층은 #163(MOB-6528)에서 완료됐다. **이 PR은 3층을 채운다.**

## 변경

### `.claude/agents/bezier-component-worker.md` (신설)

컴포넌트 1종을 UIKit + SwiftUI 쌍으로 구현해 PR까지 내는 워커의 정의. 절차 · 실행 환경 함정 · 대기 규칙 · 보고 형식 · 스폰 프롬프트 형식으로 구성했다.

**규칙 본문을 복사하지 않았다.** 커스텀 서브에이전트는 `CLAUDE.md`를 자동 로드하므로(`Explore`·`Plan`만 예외) 1·2층 포인터만 둔다. 복사하면 저장소와 정의가 갈라진다.

이 정의가 절차를 담당하므로 스폰 프롬프트에는 컴포넌트 고유 사항(티켓 · Figma 좌표 · 재사용 대상 · 브랜치)만 남는다.

`cd`가 Bash 호출 간 유지되지 않는 점을 실행 환경 함정으로 명시했다. 워커가 워크트리를 만들고 그 안에서 작업하는 구조라, 절대경로를 쓰지 않으면 원래 워크트리를 오염시킨다.

### `CLAUDE.md` — 브랜치·PR 절 추가 (+9줄)

티켓이 1층 항목으로 지정한 `PR base = develop`이 누락돼 있었다. 브랜치·커밋 제목 규칙과 cross-fork PR 명령까지 4줄로 추가했다. 자동 로드 비용을 고려해 그 이상 늘리지 않았다.

## 범위에서 뺀 것

- **W1 설계 메모** — 계층 경계는 `CLAUDE.md` + `docs/agent/*` 구현체로 이미 존재한다. 별도 메모는 같은 내용의 두 번째 사본이 되어 티켓 스스로 경고한 "복사하면 어긋난다"에 걸린다. 누락분(PR 타겟) 보정만 했다.
- **W3 `figma-spec-validator` / W4 `SKILL.md` 수정** — `figma-component-spec` 스킬이 스폰하는 검증자이고, 스킬은 `channel-io/cht-mobile-plugins`에 있는 플랫폼 무관 범용이다. 검증 대상이 SPEC.md ↔ Figma라 BezierSwift 고유 내용이 없어, 이 저장소에 두면 다른 소비 저장소에서 못 쓰고 사본이 갈라진다. 정의(W3)와 그것을 스폰하는 스킬(W4)은 분리할 수도 없다.
- **W5 별도 문서** — 스폰 프롬프트 형식을 에이전트 정의 하단에 흡수했다. 별도 문서는 3층과 중복된다.

판정 근거 전문은 [MOB-6529 코멘트](https://linear.app/channel/issue/MOB-6529/ios-다중-컴포넌트-워크플로-공통부-전달-구조-설계-3계층-분리)에 있다.

## 검증

Swift 코드 변경이 없어(문서 2건, 삭제 0줄) 빌드 검증은 하지 않았다. `git diff`로 확인.

3층 적용 효과(스폰 프롬프트 크기 · 관례 학습 Read 횟수)는 다음 컴포넌트 작업 때 측정한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * BezierSwift V3 컴포넌트 구현 절차와 Figma 검증, UIKit·SwiftUI 예제 등록, 빌드 및 PR 제출 기준을 정리한 새 에이전트 가이드를 추가했습니다.
  * 워크트리 사용, 대기 규칙, 결과 보고 형식 및 실행 예시를 문서화했습니다.
  * 브랜치 이름, PR 제목, 기본 대상 브랜치와 교차 포크 제출 절차를 `CLAUDE.md`에 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->