### PR TITLE
[MOB-6347] BezierSearch 컴포넌트 구현 (UIKit + SwiftUI)

### DIFF
--- a/Examples/BezierExamples/BezierExamples/App/CatalogRegistry.swift
+++ b/Examples/BezierExamples/BezierExamples/App/CatalogRegistry.swift
@@ -32,6 +32,7 @@ enum CatalogRegistry {
     .init(id: "modal", title: "Modal", section: .v3Components, destination: AnyView(ModalCatalog())),
     .init(id: "overlay", title: "Overlay", section: .v3Components, destination: AnyView(OverlayCatalog())),
     .init(id: "progress-bar", title: "ProgressBar", section: .v3Components, destination: AnyView(ProgressBarCatalog())),
+    .init(id: "search", title: "Search", section: .v3Components, destination: AnyView(SearchCatalog())),
     .init(id: "section", title: "Section", section: .v3Components, destination: AnyView(SectionCatalog())),
     .init(id: "section-item", title: "SectionItem", section: .v3Components, destination: AnyView(SectionItemCatalog())),
     .init(id: "spinner", title: "Spinner", section: .v3Components, destination: AnyView(SpinnerCatalog())),

--- a/Examples/BezierExamples/BezierExamples/Components/SearchCatalog.swift
+++ b/Examples/BezierExamples/BezierExamples/Components/SearchCatalog.swift
@@ -1,0 +1,122 @@
+import SwiftUI
+import UIKit
+import BezierSwift
+
+struct SearchCatalog: View {
+  @State private var isEnabled = true
+  @State private var allowClear = true
+  @State private var showsCancelButton = false
+  @State private var swiftUIText = ""
+  @State private var uiKitText = ""
+  @State private var lastEvent = "-"
+
+  var body: some View {
+    CatalogScreen(title: "Search") {
+      self.controls
+      CatalogSection(.swiftUI) { self.swiftUIPreview }
+      CatalogSection(.uiKit) { self.uiKitPreview }
+    }
+  }
+
+  private var controls: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Toggle("isEnabled", isOn: self.$isEnabled)
+      Toggle("allowClear", isOn: self.$allowClear)
+      Toggle("showsCancelButton", isOn: self.$showsCancelButton)
+
+      Button("키보드 내리기") {
+        UIApplication.shared.sendAction(
+          #selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil
+        )
+      }
+
+      Text("last event: \(self.lastEvent)")
+        .font(.caption2)
+        .foregroundColor(.secondary)
+    }
+    .font(.caption)
+  }
+
+  private var swiftUIPreview: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      SUBezierSearch(
+        text: self.$swiftUIText,
+        placeholder: "Search by name, email, phone",
+        allowClear: self.allowClear,
+        showsCancelButton: self.showsCancelButton,
+        cancelButtonTitle: "Cancel",
+        onCancel: { self.lastEvent = "SwiftUI onCancel" }
+      )
+      .onSubmit { self.lastEvent = "SwiftUI onSubmit: \(self.swiftUIText)" }
+      .disabled(!self.isEnabled)
+
+      Text("value: \(self.swiftUIText)")
+        .font(.caption2)
+        .foregroundColor(.secondary)
+    }
+  }
+
+  private var uiKitPreview: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      SearchUIKitRepresentable(
+        text: self.$uiKitText,
+        isEnabled: self.isEnabled,
+        allowClear: self.allowClear,
+        showsCancelButton: self.showsCancelButton,
+        onEvent: { self.lastEvent = $0 }
+      )
+
+      Text("value: \(self.uiKitText)")
+        .font(.caption2)
+        .foregroundColor(.secondary)
+    }
+  }
+}
+
+private struct SearchUIKitRepresentable: UIViewRepresentable {
+  @Binding var text: String
+  let isEnabled: Bool
+  let allowClear: Bool
+  let showsCancelButton: Bool
+  let onEvent: (String) -> Void
+
+  // BezierSearch를 representable 루트로 직접 반환하면 SwiftUI가 프레임을 직접 지정하는 과정에서
+  // 내부 스택의 trailing 제약이 재해석되지 않아 콘텐츠가 hug 폭으로 붙는다. wrapper에 pin해 우회한다.
+  func makeUIView(context: Context) -> UIView {
+    let wrapper = UIView()
+    let search = BezierSearch(placeholder: "Search by name, email, phone")
+    search.onTextChanged = { self.text = $0 }
+    search.onSubmit = { [weak search] in
+      self.onEvent("UIKit onSubmit: \(search?.text ?? "")")
+    }
+    search.onCancel = { self.onEvent("UIKit onCancel") }
+    wrapper.addSubview(search)
+    NSLayoutConstraint.activate([
+      search.leadingAnchor.constraint(equalTo: wrapper.leadingAnchor),
+      search.trailingAnchor.constraint(equalTo: wrapper.trailingAnchor),
+      search.topAnchor.constraint(equalTo: wrapper.topAnchor),
+      search.bottomAnchor.constraint(equalTo: wrapper.bottomAnchor),
+    ])
+    return wrapper
+  }
+
+  func updateUIView(_ wrapper: UIView, context: Context) {
+    guard let search = wrapper.subviews.compactMap({ $0 as? BezierSearch }).first else { return }
+    search.isEnabled = self.isEnabled
+    search.allowClear = self.allowClear
+    search.showsCancelButton = self.showsCancelButton
+    if search.text != self.text {
+      search.text = self.text
+    }
+  }
+
+  func sizeThatFits(_ proposal: ProposedViewSize, uiView: UIView, context: Context) -> CGSize? {
+    let width = proposal.width ?? 320
+    let fitting = uiView.systemLayoutSizeFitting(
+      CGSize(width: width, height: UIView.layoutFittingCompressedSize.height),
+      withHorizontalFittingPriority: .required,
+      verticalFittingPriority: .fittingSizeLevel
+    )
+    return CGSize(width: width, height: fitting.height)
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierSearch/BezierSearch.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierSearch/BezierSearch.swift
@@ -1,0 +1,405 @@
+//
+//  BezierSearch.swift
+//  BezierSwift
+//
+
+import UIKit
+
+/// SearchIcon이 고정된 단일 행 검색 입력 필드 (UIKit). 리스트 필터링·데이터 탐색처럼 키워드를 입력해 검색을 실행할 때 쓴다. 이름·이메일 등 일반 폼 입력에는 `BezierTextInput`을 사용한다. SwiftUI에서는 `SUBezierSearch`를 사용한다.
+///
+/// 너비는 컨테이너가 결정한다 — leading/trailing 제약으로 부모 폭을 채우는 배치가 기본이다. 높이는 40pt로 고정된다 (Figma `Search`는 size 축 없음).
+/// placeholder는 검색 범위를 명시한다 (예: `고객 이름, 이메일, 전화번호로 검색`) — `검색` 한 단어만 쓰지 않는다.
+public final class BezierSearch: UIView, BezierComponentable {
+  // MARK: - BezierComponentable
+
+  public var colorTheme: BezierColorTheme { .systemBezierColorTheme() }
+  public var componentTheme: BezierComponentTheme = .normal {
+    didSet { self.refreshAppearance() }
+  }
+
+  // MARK: - Public Properties
+
+  /// 현재 입력값. 코드로 값을 바꿔도 `onTextChanged`는 호출되지 않는다.
+  public var text: String {
+    get { self.textField.text ?? "" }
+    set {
+      guard self.textField.text != newValue else { return }
+      self.textField.text = newValue
+      self.refreshClearButton()
+    }
+  }
+
+  /// 입력 전 안내 텍스트. 검색 범위를 명시한다 (예: `고객 이름, 이메일, 전화번호로 검색`). 기본값은 빈 문자열.
+  public var placeholder: String = "" {
+    didSet { if oldValue != self.placeholder { self.refreshPlaceholder() } }
+  }
+
+  /// 활성화 여부. 끄면 모든 인터랙션이 차단되고 40% 투명도가 적용된다. 기본값 `true`.
+  public var isEnabled: Bool = true {
+    didSet { if oldValue != self.isEnabled { self.refreshEnabled() } }
+  }
+
+  /// 값이 있을 때 값을 한 번에 지우는 clear 버튼을 표시할지 여부. 포커스와 무관하게 값이 있으면 표시된다. 기본값 `false`.
+  public var allowClear: Bool = false {
+    didSet { if oldValue != self.allowClear { self.refreshClearButton() } }
+  }
+
+  /// 검색 필드 우측 바깥에 검색 모드를 종료하는 cancel 버튼을 표시할지 여부 (Figma `cancelButton`). 기본값 `false`.
+  public var showsCancelButton: Bool = false {
+    didSet { if oldValue != self.showsCancelButton { self.refreshCancelButton() } }
+  }
+
+  /// cancel 버튼의 라벨 텍스트. 제품 언어에 맞춰 지정한다. 기본값 `"Cancel"`.
+  public var cancelButtonTitle: String = "Cancel" {
+    didSet { if oldValue != self.cancelButtonTitle { self.refreshCancelButton() } }
+  }
+
+  /// 키보드 타입. 내부 텍스트 필드에 그대로 전달된다.
+  public var keyboardType: UIKeyboardType {
+    get { self.textField.keyboardType }
+    set { self.textField.keyboardType = newValue }
+  }
+
+  /// 리턴 키 타입. 기본값 `.search`.
+  public var returnKeyType: UIReturnKeyType {
+    get { self.textField.returnKeyType }
+    set { self.textField.returnKeyType = newValue }
+  }
+
+  // MARK: - Callbacks
+
+  /// 사용자 입력으로 값이 바뀔 때마다 호출된다. clear 버튼 탭으로 값이 비워질 때도 호출된다.
+  public var onTextChanged: ((String) -> Void)?
+
+  /// 포커스가 시작(`true`)·종료(`false`)될 때 호출된다.
+  public var onEditingChanged: ((Bool) -> Void)?
+
+  /// 리턴 키(검색)를 눌렀을 때 호출된다.
+  public var onSubmit: (() -> Void)?
+
+  /// cancel 버튼을 눌렀을 때 호출된다. 포커스는 자동으로 해제되며, 입력값 초기화 여부는 호출부가 결정한다.
+  public var onCancel: (() -> Void)?
+
+  // MARK: - Subviews
+
+  private let rootStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .horizontal
+    stackView.alignment = .fill
+    stackView.distribution = .fill
+    stackView.spacing = BezierSearchConstant.cancelButtonSpacing
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    return stackView
+  }()
+
+  private let fieldView: UIView = {
+    let view = UIView()
+    view.layer.masksToBounds = true
+    view.layer.cornerRadius = BezierSearchConstant.metric.cornerRadius
+    return view
+  }()
+
+  private let fieldStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .horizontal
+    stackView.alignment = .center
+    stackView.distribution = .fill
+    stackView.spacing = BezierBaseInputConstant.contentSpacing
+    stackView.isLayoutMarginsRelativeArrangement = true
+    stackView.directionalLayoutMargins = NSDirectionalEdgeInsets(
+      top: 0,
+      leading: BezierBaseInputConstant.horizontalPadding,
+      bottom: 0,
+      trailing: BezierBaseInputConstant.horizontalPadding
+    )
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    return stackView
+  }()
+
+  private let iconView: UIImageView = {
+    let imageView = UIImageView(image: BezierSearchConstant.searchIcon.uiImage)
+    imageView.contentMode = .scaleAspectFit
+    return imageView
+  }()
+
+  private let textField: UITextField = {
+    let textField = UITextField()
+    textField.borderStyle = .none
+    textField.backgroundColor = .clear
+    textField.contentVerticalAlignment = .center
+    textField.returnKeyType = .search
+    return textField
+  }()
+
+  private let clearButton: UIButton = {
+    let button = UIButton(type: .system)
+    button.setImage(BezierSearchConstant.clearIcon.uiImage, for: .normal)
+    return button
+  }()
+
+  private let cancelControl = UIControl()
+
+  private let cancelLabel: UILabel = {
+    let label = UILabel()
+    label.numberOfLines = 1
+    label.translatesAutoresizingMaskIntoConstraints = false
+    return label
+  }()
+
+  // MARK: - Init
+
+  /// placeholder를 지정해 생성한다.
+  public init(placeholder: String = "") {
+    self.placeholder = placeholder
+    super.init(frame: .zero)
+    self.setUp()
+  }
+
+  public required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    self.setUp()
+  }
+
+  // MARK: - Setup
+
+  private func setUp() {
+    self.translatesAutoresizingMaskIntoConstraints = false
+
+    self.setUpIconView()
+    self.setUpTextField()
+    self.setUpClearButton()
+    self.setUpCancelControl()
+
+    self.fieldStackView.addArrangedSubview(self.iconView)
+    self.fieldStackView.addArrangedSubview(self.textField)
+    self.fieldStackView.addArrangedSubview(self.clearButton)
+    self.fieldView.addSubview(self.fieldStackView)
+
+    self.rootStackView.addArrangedSubview(self.fieldView)
+    self.rootStackView.addArrangedSubview(self.cancelControl)
+    self.addSubview(self.rootStackView)
+
+    NSLayoutConstraint.activate([
+      self.fieldStackView.topAnchor.constraint(equalTo: self.fieldView.topAnchor),
+      self.fieldStackView.leadingAnchor.constraint(equalTo: self.fieldView.leadingAnchor),
+      self.fieldStackView.trailingAnchor.constraint(equalTo: self.fieldView.trailingAnchor),
+      self.fieldStackView.bottomAnchor.constraint(equalTo: self.fieldView.bottomAnchor),
+      self.rootStackView.topAnchor.constraint(equalTo: self.topAnchor),
+      self.rootStackView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+      self.rootStackView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+      self.rootStackView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+      self.widthAnchor.constraint(greaterThanOrEqualToConstant: BezierBaseInputConstant.minWidth),
+      self.heightAnchor.constraint(equalToConstant: BezierSearchConstant.metric.height),
+    ])
+
+    // 패딩·아이콘 영역을 탭해도 포커스되도록 한다. cancelsTouchesInView를 끄면 clearButton 탭을 삼키지 않는다.
+    let tapGesture = UITapGestureRecognizer(target: self, action: #selector(self.handleTap))
+    tapGesture.cancelsTouchesInView = false
+    self.fieldView.addGestureRecognizer(tapGesture)
+
+    self.refreshClearButton()
+    self.refreshCancelButton()
+    self.refreshAppearance()
+  }
+
+  private func setUpIconView() {
+    self.iconView.setContentHuggingPriority(.required, for: .horizontal)
+    self.iconView.setContentCompressionResistancePriority(.required, for: .horizontal)
+    NSLayoutConstraint.activate([
+      self.iconView.widthAnchor.constraint(
+        equalToConstant: BezierSearchConstant.metric.leadingContentLength
+      ),
+      self.iconView.heightAnchor.constraint(
+        equalToConstant: BezierSearchConstant.metric.leadingContentLength
+      ),
+    ])
+  }
+
+  private func setUpTextField() {
+    self.textField.delegate = self
+    self.textField.addTarget(self, action: #selector(self.handleTextChanged), for: .editingChanged)
+    self.textField.setContentHuggingPriority(UILayoutPriority(1), for: .horizontal)
+    self.textField.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+  }
+
+  private func setUpClearButton() {
+    self.clearButton.addTarget(self, action: #selector(self.handleClear), for: .touchUpInside)
+    NSLayoutConstraint.activate([
+      self.clearButton.widthAnchor.constraint(
+        equalToConstant: BezierBaseInputConstant.systemElementLength
+      ),
+      self.clearButton.heightAnchor.constraint(
+        equalToConstant: BezierBaseInputConstant.systemElementLength
+      ),
+    ])
+    self.clearButton.isHidden = true
+  }
+
+  private func setUpCancelControl() {
+    self.cancelControl.setContentHuggingPriority(.required, for: .horizontal)
+    self.cancelControl.setContentCompressionResistancePriority(.required, for: .horizontal)
+    self.cancelControl.addTarget(self, action: #selector(self.handleCancel), for: .touchUpInside)
+    self.cancelControl.addSubview(self.cancelLabel)
+    NSLayoutConstraint.activate([
+      self.cancelLabel.leadingAnchor.constraint(
+        equalTo: self.cancelControl.leadingAnchor,
+        constant: BezierSearchConstant.cancelButtonHorizontalPadding
+      ),
+      self.cancelLabel.trailingAnchor.constraint(
+        equalTo: self.cancelControl.trailingAnchor,
+        constant: -BezierSearchConstant.cancelButtonHorizontalPadding
+      ),
+      self.cancelLabel.centerYAnchor.constraint(equalTo: self.cancelControl.centerYAnchor),
+    ])
+    self.cancelControl.isHidden = true
+  }
+
+  // MARK: - First Responder
+
+  public override var canBecomeFirstResponder: Bool { self.textField.canBecomeFirstResponder }
+
+  public override var isFirstResponder: Bool { self.textField.isFirstResponder }
+
+  @discardableResult
+  public override func becomeFirstResponder() -> Bool {
+    self.textField.becomeFirstResponder()
+  }
+
+  @discardableResult
+  public override func resignFirstResponder() -> Bool {
+    self.textField.resignFirstResponder()
+  }
+
+  // MARK: - Trait
+
+  public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    self.refreshAppearance()
+  }
+
+  // MARK: - State
+
+  private var currentState: BezierBaseInputState {
+    .resolve(
+      isEnabled: self.isEnabled,
+      isReadOnly: false,
+      hasError: false,
+      isFocused: self.textField.isEditing
+    )
+  }
+
+  // MARK: - Refresh
+
+  private func refreshEnabled() {
+    self.textField.isEnabled = self.isEnabled
+    self.isUserInteractionEnabled = self.isEnabled
+    self.refreshClearButton()
+    self.refreshAppearance()
+  }
+
+  private func refreshAppearance() {
+    let state = self.currentState
+
+    self.fieldView.backgroundColor = BezierBaseInputAppearance
+      .backgroundColor(variant: BezierSearchConstant.variant, state: state)
+      .palette(self)
+
+    if let borderColor = BezierBaseInputAppearance.borderColor(
+      variant: BezierSearchConstant.variant,
+      state: state
+    ) {
+      self.fieldView.layer.borderWidth = BezierBaseInputConstant.borderWidth
+      self.fieldView.layer.borderColor = borderColor.palette(self).cgColor
+    } else {
+      self.fieldView.layer.borderWidth = 0
+      self.fieldView.layer.borderColor = nil
+    }
+
+    self.alpha = state == .disabled ? BezierBaseInputConstant.disabledOpacity : 1
+
+    let typography = BezierBaseInputConstant.textTypography
+    var attributes = self.textField.defaultTextAttributes
+    attributes[.font] = typography.uiFont
+    attributes[.kern] = typography.letterSpacing
+    attributes[.foregroundColor] = BezierBaseInputAppearance.textColor(state: state).palette(self)
+    self.textField.defaultTextAttributes = attributes
+
+    self.iconView.tintColor = BezierBaseInputConstant.iconColor.palette(self)
+    self.clearButton.tintColor = BezierBaseInputConstant.iconColor.palette(self)
+
+    self.refreshPlaceholder()
+    self.refreshCancelButton()
+  }
+
+  private func refreshPlaceholder() {
+    let typography = BezierBaseInputConstant.textTypography
+    self.textField.attributedPlaceholder = NSAttributedString(
+      string: self.placeholder,
+      attributes: [
+        .font: typography.uiFont,
+        .kern: typography.letterSpacing,
+        .foregroundColor: BezierBaseInputConstant.placeholderColor.palette(self),
+      ]
+    )
+  }
+
+  private func refreshClearButton() {
+    let isVisible = self.allowClear
+      && !self.text.isEmpty
+      && self.isEnabled
+    self.clearButton.isHidden = !isVisible
+  }
+
+  private func refreshCancelButton() {
+    self.cancelControl.isHidden = !self.showsCancelButton
+    self.cancelLabel.attributedText = BezierSearchConstant.cancelButtonTypography.attributedString(
+      self,
+      text: self.cancelButtonTitle,
+      semanticColorToken: BezierSearchConstant.cancelButtonTextColor,
+      alignment: .center,
+      lineBreakMode: .byClipping
+    )
+  }
+
+  // MARK: - Action
+
+  @objc private func handleTap() {
+    guard self.isEnabled, !self.textField.isEditing else { return }
+    self.textField.becomeFirstResponder()
+  }
+
+  @objc private func handleTextChanged() {
+    self.onTextChanged?(self.text)
+    self.refreshClearButton()
+  }
+
+  @objc private func handleClear() {
+    self.textField.text = ""
+    self.onTextChanged?("")
+    self.refreshClearButton()
+  }
+
+  @objc private func handleCancel() {
+    self.textField.resignFirstResponder()
+    self.onCancel?()
+  }
+}
+
+// MARK: - UITextFieldDelegate
+
+extension BezierSearch: UITextFieldDelegate {
+  public func textFieldDidBeginEditing(_ textField: UITextField) {
+    self.refreshAppearance()
+    self.onEditingChanged?(true)
+  }
+
+  public func textFieldDidEndEditing(_ textField: UITextField) {
+    self.refreshAppearance()
+    self.onEditingChanged?(false)
+  }
+
+  public func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+    self.onSubmit?()
+    return true
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierSearch/BezierSearchSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierSearch/BezierSearchSpec.swift
@@ -1,0 +1,21 @@
+//
+//  BezierSearchSpec.swift
+//  BezierSwift
+//
+
+import Foundation
+
+// MARK: - Constant
+
+enum BezierSearchConstant {
+  static let metric: BezierBaseInputMetric = .small
+  static let variant: BezierBaseInputVariant = .primary
+
+  static let searchIcon: BezierIcon = .search
+  static let clearIcon: BezierIcon = .cancelCircleFilled
+
+  static let cancelButtonSpacing: CGFloat = 8
+  static let cancelButtonHorizontalPadding: CGFloat = 4
+  static let cancelButtonTypography: BTSemanticToken = .textMedium(weight: .regular)
+  static let cancelButtonTextColor: BCSemanticToken = .textNeutral
+}

--- a/Sources/BezierSwift/MasterComponent/BezierSearch/SPEC.md
+++ b/Sources/BezierSwift/MasterComponent/BezierSearch/SPEC.md
@@ -1,0 +1,145 @@
+# BezierSearch SPEC
+
+> **SSOT**: [Figma · Mobile-Components / Search (2365:314)](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=2365-314)
+> **Design spec doc**: [team-design / bezier-v3 / components / Search-spec.md](https://github.com/channel-io/team-design/blob/main/bezier-v3/components/Search-spec.md) · [BaseInput.md](https://github.com/channel-io/team-design/blob/main/bezier-v3/components/BaseInput.md) (보조 참조 — 값 충돌 시 Figma 파일 우선)
+
+SearchIcon이 고정된 단일 행 검색 입력 필드 (Figma component description 1행).
+
+- **배치**: width 기본 fill(부모 폭 채움). 최소 너비 40pt. leadingContent(SearchIcon)는 swap 불가
+- **용도 경계**: 검색 외 일반 텍스트 입력에는 TextInput 사용 (Figma description)
+
+## 1. Component Properties
+
+### Search (CS `2365:314`)
+
+| Property | 값 | 비고 |
+|---|---|---|
+| **state** | `default` / `focused` / `disabled` | 배경·보더·투명도 결정 |
+| **hasValue** | `false` / `true` | `false`: `placeholder` 레이어만 표시, `true`: `value` 레이어만 표시 |
+| **allowClear** | BOOLEAN, Figma 기본 `true` | 시스템 자동 요소 — cancel-circle-filled 아이콘 20pt. `hasValue=true` + `default`·`focused`에서만 바인딩, `disabled`·`hasValue=false`는 숨김 고정 |
+| **cancelButton** | BOOLEAN, 기본 `false` | "Cancel" 텍스트 버튼. SearchField 우측 외부 배치 |
+| **placeholder** / **value** | TEXT | 각 텍스트 레이어의 내용 |
+
+- size 축 없음 — 높이 40pt 단일 고정
+- variant(appearance) 축 없음
+
+총 instance: state 3 × hasValue 2 = **6개**
+
+자식 배치 순서: `SearchField(SearchIcon → 입력 텍스트 → allowClear) → cancelButton`
+
+## 2. Layout Spec
+
+| Part | 값 |
+|---|---|
+| 높이 (FIXED) | `40pt` |
+| corner radius (SearchField) | `12pt` (`radius/12`) |
+| SearchField 좌우 패딩 | `10pt` |
+| SearchField 내부 gap | `6pt` |
+| SearchIcon (leadingContent) | `20×20pt` |
+| allowClear | `20×20pt` |
+| 최소 너비 (root) | `40pt` |
+| 보더(INNER_SHADOW) 두께 | `1.5pt` (spread) |
+| root gap (SearchField ↔ cancelButton) | `8pt` |
+| cancelButton 좌우 패딩 | `4pt` |
+| cancelButton 높이 | full (root 높이 40pt, 텍스트 수직 중앙) |
+
+- 너비: 기본 fill — 부모 폭을 채움 (Figma description). SearchField가 잔여 폭 전체를 차지하고 cancelButton은 콘텐츠 폭(hug).
+- 입력 텍스트는 1줄, 초과분 ellipsis.
+- 보더는 Effect `State/*` — `INNER_SHADOW, offset (0,0), radius 0, spread 1.5` (안쪽 1.5pt 라인). 배경·보더·radius는 SearchField 프레임에 적용되며 root는 순수 레이아웃 컨테이너다.
+
+## 3. State 별 컬러 토큰
+
+### Background (SearchField)
+
+| State | Token | Figma Variable | Raw |
+|---|---|---|---|
+| `default` / `disabled` | `fillGrey` | `color/fill/grey` | `#FBFBFB` |
+| `focused` | `fillGreyLight` | `color/fill/grey/light` | `#FDFDFD` |
+
+### Border (SearchField, INNER_SHADOW 1.5pt)
+
+| State | Effect | Token | Figma Variable | Raw |
+|---|---|---|---|---|
+| `default` / `disabled` | `State/default` | `stateDefault` | `color/state/default` | `#00000026` |
+| `focused` | `State/active` | `stateActive` | `color/state/active` | `#000000D9` |
+
+### Text / Icon
+
+| 위치 | Token | Figma Variable | Raw |
+|---|---|---|---|
+| SearchIcon | `iconNeutral` | `color/icon/neutral` | `#00000066` |
+| allowClear 아이콘 | `iconNeutral` | `color/icon/neutral` | `#00000066` |
+| placeholder (`hasValue=false`) | `textNeutralLighter` | `color/text/neutral/lighter` | `#00000066` |
+| value (`hasValue=true`) | `textNeutral` | `color/text/neutral` | `#000000D9` |
+| cancelButton 텍스트 | `textNeutral` | `color/text/neutral` | `#000000D9` |
+
+### Opacity
+
+| State | 값 |
+|---|---|
+| `disabled` | `opacity/disabled` = 40% (root 전체 — cancelButton 포함) |
+
+## 4. Typography
+
+### Case A — Typography Token 사용
+
+| 위치 | Token | Figma Style / Variable |
+|---|---|---|
+| placeholder / value | `BTSemanticToken.textXLarge(weight: .regular)` | `Typography/text/xlarge` (16 / 400 / lh 24 / ls -0.1) |
+| cancelButton 텍스트 | `BTSemanticToken.textMedium(weight: .regular)` | `Typography/text/medium` (14 / 400 / lh 18 / ls 0) |
+
+### Case B — Custom Typography
+
+없음.
+
+## 5. State 별 시각 동작
+
+| State | 변경점 | clear 버튼 (`allowClear=true` 시) | 인터랙션 |
+|---|---|---|---|
+| `default` (empty) | 기본 — SearchIcon + placeholder | 미표시 | 활성 |
+| `default` (with value) | value 텍스트 표시 | **표시** | 활성 |
+| `focused` | 배경 `fillGreyLight` + 보더 `State/active` | **표시** (값 있을 때) | 편집 중 |
+| `disabled` | 전체 opacity 40% | 미표시 | 비활성 |
+
+- **clear 버튼 노출**: 값이 있으면 `default`·`focused` 모두에서 표시, `disabled`·값 없음은 숨김 고정 — Figma 렌더 조건 `hasValue && (default|focused) && allowClear` (`2450:50` default+hasValue variant에서 표시 확인).
+
+## 6. 디자이너 가이드라인 (Figma component description 인용)
+
+- SearchIcon이 고정된 단일 행 검색 입력 필드. placeholder는 검색 범위 명시 필수 ('검색' 단어만 금지). leadingContent는 swap 불가.
+- width: 기본 fill(부모 폭 채움). 비율 지정도 가능하나 Figma는 auto-layout 기능 한계로 표현 불가(FILL/FIXED/HUG만 지원). 최소 너비 40px.
+- 검색 외 일반 텍스트 입력에는 TextInput 사용.
+
+## 7. 매핑되는 코드 심볼
+
+| 정의 | 파일 |
+|---|---|
+| UIKit 구현 | `BezierSearch.swift` |
+| SwiftUI 구현 | `SUBezierSearch.swift` |
+| 고정 metric·상수 | `BezierSearchSpec.swift` |
+| 공유 Input 레이어 (internal) | `../BezierBaseInput/BezierBaseInputSpec.swift` |
+
+## 8. Figma 외 · 협의 사항 (구현 결정 — SSOT 값 아님)
+
+1. **BaseInput 공유 레이어 재사용**: 배경·보더·state 해석은 `BezierBaseInputAppearance`(variant `.primary` 고정), 수치는 `BezierBaseInputMetric.small`(height 40 / radius 12 / leadingContent 20 — Figma 실측과 전항 일치)과 `BezierBaseInputConstant`(`horizontalPadding` 10 / `contentSpacing` 6 / `borderWidth` 1.5 / `minWidth` 40 / `systemElementLength` 20)를 그대로 사용한다. 재구현하지 않는다.
+2. **state resolve 재사용**: `BezierBaseInputState.resolve(isEnabled:isReadOnly:hasError:isFocused:)`에 `isReadOnly: false`, `hasError: false`를 고정 전달 — 결과 도메인이 Figma의 default/focused/disabled 3종과 일치한다.
+3. **allowClear 코드 기본값 `false`**: team-design Search-spec.md §10이 코드 SSOT(`@default false`)를 권위 기준으로 확정 — Figma BOOLEAN 기본 `true`는 컴포넌트 능력 노출용.
+4. **clear 표시 조건 (mobile)**: `allowClear && !text.isEmpty && isEnabled` — TextInput과 달리 focused 조건 없음 (§5). clear 탭 시 값 초기화 (design spec doc §7 Behavior).
+5. **SearchIcon 에셋**: `BezierIcon.search` 기존 에셋 사용 (Figma 인스턴스 SVG와 형상 일치 확인 — 원 r=8/20, 핸들 종점 등 path 동형). allowClear는 `BezierIcon.cancelCircleFilled` (TextInput 동일, SVG 형상 일치 확인).
+6. **cancelButton API**: Figma BOOLEAN `cancelButton` → UIKit `showsCancelButton` / SwiftUI `showsCancelButton` (UISearchBar.showsCancelButton 관례). Figma 라벨 텍스트는 "Cancel" 고정이나 제품 로컬라이즈가 필요하므로 `cancelButtonTitle`(기본값 `"Cancel"` = Figma 값)로 노출. 탭 시 포커스 해제 + `onCancel` 콜백 — 텍스트 초기화 여부는 소비자 책임 (design spec doc이 동작 미정의).
+7. **검색 키보드**: UIKit `returnKeyType` 기본값 `.search`(passthrough로 변경 가능), SwiftUI 내부 `.submitLabel(.search)` — design spec doc §7 "Enter 키 입력 시 검색 실행" 대응. 제출 콜백은 UIKit `onSubmit` 클로저 / SwiftUI 표준 `.onSubmit` modifier 상속.
+8. **INNER_SHADOW → 보더 구현**: spread 1.5 / blur 0 / offset (0,0)의 INNER_SHADOW는 안쪽 1.5pt 라인과 동일 — UIKit `layer.borderWidth = 1.5`, SwiftUI `strokeBorder(lineWidth: 1.5)` (TextInput 협의 4와 동일).
+9. **UITextField line-height 미적용**: 컨테이너 높이 40pt 고정 + 세로 중앙 정렬로 동일한 시각 결과 — font(16pt) + kern(-0.1)만 적용 (TextInput 협의 5와 동일).
+10. **배경·보더 적용 위치**: cancelButton이 SearchField 밖에 있으므로 UIKit은 root가 아닌 내부 fieldView에 배경·보더·radius를 적용하고, disabled opacity만 root 전체에 적용한다 (Figma 구조 동일).
+
+## 9. Variant 매트릭스
+
+총 instance: state 3 × hasValue 2 = **6개**
+
+```text
+state=default,  hasValue=false = 2365:186
+state=focused,  hasValue=false = 2365:202
+state=disabled, hasValue=false = 2365:234
+state=default,  hasValue=true  = 2450:50
+state=focused,  hasValue=true  = 2450:63
+state=disabled, hasValue=true  = 2450:76
+```

--- a/Sources/BezierSwift/MasterComponent/BezierSearch/SUBezierSearch.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierSearch/SUBezierSearch.swift
@@ -1,0 +1,195 @@
+//
+//  SUBezierSearch.swift
+//  BezierSwift
+//
+
+import SwiftUI
+
+/// SearchIcon이 고정된 단일 행 검색 입력 필드 (SwiftUI). 리스트 필터링·데이터 탐색처럼 키워드를 입력해 검색을 실행할 때 쓴다. 이름·이메일 등 일반 폼 입력에는 `SUBezierTextInput`을 사용한다. UIKit에서는 `BezierSearch`를 사용한다.
+///
+/// 너비는 컨테이너가 결정한다 — 기본으로 부모 폭을 채운다. 높이는 40pt로 고정된다 (Figma `Search`는 size 축 없음).
+/// placeholder는 검색 범위를 명시한다 (예: `고객 이름, 이메일, 전화번호로 검색`) — `검색` 한 단어만 쓰지 않는다.
+/// 검색 실행은 표준 `.onSubmit` modifier를 밖에서 적용하면 내부 텍스트 필드로 전파된다. 리턴 키는 검색(`.search`)으로 고정된다.
+public struct SUBezierSearch: View, Themeable {
+  @Environment(\.colorScheme) public var colorScheme
+  @Environment(\.isEnabled) private var isEnabled
+  @FocusState private var isFocused: Bool
+
+  @Binding private var text: String
+  private let placeholder: String
+  private let allowClear: Bool
+  private let showsCancelButton: Bool
+  private let cancelButtonTitle: String
+  private let onCancel: (() -> Void)?
+
+  /// 입력값 바인딩과 placeholder, clear·cancel 버튼 구성을 지정해 생성한다.
+  ///
+  /// - `allowClear`: 값이 있을 때 값을 한 번에 지우는 clear 버튼을 표시한다. 포커스와 무관하게 값이 있으면 표시된다.
+  /// - `showsCancelButton`: 검색 필드 우측 바깥에 검색 모드를 종료하는 cancel 버튼을 표시한다 (Figma `cancelButton`).
+  /// - `cancelButtonTitle`: cancel 버튼의 라벨 텍스트. 제품 언어에 맞춰 지정한다.
+  /// - `onCancel`: cancel 버튼 탭 시 호출된다. 포커스는 자동으로 해제되며, 입력값 초기화 여부는 호출부가 결정한다.
+  public init(
+    text: Binding<String>,
+    placeholder: String = "",
+    allowClear: Bool = false,
+    showsCancelButton: Bool = false,
+    cancelButtonTitle: String = "Cancel",
+    onCancel: (() -> Void)? = nil
+  ) {
+    self._text = text
+    self.placeholder = placeholder
+    self.allowClear = allowClear
+    self.showsCancelButton = showsCancelButton
+    self.cancelButtonTitle = cancelButtonTitle
+    self.onCancel = onCancel
+  }
+
+  public var body: some View {
+    HStack(spacing: BezierSearchConstant.cancelButtonSpacing) {
+      self.fieldView
+      if self.showsCancelButton {
+        self.cancelButtonView
+      }
+    }
+    .frame(height: BezierSearchConstant.metric.height)
+    .frame(minWidth: BezierBaseInputConstant.minWidth, maxWidth: .infinity)
+    // opacity는 per-view 곱이라 배경·보더가 겹치는 링 영역이 이중 블렌딩됨 — 합성 후 1회 적용 (UIKit self.alpha와 동일 결과)
+    .compositingGroup()
+    .opacity(self.state == .disabled ? BezierBaseInputConstant.disabledOpacity : 1)
+  }
+
+  // MARK: - State
+
+  private var state: BezierBaseInputState {
+    .resolve(
+      isEnabled: self.isEnabled,
+      isReadOnly: false,
+      hasError: false,
+      isFocused: self.isFocused
+    )
+  }
+
+  // MARK: - Subviews
+
+  private var fieldView: some View {
+    HStack(spacing: BezierBaseInputConstant.contentSpacing) {
+      BezierSearchConstant.searchIcon.image
+        .foregroundColor(self.palette(BezierBaseInputConstant.iconColor))
+        .frame(
+          width: BezierSearchConstant.metric.leadingContentLength,
+          height: BezierSearchConstant.metric.leadingContentLength
+        )
+
+      TextField("", text: self.$text, prompt: self.promptText)
+        .focused(self.$isFocused)
+        .textFieldStyle(.plain)
+        .submitLabel(.search)
+        .applyBezierFontStyle(
+          BezierBaseInputConstant.textTypography,
+          semanticColorToken: BezierBaseInputConstant.textColor
+        )
+        .frame(maxWidth: .infinity)
+
+      self.clearButtonView
+    }
+    .padding(.horizontal, BezierBaseInputConstant.horizontalPadding)
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .background(
+      RoundedRectangle(cornerRadius: BezierSearchConstant.metric.cornerRadius)
+        .fill(
+          self.palette(
+            BezierBaseInputAppearance.backgroundColor(
+              variant: BezierSearchConstant.variant,
+              state: self.state
+            )
+          )
+        )
+    )
+    .overlay { self.borderOverlay }
+    .contentShape(Rectangle())
+    .onTapGesture {
+      self.isFocused = true
+    }
+  }
+
+  private var promptText: Text {
+    Text(self.placeholder)
+      .font(BezierBaseInputConstant.textTypography.font)
+      .kerning(BezierBaseInputConstant.textTypography.letterSpacing)
+      .foregroundColor(self.palette(BezierBaseInputConstant.placeholderColor))
+  }
+
+  @ViewBuilder
+  private var clearButtonView: some View {
+    if self.allowClear, !self.text.isEmpty, self.isEnabled {
+      Button {
+        self.text = ""
+      } label: {
+        BezierSearchConstant.clearIcon.image
+          .foregroundColor(self.palette(BezierBaseInputConstant.iconColor))
+          .frame(
+            width: BezierBaseInputConstant.systemElementLength,
+            height: BezierBaseInputConstant.systemElementLength
+          )
+      }
+      .buttonStyle(.plain)
+    }
+  }
+
+  private var cancelButtonView: some View {
+    Button {
+      self.isFocused = false
+      self.onCancel?()
+    } label: {
+      Text(self.cancelButtonTitle)
+        .applyBezierFontStyle(
+          BezierSearchConstant.cancelButtonTypography,
+          semanticColorToken: BezierSearchConstant.cancelButtonTextColor
+        )
+        .lineLimit(1)
+        .fixedSize(horizontal: true, vertical: false)
+        .padding(.horizontal, BezierSearchConstant.cancelButtonHorizontalPadding)
+        .frame(maxHeight: .infinity)
+        .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+  }
+
+  @ViewBuilder
+  private var borderOverlay: some View {
+    if let borderColor = BezierBaseInputAppearance.borderColor(
+      variant: BezierSearchConstant.variant,
+      state: self.state
+    ) {
+      RoundedRectangle(cornerRadius: BezierSearchConstant.metric.cornerRadius)
+        .strokeBorder(self.palette(borderColor), lineWidth: BezierBaseInputConstant.borderWidth)
+    }
+  }
+}
+
+struct SUBezierSearch_Previews: PreviewProvider {
+  struct Container: View {
+    @State private var text = ""
+    @State private var filledText = "John Doe"
+
+    var body: some View {
+      VStack(spacing: 12) {
+        SUBezierSearch(text: self.$text, placeholder: "Search by name, email, phone")
+        SUBezierSearch(text: self.$filledText, allowClear: true)
+        SUBezierSearch(
+          text: self.$filledText,
+          allowClear: true,
+          showsCancelButton: true,
+          cancelButtonTitle: "Cancel"
+        )
+        SUBezierSearch(text: self.$filledText, allowClear: true)
+          .disabled(true)
+      }
+      .padding()
+    }
+  }
+
+  static var previews: some View {
+    Container()
+  }
+}


### PR DESCRIPTION
## MOB-6347

https://linear.app/channel/issue/MOB-6347

V3 Search 컴포넌트를 UIKit + SwiftUI로 구현합니다. SearchIcon이 좌측에 고정된 단일 행 검색 입력 필드로, 일반 폼 입력용 `BezierTextInput`과 분리된 검색 전용 컴포넌트입니다.

## 구현 내용

### BaseInput 공유 레이어 재사용 (재구현 없음)

```
BezierSearch (root — 레이아웃 컨테이너, gap 8)
├── fieldView (배경·보더·radius 소유)
│   ├── BezierIcon.search              20×20 · iconNeutral
│   ├── UITextField / TextField        textXLarge · 잔여 폭
│   └── BezierIcon.cancelCircleFilled  20×20 · allowClear
└── cancelButton                        textMedium · 좌우 패딩 4 (옵션)
```

수치·토큰·state 해석은 전부 `BezierBaseInput` internal 레이어에 위임하고 `BezierSearchSpec.swift`에는 Search 고유 상수(cancel 버튼 gap 8 / 패딩 4 / 타이포 / 아이콘)만 둡니다.

- `BezierBaseInputMetric.small` — height 40 / radius 12 / leadingContent 20 (Figma 실측과 일치)
- `BezierBaseInputConstant` — 패딩 10 / gap 6 / 보더 1.5 / minWidth 40 / systemElement 20
- `BezierBaseInputAppearance` — variant `.primary` 고정, state별 배경(`fillGrey`/`fillGreyLight`)·보더(`stateDefault`/`stateActive`)
- `BezierBaseInputState.resolve(isEnabled:isReadOnly:hasError:isFocused:)` — `isReadOnly: false`, `hasError: false` 고정 전달로 결과 도메인이 Figma의 default/focused/disabled 3종과 정확히 일치

### API 표면

- `text` / `placeholder` / `isEnabled` / `allowClear` / `showsCancelButton` / `cancelButtonTitle`
- 콜백: UIKit `onTextChanged` · `onEditingChanged` · `onSubmit` · `onCancel`, SwiftUI는 표준 `.onSubmit` 상속 + `onCancel`
- size·variant 축이 Figma에 없으므로 public API에도 노출하지 않습니다
- 배치는 컨테이너 책임 — `resizing`/`isFullWidth` 류 프로퍼티 없이 높이 40 고정 + `minWidth 40` 제약만 둡니다

### 동작

- **clear 버튼 노출**: `allowClear && !text.isEmpty && isEnabled` — TextInput과 달리 focused 조건이 없습니다 (모바일은 hover 개념이 없어 값이 있으면 default·focused 모두에서 표시). 탭 시 값만 초기화하고 포커스는 유지합니다
- **`allowClear` 코드 기본값 `false`** — Figma BOOLEAN 기본값은 `true`지만 team-design Search-spec.md §10이 코드 SSOT(`@default false`)를 권위 기준으로 확정했습니다. Figma 기본값 `true`는 컴포넌트 능력 노출용입니다
- **검색 키보드**: UIKit `returnKeyType` 기본 `.search`, SwiftUI `.submitLabel(.search)`
- **cancelButton**: 탭 시 포커스 해제 + `onCancel` 호출. 텍스트 초기화 여부는 소비자 책임입니다 (design spec doc이 미정의). 라벨은 로컬라이즈가 필요하므로 `cancelButtonTitle`(기본값 `"Cancel"` = Figma 값)로 노출합니다
- **disabled**: opacity 40%를 root 전체(cancelButton 포함)에 적용 + 인터랙션 차단

### 패러다임별 처리

- UIKit: 배경·보더·radius를 root가 아닌 내부 `fieldView`에 적용 (cancelButton이 SearchField 밖에 있는 Figma 구조와 동일). `traitCollectionDidChange`에서 배경·보더·텍스트·placeholder·아이콘·cancel 라벨 색을 전부 재주입해 다크모드에 적응합니다
- SwiftUI: `.compositingGroup()` 후 `.opacity()` 1회 적용 — per-view opacity 곱으로 배경·보더가 겹치는 링 영역이 이중 블렌딩되는 것을 막아 UIKit `alpha`와 동일한 결과를 냅니다
- INNER_SHADOW(spread 1.5 / blur 0 / offset 0,0)는 안쪽 1.5pt 라인과 동일하므로 UIKit `layer.borderWidth` / SwiftUI `strokeBorder`로 구현합니다

### Examples 카탈로그

`SearchCatalog`은 SwiftUI·UIKit 매트릭스를 나란히 두고 `isEnabled` / `allowClear` / `showsCancelButton` 토글과 last event 표시를 제공합니다.

- UIKit은 wrapper `UIView`에 leading·trailing pin + `sizeThatFits`가 `proposal.width` 반환 — `BezierSearch`가 content-hug intrinsic width를 가져 representable 루트로 직접 반환하면 full-width가 되지 않습니다
- `@State`로 바뀌는 축(`isEnabled`/`allowClear`/`showsCancelButton`/`text`)은 `updateUIView`에서 재주입합니다 (`makeUIView`는 1회만 호출)
- 검증 중 발견한 결함 1건: `search.onSubmit` 클로저가 `search`를 강하게 캡처해 `BezierSearch` ↔ 클로저 retain cycle이 발생했습니다 → `[weak search]`로 수정

## Spec 검증

figma-component-spec 3단계 사이클로 검증했습니다 (Figma = SSOT).

- **Phase 1**: Figma 실측 기반 `SPEC.md` 작성 — Mobile CS `2365:314`, state 3 × hasValue 2 = 6 variant
- **Phase 2**: Properties / Layout / Color / Typography / Asset / Spec Noise / Implementation Reference 7개 차원 병렬 검증

| 차원 | 결과 |
|---|---|
| Properties | ✅ 6 variant · property 축·기본값 전수 일치 |
| Layout | ✅ §2 11개 행 전수 일치 |
| Color | ✅ 8개 토큰 전수 일치 (아이콘 색은 SVG raw `fill-opacity` 직접 확인) |
| Typography | ✅ 3개 텍스트 노드 모두 등록된 Figma Style — Custom 없음 |
| Asset | ✅ SearchIcon·cancel-circle-filled path 동형, SF Symbol 대체 0건 |
| Spec Noise | ❌ → 수정 후 ✅ |
| Implementation Reference | ✅ 코드 심볼·상수값·협의 사항 전수 실재 |

Spec Noise Detector가 지적한 2건을 SPEC.md에서 제거했습니다.

- §5 "state 축에 error / readOnly 없음" — `error`/`readOnly`는 형제 컴포넌트 TextInput의 값이며, Search의 state 3값은 §1에 이미 명시돼 있어 타 컴포넌트 참조성 중복
- §8-11 "웹 전용 요소 스코프 제외(hovered·size 축·`selectAllOn*`·Ref API)" — bezier-react라는 별개 코드베이스의 API 표면을 근거로 부재를 서술한 스코프 disclaimer로, 구현 결정이 아님

추가로 Implementation Reference Validator 지적을 반영해 §8-1의 "trailing 20"을 실제 코드 심볼명(`systemElementLength`)으로 정정했습니다.

- **Phase 3**: UIKit · SwiftUI Implementation Validator 모두 ✅ — 매직넘버 없이 BaseInput 상수만 참조하고, clear 노출 조건이 TextInput(`isEditing` 포함)과 정확히 분기되는 것까지 확인

Figma에 없는 구현 결정(BaseInput 재사용, `allowClear` 코드 기본값, cancelButton API·로컬라이즈, INNER_SHADOW→보더 변환, 배경·보더 적용 위치)은 `SPEC.md` §8에 협의 사항으로 분리 기록했습니다.

## 시뮬레이터 검증 (iPhone 17 / iOS 26.4, 라이트·다크)

카탈로그를 직접 조작해 전 축을 확인했습니다. 캡처 원본은 로컬 `Screenshots-MOB-6347/`(미커밋)에 보관 — 필요 시 코멘트로 첨부합니다.

| 확인 항목 | 확인 내용 | 결과 |
|---|---|---|
| default (empty) | SearchIcon 20×20 + `textNeutralLighter` placeholder, radius 12, `fillGrey` 배경, `stateDefault` 보더. `allowClear=ON`이어도 값이 없어 clear 미표시 | ✅ |
| focused | 보더가 `stateActive`(진한 링)로, 배경이 `fillGreyLight`로 전환. 캐럿 표시 | ✅ |
| hasValue + clear 노출 | 값 입력 시 `cancelCircleFilled` 20×20 등장, 텍스트 필드 폭이 정확히 26pt(=20+6) 축소 | ✅ |
| **clear 노출 조건 (TextInput과 분기)** | SwiftUI 필드가 **포커스를 잃은 default 상태에서도** 값이 있으면 clear 유지 — SPEC §5·§8-4의 focused 조건 없음이 실제 렌더로 확인됨 | ✅ |
| clear 탭 동작 | 값만 비워지고 **포커스 유지**(캐럿 잔존 + `stateActive` 보더 유지), clear 사라지며 폭 26pt 복원 | ✅ |
| cancelButton 레이아웃 | SearchField 우측 끝 313 → Cancel 시작 321(**gap 8**), 높이 40(**full**), UIKit 라벨 x=325 vs 버튼 x=321(**패딩 4**), 45+4+4=53으로 SwiftUI 버튼 폭과 일치 | ✅ |
| disabled | root 전체가 40%로 흐려지며 **cancelButton도 함께 포함**, clear 숨김(폭 26pt 복원), 전 요소 입력 차단 | ✅ |
| 다크모드 (UIKit 토큰 재주입) | 라이트에서 생성된 뷰를 다크로 전환 — 배경·**보더(CGColor)**·값 텍스트·placeholder·SearchIcon·clear tint·**cancel 라벨**이 전부 재해석. stale 라이트 색 없음 | ✅ |
| 다크 focused / 다크 disabled | 다크에서도 `stateActive` 밝은 링 전환, 40% 흐림(cancel 포함) 동일 동작 | ✅ |
| UIKit ↔ SwiftUI 패리티 | 접근성 프레임 실측 일치 — 아이콘 x=38(20×20), 텍스트 x=64, clear x=283/344, Cancel 321(w=53). 모든 상태에서 두 구현이 동일 좌표·동일 색 | ✅ |

접근성 프레임으로 SPEC §2 수치를 직접 실측 검증했습니다: 필드 내부 패딩 10(아이콘 x=38 ↔ 필드 좌단 28) · gap 6(아이콘 끝 58 → 텍스트 64) · clear 20 + gap 6 · root gap 8 · cancel 패딩 4 · 높이 40.

시각 검증에서 발견된 SPEC 대비 결함은 **없어 코드는 수정하지 않았습니다.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - UIKit 및 SwiftUI에서 사용할 수 있는 한 줄 검색 입력 컴포넌트를 추가했습니다.
  - 검색어 입력, 제출, 지우기, 취소 이벤트를 지원합니다.
  - 활성화 상태, 지우기 버튼, 취소 버튼 및 테마 설정을 제공합니다.
  - 검색 컴포넌트 카탈로그와 예제를 추가했습니다.

- **문서**
  - 검색 컴포넌트의 레이아웃, 상태, 스타일 및 동작 사양을 문서화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->