### PR TITLE
[MOB-6351] BezierForm 컴포넌트 구현 (UIKit + SwiftUI)

### DIFF
--- a/Examples/BezierExamples/BezierExamples/App/CatalogRegistry.swift
+++ b/Examples/BezierExamples/BezierExamples/App/CatalogRegistry.swift
@@ -27,6 +27,7 @@ enum CatalogRegistry {
     .init(id: "dropdown-menu", title: "DropdownMenu", section: .v3Components, destination: AnyView(DropdownMenuCatalog())),
     .init(id: "emoji", title: "Emoji", section: .v3Components, destination: AnyView(EmojiCatalog())),
     .init(id: "floating-banner", title: "FloatingBanner", section: .v3Components, destination: AnyView(FloatingBannerCatalog())),
+    .init(id: "form", title: "Form", section: .v3Components, destination: AnyView(FormCatalog())),
     .init(id: "form-group", title: "FormGroup", section: .v3Components, destination: AnyView(FormGroupCatalog())),
     .init(id: "icon-button", title: "IconButton", section: .v3Components, destination: AnyView(IconButtonCatalog())),
     .init(id: "modal", title: "Modal", section: .v3Components, destination: AnyView(ModalCatalog())),

--- a/Examples/BezierExamples/BezierExamples/Components/FormCatalog.swift
+++ b/Examples/BezierExamples/BezierExamples/Components/FormCatalog.swift
@@ -1,0 +1,245 @@
+import SwiftUI
+import UIKit
+import BezierSwift
+
+struct FormCatalog: View {
+  @State private var showLabel = true
+  @State private var showDescription = true
+  @State private var isRequired = true
+  @State private var hasError = false
+  @State private var hasCustomContent = false
+  @State private var isEnabled = true
+  @State private var swiftUIIntro = ""
+  @State private var swiftUIEmail = ""
+  @State private var swiftUIChecked: BezierCheckboxChecked = .unchecked
+  @State private var uiKitIntro = ""
+  @State private var uiKitEmail = ""
+
+  private let introDescription = "프로필에 표시할 소개를 입력해요"
+  private let introError = "소개글을 입력해주세요"
+  private let inlineDescription = "다른 언어로 자동 번역해요"
+
+  var body: some View {
+    CatalogScreen(title: "Form") {
+      self.controls
+      CatalogSection(.swiftUI) { self.swiftUIPreview }
+      CatalogSection(.uiKit) { self.uiKitPreview }
+    }
+  }
+
+  private var controls: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Toggle("showLabel (1번 · inline 필드)", isOn: self.$showLabel)
+      Toggle("showDescription", isOn: self.$showDescription)
+      Toggle("isRequired", isOn: self.$isRequired)
+      Toggle("hasError", isOn: self.$hasError)
+      Toggle("hasCustomContent (inline 필드)", isOn: self.$hasCustomContent)
+      Toggle("isEnabled", isOn: self.$isEnabled)
+
+      Button("키보드 내리기") {
+        UIApplication.shared.sendAction(
+          #selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil
+        )
+      }
+    }
+    .font(.caption)
+  }
+
+  // MARK: - SwiftUI
+
+  private var swiftUIPreview: some View {
+    SUBezierForm {
+      SUBezierFormField(
+        labelText: self.showLabel ? "소개글" : nil,
+        description: self.showDescription ? self.introDescription : nil,
+        isRequired: self.isRequired,
+        errorText: self.hasError ? self.introError : nil
+      ) {
+        SUBezierTextInput(
+          text: self.$swiftUIIntro,
+          placeholder: "Placeholder",
+          hasError: self.hasError
+        )
+      }
+
+      SUBezierFormField(labelText: "이메일") {
+        SUBezierTextInput(
+          text: self.$swiftUIEmail,
+          placeholder: "예: hong@company.com"
+        )
+      }
+
+      self.swiftUIInlineField
+    }
+    .disabled(!self.isEnabled)
+  }
+
+  // customContent 슬롯 유무는 제네릭 타입(EmptyView 여부)으로 판정되므로, 조건부 뷰를
+  // 슬롯 안에 넣으면 Optional<View>가 되어 빈 상태에서도 슬롯이 살아있는 것으로 잡힌다.
+  // 이니셜라이저 자체를 분기해 CustomContent == EmptyView를 성립시킨다.
+  @ViewBuilder
+  private var swiftUIInlineField: some View {
+    if self.hasCustomContent {
+      SUBezierFormField(
+        labelPosition: .left,
+        labelText: self.showLabel ? "번역" : nil,
+        description: self.showDescription ? self.inlineDescription : nil,
+        control: { self.swiftUIInlineControl },
+        customContent: {
+          RoundedRectangle(cornerRadius: 8)
+            .fill(Color.red.opacity(0.08))
+            .frame(height: 100)
+            .overlay(
+              Text("customContent")
+                .font(.caption2)
+                .foregroundColor(.secondary)
+            )
+        }
+      )
+    } else {
+      SUBezierFormField(
+        labelPosition: .left,
+        labelText: self.showLabel ? "번역" : nil,
+        description: self.showDescription ? self.inlineDescription : nil,
+        control: { self.swiftUIInlineControl }
+      )
+    }
+  }
+
+  private var swiftUIInlineControl: some View {
+    SUBezierCheckbox(label: "사용", checked: self.swiftUIChecked) { checked in
+      self.swiftUIChecked = checked
+    }
+  }
+
+  // MARK: - UIKit
+
+  private var uiKitPreview: some View {
+    FormUIKitRepresentable(
+      introText: self.$uiKitIntro,
+      emailText: self.$uiKitEmail,
+      showLabel: self.showLabel,
+      showDescription: self.showDescription,
+      isRequired: self.isRequired,
+      hasError: self.hasError,
+      hasCustomContent: self.hasCustomContent,
+      isEnabled: self.isEnabled,
+      introDescription: self.introDescription,
+      introError: self.introError,
+      inlineDescription: self.inlineDescription
+    )
+    .disabled(!self.isEnabled)
+  }
+}
+
+private struct FormUIKitRepresentable: UIViewRepresentable {
+  @Binding var introText: String
+  @Binding var emailText: String
+  let showLabel: Bool
+  let showDescription: Bool
+  let isRequired: Bool
+  let hasError: Bool
+  let hasCustomContent: Bool
+  let isEnabled: Bool
+  let introDescription: String
+  let introError: String
+  let inlineDescription: String
+
+  final class Coordinator {
+    var introField: BezierFormField?
+    var inlineField: BezierFormField?
+    var introInput: BezierTextInput?
+    var emailInput: BezierTextInput?
+    var checkbox: BezierCheckbox?
+    var customContentView: UIView?
+  }
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator()
+  }
+
+  // BezierForm은 intrinsic width가 없어 UIKitWrap(fittingSizeLevel)에서는 폭이 hug로 접힌다.
+  // wrapper에 pin하고 sizeThatFits에서 proposal.width를 그대로 반환해 전체 폭을 확보한다.
+  func makeUIView(context: Context) -> UIView {
+    let introInput = BezierTextInput(placeholder: "Placeholder")
+    introInput.onTextChanged = { self.introText = $0 }
+    let introField = BezierFormField(control: introInput)
+
+    let emailInput = BezierTextInput(placeholder: "예: hong@company.com")
+    emailInput.onTextChanged = { self.emailText = $0 }
+    let emailField = BezierFormField(labelText: "이메일", control: emailInput)
+
+    let checkbox = BezierCheckbox(label: "사용")
+    checkbox.onCheckedChange = { [weak checkbox] checked in
+      checkbox?.checked = checked
+    }
+    let customContentView: UIView = {
+      let view = UIView()
+      view.backgroundColor = UIColor.systemRed.withAlphaComponent(0.08)
+      view.layer.cornerRadius = 8
+      view.heightAnchor.constraint(equalToConstant: 100).isActive = true
+      return view
+    }()
+    let inlineField = BezierFormField(
+      labelPosition: .left,
+      labelText: self.showLabel ? "번역" : nil,
+      control: checkbox
+    )
+
+    let form = BezierForm(fields: [introField, emailField, inlineField])
+
+    context.coordinator.introField = introField
+    context.coordinator.inlineField = inlineField
+    context.coordinator.introInput = introInput
+    context.coordinator.emailInput = emailInput
+    context.coordinator.checkbox = checkbox
+    context.coordinator.customContentView = customContentView
+
+    let wrapper = UIView()
+    wrapper.addSubview(form)
+    NSLayoutConstraint.activate([
+      form.topAnchor.constraint(equalTo: wrapper.topAnchor),
+      form.leadingAnchor.constraint(equalTo: wrapper.leadingAnchor),
+      form.trailingAnchor.constraint(equalTo: wrapper.trailingAnchor),
+      form.bottomAnchor.constraint(equalTo: wrapper.bottomAnchor),
+    ])
+    return wrapper
+  }
+
+  func updateUIView(_ wrapper: UIView, context: Context) {
+    let coordinator = context.coordinator
+    guard
+      let introField = coordinator.introField,
+      let inlineField = coordinator.inlineField,
+      let introInput = coordinator.introInput,
+      let emailInput = coordinator.emailInput,
+      let checkbox = coordinator.checkbox
+    else { return }
+
+    introField.labelText = self.showLabel ? "소개글" : nil
+    introField.fieldDescription = self.showDescription ? self.introDescription : nil
+    introField.isRequired = self.isRequired
+    introField.errorText = self.hasError ? self.introError : nil
+    introInput.hasError = self.hasError
+    introInput.isEnabled = self.isEnabled
+    if introInput.text != self.introText { introInput.text = self.introText }
+
+    emailInput.isEnabled = self.isEnabled
+    if emailInput.text != self.emailText { emailInput.text = self.emailText }
+
+    inlineField.labelText = self.showLabel ? "번역" : nil
+    inlineField.fieldDescription = self.showDescription ? self.inlineDescription : nil
+    inlineField.customContent = self.hasCustomContent ? coordinator.customContentView : nil
+    checkbox.isEnabled = self.isEnabled
+  }
+
+  func sizeThatFits(_ proposal: ProposedViewSize, uiView: UIView, context: Context) -> CGSize? {
+    let width = proposal.width ?? 320
+    let fitting = uiView.systemLayoutSizeFitting(
+      CGSize(width: width, height: UIView.layoutFittingCompressedSize.height),
+      withHorizontalFittingPriority: .required,
+      verticalFittingPriority: .fittingSizeLevel
+    )
+    return CGSize(width: width, height: fitting.height)
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierForm/BezierForm.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierForm/BezierForm.swift
@@ -1,0 +1,75 @@
+//
+//  BezierForm.swift
+//  BezierSwift
+//
+
+import UIKit
+
+/// 한 번에 함께 검증·제출되어야 하는 FormField들의 컨테이너 (UIKit). `BezierFormField`를 세로로 쌓으며 필드 간 간격은 필드 자체의 하단 패딩이 담당한다. 즉시 저장이 필요한 화면에는 Form이 아닌 `BezierSection` 계열을 사용한다. submit 액션(예: 내비게이션 바 저장 버튼)과 카드 chrome 조합은 화면(소비자) 책임이다. SwiftUI에서는 `SUBezierForm`을 사용한다.
+public final class BezierForm: UIView {
+  // MARK: - Public Properties
+
+  /// 현재 표시 중인 필드 뷰 배열. 읽기 전용이며 `setFields(_:)`/`addField(_:)`로 변경한다.
+  public private(set) var fields: [UIView] = []
+
+  // MARK: - Subviews
+
+  private let rootStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    stackView.alignment = .fill
+    stackView.distribution = .fill
+    stackView.spacing = BezierFormConstant.fieldSpacing
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    return stackView
+  }()
+
+  // MARK: - Init
+
+  /// 초기 필드 배열로 폼을 만든다. 필드는 이후 `setFields(_:)`/`addField(_:)`로 교체·추가할 수 있다.
+  public init(fields: [UIView] = []) {
+    self.fields = fields
+    super.init(frame: .zero)
+    self.setUp()
+  }
+
+  public required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    self.setUp()
+  }
+
+  // MARK: - Setup
+
+  private func setUp() {
+    self.translatesAutoresizingMaskIntoConstraints = false
+
+    self.addSubview(self.rootStackView)
+    NSLayoutConstraint.activate([
+      self.rootStackView.topAnchor.constraint(equalTo: self.topAnchor),
+      self.rootStackView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+      self.rootStackView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+      self.rootStackView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+    ])
+
+    self.rebuildFields()
+  }
+
+  // MARK: - Fields
+
+  /// 필드 배열을 통째로 교체한다.
+  public func setFields(_ fields: [UIView]) {
+    self.fields = fields
+    self.rebuildFields()
+  }
+
+  /// 필드를 끝에 하나 추가한다.
+  public func addField(_ field: UIView) {
+    self.fields.append(field)
+    self.rebuildFields()
+  }
+
+  private func rebuildFields() {
+    self.rootStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+    self.fields.forEach { self.rootStackView.addArrangedSubview($0) }
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierForm/BezierFormField.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierForm/BezierFormField.swift
@@ -1,0 +1,352 @@
+//
+//  BezierFormField.swift
+//  BezierSwift
+//
+
+import UIKit
+
+/// 라벨 · 컨트롤 · 설명 · 에러 메시지를 하나의 필드 행으로 묶는 FormField (UIKit). `BezierForm` 안에서만 사용하고 단독 배치하지 않는다. 컨트롤 슬롯에는 `BezierTextInput` 등 실제 입력 컴포넌트를 넣으며, 에러 시 컨트롤 자체의 에러 표시(`BezierTextInput.hasError` 등)는 소비자가 별도로 지정한다. SwiftUI에서는 `SUBezierFormField`를 사용한다.
+public final class BezierFormField: UIView, BezierComponentable {
+  // MARK: - BezierComponentable
+
+  public var colorTheme: BezierColorTheme { .systemBezierColorTheme() }
+  public var componentTheme: BezierComponentTheme = .normal {
+    didSet {
+      self.errorMessageView.componentTheme = self.componentTheme
+      self.refreshAppearance()
+    }
+  }
+
+  // MARK: - Public Properties
+
+  /// 라벨-컨트롤 배치(top/left) (기본값 `.top`). `left`는 라벨을 전제로 한 배치다.
+  public var labelPosition: BezierFormFieldLabelPosition = .top {
+    didSet {
+      if oldValue != self.labelPosition {
+        self.rebuildContentLayout()
+        self.refreshLabelArea()
+      }
+    }
+  }
+
+  /// 라벨 텍스트. `top`에서 `nil`이면 라벨 영역(설명 포함)을 숨긴다. `left`에서는 라벨 영역이 자리를 유지한다 (기본값 `nil`).
+  public var labelText: String? {
+    didSet { if oldValue != self.labelText { self.refreshLabelArea() } }
+  }
+
+  /// 라벨 부제(필드 의미·입력 형식 안내). `nil`이면 숨긴다 (기본값 `nil`).
+  public var fieldDescription: String? {
+    didSet { if oldValue != self.fieldDescription { self.refreshLabelArea() } }
+  }
+
+  /// 필수 입력 표시. `true`면 라벨 끝에 주황색 `*` 마커를 붙인다 (기본값 `false`).
+  public var isRequired: Bool = false {
+    didSet { if oldValue != self.isRequired { self.refreshLabelArea() } }
+  }
+
+  /// 에러 메시지. `nil`이 아니면 필드 하단에 에러 메시지 행을 표시한다 (기본값 `nil`).
+  public var errorText: String? {
+    didSet { if oldValue != self.errorText { self.refreshErrorMessage() } }
+  }
+
+  /// 컨트롤 슬롯 뷰. `top`이면 전체 폭, `left`면 우측 정렬(최소 120pt · 최대 200pt)로 배치된다.
+  public var control: UIView? {
+    didSet { self.updateSlot(container: self.controlContainer, old: oldValue, new: self.control) }
+  }
+
+  /// 필드 직속 복합 콘텐츠 슬롯 뷰(전체 폭). `nil`이면 비운다.
+  public var customContent: UIView? {
+    didSet { self.updateSlot(container: self.customContentContainer, old: oldValue, new: self.customContent) }
+  }
+
+  // MARK: - Subviews
+
+  private let rootStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    stackView.alignment = .fill
+    stackView.distribution = .fill
+    stackView.spacing = BezierFormConstant.fieldContentSpacing
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    return stackView
+  }()
+
+  private let contentStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.distribution = .fill
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    return stackView
+  }()
+
+  private let labelAreaStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    stackView.alignment = .leading
+    stackView.distribution = .fill
+    stackView.spacing = BezierFormConstant.labelToDescriptionSpacing
+    stackView.isLayoutMarginsRelativeArrangement = true
+    stackView.directionalLayoutMargins = NSDirectionalEdgeInsets(
+      top: 0,
+      leading: BezierFormConstant.labelAreaLeadingPadding,
+      bottom: 0,
+      trailing: 0
+    )
+    return stackView
+  }()
+
+  private let labelRowStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .horizontal
+    stackView.alignment = .top
+    stackView.distribution = .fill
+    stackView.spacing = BezierFormConstant.labelRowSpacing
+    return stackView
+  }()
+
+  private let titleLabel: UILabel = {
+    let label = UILabel()
+    label.numberOfLines = 1
+    return label
+  }()
+
+  private let requiredMarkerLabel: UILabel = {
+    let label = UILabel()
+    label.numberOfLines = 1
+    return label
+  }()
+
+  private let descriptionLabel: UILabel = {
+    let label = UILabel()
+    label.numberOfLines = 0
+    return label
+  }()
+
+  private let controlContainer = UIView()
+  private let customContentContainer = UIView()
+  private let errorMessageView = BezierFormFieldErrorMessage()
+
+  private var controlLayoutConstraints: [NSLayoutConstraint] = []
+
+  // MARK: - Init
+
+  /// 배치·라벨·설명·필수 여부·에러 메시지·슬롯 뷰로 필드를 만든다.
+  public init(
+    labelPosition: BezierFormFieldLabelPosition = .top,
+    labelText: String? = nil,
+    description: String? = nil,
+    isRequired: Bool = false,
+    errorText: String? = nil,
+    control: UIView? = nil,
+    customContent: UIView? = nil
+  ) {
+    self.labelPosition = labelPosition
+    self.labelText = labelText
+    self.fieldDescription = description
+    self.isRequired = isRequired
+    self.errorText = errorText
+    self.control = control
+    self.customContent = customContent
+    super.init(frame: .zero)
+    self.setUp()
+  }
+
+  public required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    self.setUp()
+  }
+
+  // MARK: - Setup
+
+  private func setUp() {
+    self.translatesAutoresizingMaskIntoConstraints = false
+
+    self.labelAreaStackView.setContentHuggingPriority(UILayoutPriority(1), for: .horizontal)
+    self.labelAreaStackView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+    self.titleLabel.setContentHuggingPriority(.required, for: .horizontal)
+    self.requiredMarkerLabel.setContentHuggingPriority(.required, for: .horizontal)
+    self.requiredMarkerLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
+
+    self.labelRowStackView.addArrangedSubview(self.titleLabel)
+    self.labelRowStackView.addArrangedSubview(self.requiredMarkerLabel)
+    self.labelAreaStackView.addArrangedSubview(self.labelRowStackView)
+    self.labelAreaStackView.addArrangedSubview(self.descriptionLabel)
+
+    self.contentStackView.addArrangedSubview(self.labelAreaStackView)
+    self.contentStackView.addArrangedSubview(self.controlContainer)
+
+    self.rootStackView.addArrangedSubview(self.contentStackView)
+    self.rootStackView.addArrangedSubview(self.customContentContainer)
+    self.rootStackView.addArrangedSubview(self.errorMessageView)
+    self.addSubview(self.rootStackView)
+
+    NSLayoutConstraint.activate([
+      self.rootStackView.topAnchor.constraint(equalTo: self.topAnchor),
+      self.rootStackView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+      self.rootStackView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+      self.rootStackView.bottomAnchor.constraint(
+        equalTo: self.bottomAnchor,
+        constant: -BezierFormConstant.fieldBottomPadding
+      ),
+    ])
+
+    self.updateSlot(container: self.controlContainer, old: nil, new: self.control)
+    self.updateSlot(container: self.customContentContainer, old: nil, new: self.customContent)
+    self.rebuildContentLayout()
+    self.refreshLabelArea()
+    self.refreshErrorMessage()
+  }
+
+  // MARK: - Layout
+
+  private func rebuildContentLayout() {
+    NSLayoutConstraint.deactivate(self.controlLayoutConstraints)
+    self.controlLayoutConstraints = []
+
+    switch self.labelPosition {
+    case .top:
+      self.contentStackView.axis = .vertical
+      self.contentStackView.alignment = .fill
+      self.contentStackView.spacing = BezierFormConstant.labelToControlSpacing
+
+      if let control = self.control {
+        self.controlLayoutConstraints = [
+          control.leadingAnchor.constraint(equalTo: self.controlContainer.leadingAnchor),
+          control.trailingAnchor.constraint(equalTo: self.controlContainer.trailingAnchor),
+        ]
+      }
+
+    case .left:
+      self.contentStackView.axis = .horizontal
+      self.contentStackView.alignment = .top
+      self.contentStackView.spacing = 0
+
+      var constraints = [
+        self.controlContainer.widthAnchor.constraint(
+          greaterThanOrEqualToConstant: BezierFormConstant.inlineControlMinWidth
+        ),
+        self.controlContainer.widthAnchor.constraint(
+          lessThanOrEqualToConstant: BezierFormConstant.inlineControlMaxWidth
+        ),
+      ]
+      if let control = self.control {
+        // controlContainer는 intrinsic size가 없어 스택이 폭을 정할 근거가 없다. 선호 폭을
+        // 최소 폭으로 고정해 남는 폭을 LabelArea가 가져가게 한다. control 폭에 등호를 걸면
+        // 그 등호가 control의 content hugging을 이겨 컨트롤 자체가 컨테이너 폭까지 늘어난다.
+        let preferredWidthConstraint = self.controlContainer.widthAnchor.constraint(
+          equalToConstant: BezierFormConstant.inlineControlMinWidth
+        )
+        preferredWidthConstraint.priority = .defaultHigh
+        // 고유 폭이 없는 컨트롤이 0폭으로 접히지 않게 하는 최후 순위 fallback.
+        // content hugging보다 낮은 우선순위라 고유 폭이 있는 컨트롤은 늘어나지 않는다.
+        let fallbackFillConstraint = control.leadingAnchor.constraint(
+          equalTo: self.controlContainer.leadingAnchor
+        )
+        fallbackFillConstraint.priority = UILayoutPriority(1)
+        constraints += [
+          control.leadingAnchor.constraint(greaterThanOrEqualTo: self.controlContainer.leadingAnchor),
+          control.trailingAnchor.constraint(equalTo: self.controlContainer.trailingAnchor),
+          preferredWidthConstraint,
+          fallbackFillConstraint,
+        ]
+      }
+      self.controlLayoutConstraints = constraints
+    }
+
+    NSLayoutConstraint.activate(self.controlLayoutConstraints)
+  }
+
+  // MARK: - Slot
+
+  private func updateSlot(container: UIView, old: UIView?, new: UIView?) {
+    old?.removeFromSuperview()
+    guard let new else {
+      container.isHidden = true
+      if container === self.controlContainer { self.rebuildContentLayout() }
+      return
+    }
+    new.translatesAutoresizingMaskIntoConstraints = false
+    container.addSubview(new)
+    NSLayoutConstraint.activate([
+      new.topAnchor.constraint(equalTo: container.topAnchor),
+      new.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+    ])
+    if container === self.controlContainer {
+      self.rebuildContentLayout()
+    } else {
+      NSLayoutConstraint.activate([
+        new.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+        new.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+      ])
+    }
+    container.isHidden = false
+  }
+
+  // MARK: - Trait
+
+  public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    self.refreshAppearance()
+  }
+
+  // MARK: - Refresh
+
+  private func refreshAppearance() {
+    self.refreshLabelArea()
+  }
+
+  private func refreshLabelArea() {
+    if let labelText = self.labelText {
+      self.titleLabel.attributedText = BezierFormConstant.labelTypography.attributedString(
+        self,
+        text: labelText,
+        semanticColorToken: BezierFormConstant.labelColor,
+        alignment: .left,
+        lineBreakMode: .byTruncatingTail
+      )
+      self.titleLabel.isHidden = false
+    } else {
+      self.titleLabel.attributedText = nil
+      self.titleLabel.isHidden = true
+    }
+
+    // left 배치는 LabelArea가 상시 표시된다. 라벨이 비어도 컨테이너를 남겨야 남는 폭을
+    // 흡수해 컨트롤이 우측에 고정된다 — 숨기면 space-between 구조가 무너진다.
+    self.labelAreaStackView.isHidden = self.labelText == nil && self.labelPosition == .top
+
+    if self.isRequired {
+      self.requiredMarkerLabel.attributedText = BezierFormConstant.labelTypography.attributedString(
+        self,
+        text: BezierFormConstant.requiredMarkerText,
+        semanticColorToken: BezierFormConstant.requiredMarkerColor,
+        alignment: .left
+      )
+      self.requiredMarkerLabel.isHidden = false
+    } else {
+      self.requiredMarkerLabel.attributedText = nil
+      self.requiredMarkerLabel.isHidden = true
+    }
+
+    if let fieldDescription = self.fieldDescription {
+      self.descriptionLabel.attributedText = BezierFormConstant.descriptionTypography.attributedString(
+        self,
+        text: fieldDescription,
+        semanticColorToken: BezierFormConstant.descriptionColor,
+        alignment: .left
+      )
+      self.descriptionLabel.isHidden = false
+    } else {
+      self.descriptionLabel.attributedText = nil
+      self.descriptionLabel.isHidden = true
+    }
+  }
+
+  private func refreshErrorMessage() {
+    if let errorText = self.errorText {
+      self.errorMessageView.text = errorText
+      self.errorMessageView.isHidden = false
+    } else {
+      self.errorMessageView.text = ""
+      self.errorMessageView.isHidden = true
+    }
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierForm/BezierFormFieldErrorMessage.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierForm/BezierFormFieldErrorMessage.swift
@@ -1,0 +1,125 @@
+//
+//  BezierFormFieldErrorMessage.swift
+//  BezierSwift
+//
+
+import UIKit
+
+/// FormField 하단에 붙는 에러 메시지 행 (UIKit, internal). `BezierFormField`의 `errorText`가 설정될 때만 표시되며 단독 사용하지 않는다.
+final class BezierFormFieldErrorMessage: UIView, BezierComponentable {
+  // MARK: - BezierComponentable
+
+  var colorTheme: BezierColorTheme { .systemBezierColorTheme() }
+  var componentTheme: BezierComponentTheme = .normal {
+    didSet { self.refreshAppearance() }
+  }
+
+  // MARK: - Properties
+
+  var text: String = "" {
+    didSet { if oldValue != self.text { self.refreshText() } }
+  }
+
+  // MARK: - Subviews
+
+  private let rootStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .horizontal
+    stackView.alignment = .top
+    stackView.distribution = .fill
+    stackView.spacing = BezierFormConstant.errorMessageSpacing
+    stackView.isLayoutMarginsRelativeArrangement = true
+    stackView.directionalLayoutMargins = NSDirectionalEdgeInsets(
+      top: 0,
+      leading: BezierFormConstant.errorMessageLeadingPadding,
+      bottom: 0,
+      trailing: 0
+    )
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    return stackView
+  }()
+
+  private let iconBox = UIView()
+
+  private let iconImageView: UIImageView = {
+    let imageView = UIImageView()
+    imageView.contentMode = .scaleAspectFit
+    imageView.image = BezierFormConstant.errorIcon.uiImage?.withRenderingMode(.alwaysTemplate)
+    return imageView
+  }()
+
+  private let textLabel: UILabel = {
+    let label = UILabel()
+    label.numberOfLines = 0
+    return label
+  }()
+
+  // MARK: - Init
+
+  init(text: String = "") {
+    self.text = text
+    super.init(frame: .zero)
+    self.setUp()
+  }
+
+  required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    self.setUp()
+  }
+
+  // MARK: - Setup
+
+  private func setUp() {
+    self.translatesAutoresizingMaskIntoConstraints = false
+    self.layer.cornerRadius = BezierFormConstant.errorMessageCornerRadius
+
+    self.iconBox.setContentHuggingPriority(.required, for: .horizontal)
+    self.iconBox.setContentCompressionResistancePriority(.required, for: .horizontal)
+    self.textLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
+    self.textLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+    self.iconImageView.translatesAutoresizingMaskIntoConstraints = false
+    self.iconBox.addSubview(self.iconImageView)
+    self.rootStackView.addArrangedSubview(self.iconBox)
+    self.rootStackView.addArrangedSubview(self.textLabel)
+    self.addSubview(self.rootStackView)
+
+    NSLayoutConstraint.activate([
+      self.iconBox.widthAnchor.constraint(equalToConstant: BezierFormConstant.errorIconLength),
+      self.iconBox.heightAnchor.constraint(equalToConstant: BezierFormConstant.errorIconBoxHeight),
+      self.iconImageView.widthAnchor.constraint(equalToConstant: BezierFormConstant.errorIconLength),
+      self.iconImageView.heightAnchor.constraint(equalToConstant: BezierFormConstant.errorIconLength),
+      self.iconImageView.centerXAnchor.constraint(equalTo: self.iconBox.centerXAnchor),
+      self.iconImageView.centerYAnchor.constraint(equalTo: self.iconBox.centerYAnchor),
+      self.rootStackView.topAnchor.constraint(equalTo: self.topAnchor),
+      self.rootStackView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+      self.rootStackView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+      self.rootStackView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+    ])
+
+    self.refreshAppearance()
+  }
+
+  // MARK: - Trait
+
+  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    self.refreshAppearance()
+  }
+
+  // MARK: - Refresh
+
+  private func refreshAppearance() {
+    self.iconImageView.tintColor = BezierFormConstant.errorMessageIconColor.palette(self)
+    self.refreshText()
+  }
+
+  private func refreshText() {
+    self.textLabel.attributedText = BezierFormConstant.errorMessageTypography.attributedString(
+      self,
+      text: self.text,
+      semanticColorToken: BezierFormConstant.errorMessageTextColor,
+      alignment: .left
+    )
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierForm/BezierFormSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierForm/BezierFormSpec.swift
@@ -1,0 +1,63 @@
+//
+//  BezierFormSpec.swift
+//  BezierSwift
+//
+
+import CoreGraphics
+
+// MARK: - Label Position
+
+/// FormField의 라벨-컨트롤 배치. Figma `Internal/FormField` 컴포넌트의 `labelPosition` 프로퍼티에 대응 (case 이름 = Figma 값).
+public enum BezierFormFieldLabelPosition: CaseIterable {
+  /// 라벨 아래에 컨트롤이 전체 폭으로 깔리는 stacked 배치 (기본값). TextInput처럼 넓은 컨트롤에 쓴다.
+  case top
+  /// 라벨 좌측 · 컨트롤 우측의 inline 배치. Switch·Select처럼 compact한 컨트롤에 쓴다. 컨트롤 영역은 최소 120pt · 최대 200pt 폭으로 우측 정렬된다. 라벨을 전제로 한 배치라 라벨을 비워도 라벨 영역은 자리를 유지한다.
+  case left
+}
+
+// MARK: - Constant
+
+/// Form 계열의 Figma 실측 레이아웃 상수. 폼 주변에 커스텀 뷰를 붙일 때 간격을 맞추는 용도로 공개한다.
+public enum BezierFormConstant {
+  /// Form이 필드 사이에 주는 간격. 필드 간 여백은 `fieldBottomPadding`이 담당하므로 0이다.
+  public static let fieldSpacing: CGFloat = 0
+  /// FormField 루트 세로 간격 (Content · customContent · 에러 메시지 사이).
+  public static let fieldContentSpacing: CGFloat = 6
+  /// FormField 하단 패딩. 폼 안에서 필드 간 실질 간격이 된다.
+  public static let fieldBottomPadding: CGFloat = 24
+  /// `top` 배치에서 라벨 영역과 컨트롤 사이 간격.
+  public static let labelToControlSpacing: CGFloat = 8
+  /// 라벨 영역 좌측 패딩.
+  public static let labelAreaLeadingPadding: CGFloat = 2
+  /// 라벨과 필수 마커(`*`) 사이 간격.
+  public static let labelRowSpacing: CGFloat = 2
+  /// 라벨과 설명 텍스트 사이 간격.
+  public static let labelToDescriptionSpacing: CGFloat = 2
+  /// `left` 배치에서 컨트롤 영역 최소 폭.
+  public static let inlineControlMinWidth: CGFloat = 120
+  /// `left` 배치에서 컨트롤 영역 최대 폭.
+  public static let inlineControlMaxWidth: CGFloat = 200
+  /// 에러 메시지의 아이콘과 텍스트 사이 간격.
+  public static let errorMessageSpacing: CGFloat = 4
+  /// 에러 메시지 좌측 패딩 (라벨 영역 좌측 패딩과 정렬).
+  public static let errorMessageLeadingPadding: CGFloat = 2
+  /// 에러 메시지 행의 코너 반경. 배경이 없어 시각 결과는 없고 Figma 값 보존용이다.
+  public static let errorMessageCornerRadius: CGFloat = 8
+  /// 에러 아이콘을 감싸는 박스 높이. 아이콘은 이 안에서 수직 중앙 정렬된다.
+  public static let errorIconBoxHeight: CGFloat = 16
+  /// 에러 아이콘 한 변 길이.
+  public static let errorIconLength: CGFloat = 10
+
+  static let requiredMarkerText = "*"
+  static let errorIcon: BezierIcon = .errorDiamondFilled
+
+  static let labelTypography: BTSemanticToken = .labelLarge
+  static let descriptionTypography: BTSemanticToken = .textXSmall(weight: .regular)
+  static let errorMessageTypography: BTSemanticToken = .captionMedium(weight: .regular)
+
+  static let labelColor: BCSemanticToken = .textNeutral
+  static let requiredMarkerColor: BCSemanticToken = .textAccentOrange
+  static let descriptionColor: BCSemanticToken = .textNeutralLighter
+  static let errorMessageTextColor: BCSemanticToken = .textAccentOrange
+  static let errorMessageIconColor: BCSemanticToken = .iconAccentOrange
+}

--- a/Sources/BezierSwift/MasterComponent/BezierForm/SPEC.md
+++ b/Sources/BezierSwift/MasterComponent/BezierForm/SPEC.md
@@ -1,0 +1,192 @@
+# BezierForm SPEC
+
+> **SSOT**: [Figma · Mobile-Components / Form (2925:52)](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=2925-52) · [Internal/FormField (2920:46)](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=2920-46) · [Internal/FormFieldErrorMessage (5042:3035)](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=5042-3035)
+> **Design spec doc**: [team-design / bezier-v3 / components / Form-spec.md](https://github.com/channel-io/team-design/blob/main/bezier-v3/components/Form-spec.md) (보조 참조 — 값 충돌 시 Figma 파일 우선)
+
+한 번에 함께 검증·제출되어야 하는 FormField들의 컨테이너 (Figma component description 1행).
+
+## 1. Component Properties
+
+### Form (COMPONENT `2925:52`)
+
+| Property | 값 | 비고 |
+|---|---|---|
+| (variant/property 없음) | — | FormField 인스턴스들의 세로 스택 단일 COMPONENT. 마스터에 FormField 3개 배치 |
+
+### Internal/FormField (CS `2920:46`)
+
+| Property | 값 | 비고 |
+|---|---|---|
+| **labelPosition** | `top`(기본) / `left` | 라벨-컨트롤 배치. top=stacked, left=inline |
+| **label** | TEXT, 기본 `"Label"` | 라벨 텍스트 |
+| **hasLabel** | BOOLEAN, 기본 `true` | LabelArea 표시 여부 — `top` variant에만 배선 (`left`는 LabelArea 상시 표시) |
+| **hasDescription** | BOOLEAN, 기본 `true` | Description(라벨 부제) 표시 여부 |
+| **description** | TEXT, 기본 `"Description text"` | 라벨 부제 텍스트 |
+| **required** | BOOLEAN, 기본 `false` | 라벨 끝 `*` 마커 표시 |
+| **hasError** | BOOLEAN, 기본 `false` | Internal/FormFieldErrorMessage 행 표시 |
+| **hasCustomContent** | BOOLEAN, 기본 `false` | customContentWrapper 표시 |
+| **stackedControl** | SLOT (FILL width, 마스터 placeholder 높이 36) | `top` variant의 컨트롤 슬롯 |
+| **inlineControl** | SLOT (마스터 placeholder 120×36) | `left` variant의 컨트롤 슬롯 |
+| **customContent** | SLOT (FILL width, 마스터 placeholder 높이 100) | 필드 직속 복합 콘텐츠 슬롯 |
+
+### Internal/FormFieldErrorMessage (COMPONENT `5042:3035`)
+
+| Property | 값 | 비고 |
+|---|---|---|
+| **errorTtext** | TEXT, 기본 `"Error message"` | 에러 메시지 텍스트 (Figma 원문 property 이름 그대로 — 오탈자 포함) |
+
+## 2. Layout Spec
+
+### Form 루트 (`2925:52`)
+
+| Part | 값 |
+|---|---|
+| 배치 | 세로 스택, FormField들 FILL width |
+| FormField 간 간격 | `0pt` (필드 간 간격은 FormField 자체의 하단 패딩 24pt가 담당) |
+| 루트 패딩 | 없음 |
+| 마스터 폭 | 303 (사용처 FILL — 예시 프레임 `5042:2490`에서 343) |
+
+### FormField 루트 (variant 공통)
+
+> **파일 내 구조 divergence 실측** — Form 마스터(`2925:52`) 내부의 FormField 인스턴스 3개는 CS(`2920:46`)가 아니라 별도 노드 `2920:34`("FormField/top")를 main component로 참조하며, 아래 표와 다른 stale 구조를 갖는다: ControlGroup에 gap `4pt`가 있고, 그 안에 `Internal/FormFieldErrorMessage` 인스턴스가 아닌 **hidden TEXT 레이어** `ErrorMessage`가 들어 있으며, `hasError` property 자체가 없어 그 텍스트를 표시할 수단이 없다. 반면 CS(`2920:46`)와 예시 프레임(`5042:2490`)의 Form 인스턴스는 아래 표대로 ErrorMessage를 FormField 루트에 배치한다. 아래 값과 §1 FormField 표는 **CS + 예시 프레임 기준**이며 구현도 이를 따른다.
+
+| Part | 값 |
+|---|---|
+| 배치 | 세로 스택: Content → customContentWrapper(있으면) → ErrorMessage(있으면) |
+| 루트 gap | `6pt` |
+| 하단 패딩 | `24pt` |
+| 좌우/상단 패딩 | 없음 |
+
+### Content (labelPosition=top, `2920:45`)
+
+| Part | 값 |
+|---|---|
+| 배치 | 세로 스택 gap `8pt`: LabelArea(hasLabel=true 시) → ControlGroup |
+| ControlGroup | 세로, FILL width. stackedControl 슬롯 FILL width (마스터 placeholder 높이 36 — 실사용 높이는 컨트롤 고유값: 예시에서 TextArea 64, TextInput 40) |
+
+### Content (labelPosition=left, `2920:23`)
+
+| Part | 값 |
+|---|---|
+| 배치 | 가로, 양끝 배치(space-between), 상단 정렬 |
+| LabelArea | 남는 폭 채움 (flex-1, min-width 1) |
+| ControlGroup | min-width `120pt` / max-width `200pt`, 내부 컨트롤 우측 정렬. inlineControl 슬롯 마스터 placeholder 120×36 (실사용 크기는 컨트롤 고유값: 예시에서 Button 81×24) |
+
+### LabelArea (variant 공통)
+
+| Part | 값 |
+|---|---|
+| 배치 | 세로 gap `2pt`: LabelRow → Description(hasDescription=true 시) |
+| 좌측 패딩 | `2pt` |
+| LabelRow | 가로 gap `2pt`: FormLabel → RequiredMarker(`*`, required=true 시) |
+
+### customContentWrapper
+
+| Part | 값 |
+|---|---|
+| 배치 | FILL width, customContent 슬롯 FILL width (마스터 placeholder 높이 100) |
+
+### Internal/FormFieldErrorMessage
+
+| Part | 값 | Figma Variable |
+|---|---|---|
+| 배치 | 가로 gap `4pt`: iconBox → 텍스트(flex-1, break-word), 상단 정렬 | — |
+| radius | `8pt` | `radius/8` |
+| FormField 내 배치 시 좌측 패딩 | `2pt` (인스턴스 오버라이드 — LabelArea 좌측 패딩과 정렬) | — |
+| iconBox | 높이 `16pt`, 아이콘 수직·수평 센터 | — |
+| 아이콘 | `icon/error-diamond-filled` `10×10pt` | `sourceSize/10` |
+
+## 3. 컬러 토큰
+
+| 영역 | Token | Figma Variable | Raw |
+|---|---|---|---|
+| FormLabel 텍스트 | `textNeutral` | `color/text/neutral` | `#000000D9` |
+| RequiredMarker `*` | `textAccentOrange` | `color/text/accent/orange` | `#E67F2B` |
+| Description 텍스트 | `textNeutralLighter` | `color/text/neutral/lighter` | `#00000066` |
+| ErrorMessage 텍스트 | `textAccentOrange` | `color/text/accent/orange` | `#E67F2B` |
+| ErrorMessage 아이콘 | `iconAccentOrange` | `color/icon/accent/orange` | `#E67F2B` |
+
+## 4. Typography
+
+### Case A — Typography Token 사용
+
+| 위치 | Token | Figma Style 이름 |
+|---|---|---|
+| FormLabel · RequiredMarker | `BTSemanticToken.labelLarge` | `Typography/label/large` (15 / 700 / lh 20 / ls 0) |
+| Description | `BTSemanticToken.textXSmall(weight: .regular)` | `Typography/text/xsmall` (12 / 400 / lh 16 / ls 0) |
+| ErrorMessage 텍스트 | `BTSemanticToken.captionMedium(weight: .regular)` | `Typography/caption/medium` (12 / 400 / lh 16 / ls 0) |
+
+### Case B — Custom Typography
+
+없음.
+
+## 5. State 별 시각 동작
+
+| State | 시각 동작 |
+|---|---|
+| default | ErrorMessage 미표시 |
+| hasError=true | FormField 하단(customContent 다음)에 Internal/FormFieldErrorMessage 행 표시 |
+
+- 컨트롤 자체의 에러 보더(예시 프레임 `5042:2490`의 TextArea에 걸린 `State/error` = INNER_SHADOW `color/state/warning` spread 1.5)는 슬롯에 주입되는 컨트롤 컴포넌트(TextInput 등)의 `hasError` state 소관이다. FormField CS의 hasError는 ErrorMessage 행 표시만 배선한다.
+- Form 자체에는 state variant 축 없음.
+
+## 6. 디자이너 가이드라인 (Figma component description 인용)
+
+### Form
+
+- 한 번에 함께 검증·제출되어야 하는 FormField들의 컨테이너. 일괄 제출 방식. hasChanges=false(기본): FormActions 숨김 (pristine 상태) / hasChanges=true: FormActions 출현 → Save 버튼 활성화 (dirty 상태). 즉시 저장이 필요하면 Form이 아닌 Settings 사용. 마지막 FormField의 Divider는 visible=false로 오버라이드됨.
+  - (구조 실측: Mobile COMPONENT `2925:52`에는 hasChanges property·FormActions·Divider 레이어가 존재하지 않음 — FormField 세로 스택만 존재. 예시 프레임 `5042:2490`의 저장 버튼은 Navbar 우측 텍스트 버튼으로 페이지 레벨에 배치됨)
+
+### Internal/FormField
+
+- Used within Form only. Do not place standalone. 레이블·컨트롤·보조텍스트·에러 메시지를 하나의 행으로 묶는 필드 래퍼. Form(일괄 제출) 안에서 사용하며, submit 전 검증 피드백을 인라인으로 표시.
+- layout: inline(Switch·Select 등 compact 컨트롤) / stacked(TextInput 등 넓은 컨트롤)
+- state: default / error (error 시 ErrorMessage 자동 표시 + Control orange stroke)
+- required: true 시 라벨 끝에 `*` 마커 표시 (nullable 필수 입력 필드용)
+- showDescription: 라벨 부제 표시 여부 (CS property 실명은 `hasDescription`)
+- hasCustomContent: true 시 customContent SLOT 표시
+- customContent(SLOT): 해당 필드와 직접 관련된 복합 값 표시·입력용. FILL width.
+- errorMessages(SLOT): ErrorMessage 인스턴스만 배치 가능
+
+### Internal/FormFieldErrorMessage
+
+- Used within FormField only. Do not place standalone. Pill-shaped 에러 알림 박스. FormField의 state=error에서 자동 표시. 다중 에러 시 ErrorMessageStack 안에 수직 스택.
+- errorText: 에러 메시지 텍스트 (TEXT property)
+- Settings에서는 미사용 — 즉시 저장 에러는 롤백+Toast로 처리 (DL-032).
+  - (구조 실측: Mobile FormField CS에는 ErrorMessageStack 레이어 없음 — 단일 ErrorMessage 인스턴스만 배선)
+
+## 7. 매핑되는 코드 심볼
+
+| 정의 | 파일 |
+|---|---|
+| UIKit Form 컨테이너 | `BezierForm.swift` |
+| SwiftUI Form 컨테이너 | `SUBezierForm.swift` |
+| UIKit FormField | `BezierFormField.swift` |
+| SwiftUI FormField | `SUBezierFormField.swift` |
+| UIKit ErrorMessage 행 (internal) | `BezierFormFieldErrorMessage.swift` |
+| SwiftUI ErrorMessage 행 (internal) | `SUBezierFormFieldErrorMessage.swift` |
+| labelPosition / constant | `BezierFormSpec.swift` |
+| 에러 아이콘 | `BezierIcon.errorDiamondFilled` (`icon-error-diamond-filled`) |
+
+## 8. Figma 외 · 협의 사항
+
+Figma에 없는 구현 아키텍처 결정은 아래에 분리 표기한다. SSOT 값이 아니다.
+
+1. **boolean+TEXT 쌍의 optional String 축약**: `hasLabel`+`label` → `labelText: String?`, `hasDescription`+`description` → `description: String?`, `hasError`+`errorTtext` → `errorText: String?` (nil = 미표시). BezierSection의 `labelText: String?` 선례를 따른다.
+   - init 파라미터 레이블은 UIKit·SwiftUI 모두 `description:`이지만, UIKit 저장 프로퍼티명만 `fieldDescription`이다 — `UIView`가 상속하는 `NSObject.description`과 충돌하기 때문이다. SwiftUI는 충돌이 없어 `description` 그대로 쓴다.
+2. **`required` → `isRequired`**: Swift에서 `required`는 선언 수식어 키워드라 프로퍼티명으로 사용하지 않는다.
+3. **FormActions / FormHeader / FormError / FormDivider 스코프 제외**: team-design Form-spec.md §3의 웹 구조 파트들로, Mobile Figma에는 존재하지 않는다. 예시 프레임의 저장 버튼은 Navbar 배치(페이지 소관)다.
+4. **컨트롤 에러 보더는 컨트롤 소관**: FormField는 임의 뷰를 슬롯으로 받으므로 컨트롤의 에러 표시(BezierTextInput `hasError` 등)는 소비자가 별도 지정한다.
+5. **Card 조합은 소비자 책임**: team-design spec상 Form은 Card 안에 배치되지만, `BezierCard`는 chrome만 제공하고 Title·Description은 Card 스코프 밖이므로 조합은 소비자가 구성한다.
+6. **다중 에러 미지원**: Mobile FormField CS가 단일 ErrorMessage만 배선하므로 `errorText`는 단일 문자열이다.
+7. **Form 컨테이너 코드 표면**: UIKit `BezierForm`은 `setFields(_:)`/`addField(_:)`(BezierSection `setItems`/`addItem` 선례), SwiftUI `SUBezierForm`은 `@ViewBuilder` content(bezier-react `<Form>{children}</Form>` 동형)로 받는다.
+8. **ErrorMessage radius 8의 구현 표현**: Figma ErrorMessage 노드는 radius 8만 있고 clip content가 꺼져 있어 배경 없는 행에서 시각 결과가 없다. UIKit은 `layer.cornerRadius`(masksToBounds 없음)로 보존하고, SwiftUI는 배경 없는 radius를 클리핑 없이 표현할 수단이 없어 미적용한다 — 두 경로 모두 렌더 결과는 Figma와 동일.
+9. **`labelPosition == .left` + `labelText == nil`의 처리**: Figma는 `left` variant에서 LabelArea를 상시 표시하며(§1 `hasLabel` 비고) 라벨 없는 `left`를 정의하지 않는다. `labelText`를 두 배치에서 동일하게 optional로 받되, **`left`에서는 nil이어도 LabelArea 컨테이너를 유지**해 남는 폭을 흡수시킨다(라벨 텍스트만 비움) — 컨테이너까지 걷어내면 남는 폭을 흡수할 주체가 사라져 컨트롤이 가운데로 쏠리고 §2의 space-between 구조가 무너지기 때문이다(실측: 필드 폭 200pt에서 컨테이너 부재 시 컨트롤 x=90~110, 유지 시 x=180~200). `top`에서만 nil이 LabelArea 전체를 숨긴다. 별도 이니셜라이저로 타입 강제하는 대신 이 방식을 택한 이유는 배치 축 하나 때문에 public 표면이 두 배가 되기 때문이다.
+
+## 9. Variant 매트릭스
+
+```text
+Form:                  단일 COMPONENT = 2925:52  (variant 축 없음)
+FormField:             labelPosition=top = 2920:45, labelPosition=left = 2920:23  (총 2)
+FormFieldErrorMessage: 단일 COMPONENT = 5042:3035  (variant 축 없음)
+```

--- a/Sources/BezierSwift/MasterComponent/BezierForm/SUBezierForm.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierForm/SUBezierForm.swift
@@ -1,0 +1,40 @@
+//
+//  SUBezierForm.swift
+//  BezierSwift
+//
+
+import SwiftUI
+
+/// 한 번에 함께 검증·제출되어야 하는 FormField들의 컨테이너 (SwiftUI). `SUBezierFormField`를 세로로 쌓으며 필드 간 간격은 필드 자체의 하단 패딩이 담당한다. 즉시 저장이 필요한 화면에는 Form이 아닌 `SUBezierSection` 계열을 사용한다. submit 액션(예: 내비게이션 바 저장 버튼)과 카드 chrome 조합은 화면(소비자) 책임이다. UIKit에서는 `BezierForm`을 사용한다.
+public struct SUBezierForm<Content: View>: View {
+  private let content: Content
+
+  /// FormField들을 담는 콘텐츠 빌더로 폼을 만든다.
+  public init(@ViewBuilder content: () -> Content) {
+    self.content = content()
+  }
+
+  public var body: some View {
+    VStack(alignment: .leading, spacing: BezierFormConstant.fieldSpacing) {
+      self.content
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+  }
+}
+
+struct SUBezierForm_Previews: PreviewProvider {
+  static var previews: some View {
+    ScrollView {
+      SUBezierForm {
+        SUBezierFormField(labelText: "이름", isRequired: true) {
+          SUBezierTextInput(text: .constant(""), placeholder: "이름 입력")
+        }
+
+        SUBezierFormField(labelText: "이메일", description: "회사 이메일을 입력해요") {
+          SUBezierTextInput(text: .constant(""), placeholder: "예: hong@company.com")
+        }
+      }
+      .padding(16)
+    }
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierForm/SUBezierFormField.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierForm/SUBezierFormField.swift
@@ -1,0 +1,185 @@
+//
+//  SUBezierFormField.swift
+//  BezierSwift
+//
+
+import SwiftUI
+
+/// 라벨 · 컨트롤 · 설명 · 에러 메시지를 하나의 필드 행으로 묶는 FormField (SwiftUI). `SUBezierForm` 안에서만 사용하고 단독 배치하지 않는다. 컨트롤 슬롯에는 `SUBezierTextInput` 등 실제 입력 컴포넌트를 넣으며, 에러 시 컨트롤 자체의 에러 표시(`SUBezierTextInput`의 `hasError` 등)는 소비자가 별도로 지정한다. UIKit에서는 `BezierFormField`를 사용한다.
+public struct SUBezierFormField<Control: View, CustomContent: View>: View {
+  private let labelPosition: BezierFormFieldLabelPosition
+  private let labelText: String?
+  private let description: String?
+  private let isRequired: Bool
+  private let errorText: String?
+  private let control: Control
+  private let customContent: CustomContent
+
+  /// 배치·라벨·설명·필수 여부·에러 메시지와 슬롯 빌더로 필드를 만든다.
+  /// - `labelText`: `.top`에서 `nil`이면 라벨 영역(설명 포함)을 숨긴다. `.left`는 라벨을 전제로 한 배치라 `nil`이어도 라벨 영역이 자리를 유지한다.
+  /// - `errorText`: `nil`이 아니면 필드 하단에 에러 메시지 행을 표시한다.
+  /// - `customContent`: 필드 직속 복합 콘텐츠 슬롯(전체 폭).
+  public init(
+    labelPosition: BezierFormFieldLabelPosition = .top,
+    labelText: String? = nil,
+    description: String? = nil,
+    isRequired: Bool = false,
+    errorText: String? = nil,
+    @ViewBuilder control: () -> Control,
+    @ViewBuilder customContent: () -> CustomContent
+  ) {
+    self.labelPosition = labelPosition
+    self.labelText = labelText
+    self.description = description
+    self.isRequired = isRequired
+    self.errorText = errorText
+    self.control = control()
+    self.customContent = customContent()
+  }
+
+  public var body: some View {
+    VStack(alignment: .leading, spacing: BezierFormConstant.fieldContentSpacing) {
+      self.contentView
+
+      if CustomContent.self != EmptyView.self {
+        self.customContent
+          .frame(maxWidth: .infinity, alignment: .leading)
+      }
+
+      if let errorText = self.errorText {
+        SUBezierFormFieldErrorMessage(errorText)
+      }
+    }
+    .padding(.bottom, BezierFormConstant.fieldBottomPadding)
+    .frame(maxWidth: .infinity, alignment: .leading)
+  }
+
+  // MARK: - Content
+
+  @ViewBuilder
+  private var contentView: some View {
+    switch self.labelPosition {
+    case .top:
+      VStack(alignment: .leading, spacing: BezierFormConstant.labelToControlSpacing) {
+        self.labelAreaView
+        self.control
+          .frame(maxWidth: .infinity, alignment: .leading)
+      }
+    case .left:
+      HStack(alignment: .top, spacing: 0) {
+        self.labelAreaView
+          .frame(maxWidth: .infinity, alignment: .leading)
+        self.control
+          .frame(
+            minWidth: BezierFormConstant.inlineControlMinWidth,
+            maxWidth: BezierFormConstant.inlineControlMaxWidth,
+            alignment: .topTrailing
+          )
+          .fixedSize(horizontal: true, vertical: false)
+      }
+    }
+  }
+
+  // left 배치는 LabelArea가 상시 표시된다. 라벨이 비어도 컨테이너를 남겨야 남는 폭을
+  // 흡수해 컨트롤이 우측에 고정된다 — 걷어내면 space-between 구조가 무너진다.
+  @ViewBuilder
+  private var labelAreaView: some View {
+    if self.labelText != nil || self.labelPosition == .left {
+      VStack(alignment: .leading, spacing: BezierFormConstant.labelToDescriptionSpacing) {
+        HStack(alignment: .top, spacing: BezierFormConstant.labelRowSpacing) {
+          if let labelText = self.labelText {
+            Text(labelText)
+              .applyBezierFontStyle(
+                BezierFormConstant.labelTypography,
+                semanticColorToken: BezierFormConstant.labelColor
+              )
+              .lineLimit(1)
+              .truncationMode(.tail)
+          }
+
+          if self.isRequired {
+            Text(BezierFormConstant.requiredMarkerText)
+              .applyBezierFontStyle(
+                BezierFormConstant.labelTypography,
+                semanticColorToken: BezierFormConstant.requiredMarkerColor
+              )
+          }
+        }
+
+        if let description = self.description {
+          Text(description)
+            .applyBezierFontStyle(
+              BezierFormConstant.descriptionTypography,
+              semanticColorToken: BezierFormConstant.descriptionColor
+            )
+            .fixedSize(horizontal: false, vertical: true)
+        }
+      }
+      .padding(.leading, BezierFormConstant.labelAreaLeadingPadding)
+    }
+  }
+}
+
+// MARK: - Convenience init
+
+extension SUBezierFormField where CustomContent == EmptyView {
+  /// 커스텀 콘텐츠 슬롯 없이 만드는 편의 이니셜라이저.
+  public init(
+    labelPosition: BezierFormFieldLabelPosition = .top,
+    labelText: String? = nil,
+    description: String? = nil,
+    isRequired: Bool = false,
+    errorText: String? = nil,
+    @ViewBuilder control: () -> Control
+  ) {
+    self.init(
+      labelPosition: labelPosition,
+      labelText: labelText,
+      description: description,
+      isRequired: isRequired,
+      errorText: errorText,
+      control: control,
+      customContent: { EmptyView() }
+    )
+  }
+}
+
+struct SUBezierFormField_Previews: PreviewProvider {
+  static var previews: some View {
+    ScrollView {
+      SUBezierForm {
+        SUBezierFormField(
+          labelText: "소개글",
+          description: "프로필에 표시할 소개를 입력해요",
+          isRequired: true,
+          errorText: "소개글을 입력해주세요"
+        ) {
+          SUBezierTextInput(
+            text: .constant(""),
+            placeholder: "Placeholder",
+            hasError: true
+          )
+        }
+
+        SUBezierFormField(labelText: "Label") {
+          SUBezierTextInput(text: .constant(""), placeholder: "placeholder")
+        }
+
+        SUBezierFormField(
+          labelPosition: .left,
+          labelText: "번역",
+          description: "Description text",
+          control: {
+            SUBezierCheckbox(label: "사용")
+          },
+          customContent: {
+            RoundedRectangle(cornerRadius: 8)
+              .fill(Color.red.opacity(0.1))
+              .frame(height: 100)
+          }
+        )
+      }
+      .padding(16)
+    }
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierForm/SUBezierFormFieldErrorMessage.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierForm/SUBezierFormFieldErrorMessage.swift
@@ -1,0 +1,41 @@
+//
+//  SUBezierFormFieldErrorMessage.swift
+//  BezierSwift
+//
+
+import SwiftUI
+
+/// FormField 하단에 붙는 에러 메시지 행 (SwiftUI, internal). `SUBezierFormField`의 `errorText`가 설정될 때만 표시되며 단독 사용하지 않는다.
+struct SUBezierFormFieldErrorMessage: View, Themeable {
+  @Environment(\.colorScheme) var colorScheme
+
+  private let text: String
+
+  init(_ text: String) {
+    self.text = text
+  }
+
+  var body: some View {
+    HStack(alignment: .top, spacing: BezierFormConstant.errorMessageSpacing) {
+      BezierFormConstant.errorIcon.image
+        .renderingMode(.template)
+        .resizable()
+        .scaledToFit()
+        .frame(
+          width: BezierFormConstant.errorIconLength,
+          height: BezierFormConstant.errorIconLength
+        )
+        .foregroundColor(self.palette(BezierFormConstant.errorMessageIconColor))
+        .frame(height: BezierFormConstant.errorIconBoxHeight)
+
+      Text(self.text)
+        .applyBezierFontStyle(
+          BezierFormConstant.errorMessageTypography,
+          semanticColorToken: BezierFormConstant.errorMessageTextColor
+        )
+        .fixedSize(horizontal: false, vertical: true)
+    }
+    .padding(.leading, BezierFormConstant.errorMessageLeadingPadding)
+    .frame(maxWidth: .infinity, alignment: .leading)
+  }
+}


### PR DESCRIPTION
## MOB-6351

https://linear.app/channel/issue/MOB-6351

V3 Form 컴포넌트 패밀리(Form / FormField / FormFieldErrorMessage)를 UIKit + SwiftUI로 구현합니다.

## 구현 내용

### 구조

```
BezierForm (FormField 세로 스택 · gap 0)
└── BezierFormField ×N (루트 gap 6 · 하단 패딩 24)
    ├── Content
    │   ├── LabelArea (좌측 패딩 2 · gap 2)
    │   │   ├── LabelRow (gap 2): FormLabel + RequiredMarker `*`
    │   │   └── Description
    │   └── ControlGroup — control 슬롯
    ├── customContentWrapper — customContent 슬롯 (FILL width)
    └── BezierFormFieldErrorMessage (internal · errorText 있을 때만)
```

필드 간 간격은 Form이 아니라 **FormField 자체의 하단 패딩 24pt**가 담당합니다 (Figma Form 루트 gap = 0).

### Form — `BezierForm` / `SUBezierForm`

- UIKit은 `setFields(_:)` / `addField(_:)` (`BezierSection`의 `setItems`/`addItem` 선례), SwiftUI는 `@ViewBuilder` content
- Figma Mobile `Form`(`2925:52`)에 variant 축·FormActions·Divider 레이어가 없어 컨테이너 역할만 담당. submit 액션은 화면(소비자) 책임 — 예시 프레임에서도 저장 버튼은 Navbar에 배치됨

### FormField — `BezierFormField` / `SUBezierFormField`

- `labelPosition` `.top`(stacked) / `.left`(inline) — Figma `labelPosition` 2 variant
  - `.top`: 라벨 아래 컨트롤 전체 폭, Content gap 8
  - `.left`: 가로 space-between, LabelArea flex-1, 컨트롤 영역 min 120 / max 200 우측 정렬
- Figma의 boolean+TEXT 쌍을 optional String으로 축약: `hasLabel`+`label` → `labelText: String?`, `hasDescription`+`description` → `description: String?`, `hasError`+`errorTtext` → `errorText: String?`
- `required` → `isRequired` (Swift 선언 수식어 키워드 회피)
- `control` / `customContent` 슬롯은 임의 뷰를 받음 — 컨트롤 자체의 에러 보더(`BezierTextInput.hasError` 등)는 소비자가 지정
- UIKit은 `traitCollectionDidChange`에서 라벨 토큰 색을 재주입해 다크모드 적응

### FormFieldErrorMessage — `BezierFormFieldErrorMessage` / `SUBezierFormFieldErrorMessage` (internal)

- 가로 gap 4 · 좌측 패딩 2 · iconBox 높이 16 · `BezierIcon.errorDiamondFilled` 10×10 (`iconAccentOrange` template tint)
- 텍스트 `captionMedium(.regular)` / `textAccentOrange`, flex-1 + break-word
- Figma는 단일 ErrorMessage만 배선하므로 다중 에러 미지원 (`errorText`는 단일 문자열)

## Spec 검증

figma-component-spec 사이클로 검증했습니다 (Figma = SSOT). **최종 7/7 차원 + 구현 2/2 패러다임 모두 ✅.**

**Phase 1** — Figma 실측 기반 `SPEC.md` 작성: Form `2925:52` / Internal/FormField `2920:46`(top `2920:45`, left `2920:23`) / Internal/FormFieldErrorMessage `5042:3035`

**Phase 2 — spec 검증 7차원** (5개 검증자 병렬)

| 차원 | 1차 | 최종 |
|---|---|---|
| Properties | ✅ | ✅ |
| Layout | ❌ | ✅ (재검증) |
| Color | ✅ | ✅ |
| Typography | ✅ | ✅ |
| Asset | ✅ | ✅ |
| Spec Noise | ✅ | ✅ |
| Implementation Reference | ❌ | ✅ (재검증) |

- **Layout 재검증 ✅** — 아래 결함 1의 divergence 각주 5개 주장이 전부 Figma 실측과 일치함을 확인. `get_design_context(2925:52)`가 `data-node-id="2920:34"`로 직접 resolve되고(추측이 아닌 MCP 부여 id), 해당 노드가 CS 프레임 `2920:46`의 자식 목록(`2920:45`/`2920:23`)에 없어 별도 노드임이 구조적으로 확인됨. `get_metadata`도 `<text ... hidden="true" />`로 인스턴스가 아닌 TEXT 레이어임을 명시. 예시 프레임(`5042:2490`)은 `<instance name="Internal/FormFieldErrorMessage">`를 FormField 루트에 배치. 수치 표 전수(Form 루트 w303·사용처 w343, FormField gap 6/pb 24, Content-top gap 8·stackedControl h36, Content-left min120/max200·inlineControl 120×36, LabelArea gap 2/pl 2, customContentWrapper FILL h100, ErrorMessage gap 4·radius 8·pl 2 override·iconBox h16·아이콘 10×10)도 1:1 일치.
- **Implementation Reference 재검증 ✅** — §8-1 `fieldDescription` 각주와 §8-5 Card 문구가 코드와 일치(Critical/Minor 0건). §7 파일 7행 · `BezierIcon.errorDiamondFilled` · §4 타이포 3종 시그니처 · §3 컬러 4종 · §2 `BezierFormConstant` 14개 수치 · `BezierFormFieldLabelPosition` 전수 실재 재확인.

**Phase 3 — 구현 검증** UIKit ✅ / SwiftUI ✅ (각 1차 ❌ → 아래 결함 2·3 수정 후 통과)

Figma에 없는 구현 결정(optional String 축약 · `isRequired` 개명 · 웹 전용 FormActions/FormHeader/FormError/FormDivider 스코프 제외 · Card 조합은 소비자 책임 · 다중 에러 미지원 · 컨테이너 API 표면 · radius 8 표현 · `.left`+nil 라벨 처리)은 `SPEC.md` §8에 협의 사항 9개 항목으로 분리 기록했습니다.

잔여 Minor 2건(LabelArea min-width 1 제약 부재, 슬롯 didSet 동일값 가드 부재)은 기능·시각 영향 없음으로 non-blocking 확정했습니다.

### 검증에서 발견·수정한 결함

**1. Figma 파일 내 구조 divergence (SPEC 보강)** — Form 마스터(`2925:52`) 안의 FormField 인스턴스 3개는 CS(`2920:46`)가 아니라 별도 노드 `2920:34`를 참조하는 stale 구조였습니다. 그쪽은 ControlGroup에 gap 4pt가 있고 그 안에 `Internal/FormFieldErrorMessage` 인스턴스가 아닌 **hidden TEXT 레이어**가 들어 있으며 `hasError` property 자체가 없어 표시할 수단이 없습니다. CS와 예시 프레임(`5042:2490`)은 ErrorMessage를 FormField 루트에 배치하므로, **CS + 예시 프레임을 기준**으로 삼고 이 divergence를 SPEC §2에 실측 각주로 남겼습니다.

**2. `.left` + `labelText == nil`에서 space-between 붕괴 (구현 수정)** — 라벨이 nil이면 두 패러다임 모두 LabelArea를 통째로 숨겨, 남는 폭을 흡수할 주체가 사라지면서 컨트롤이 가운데로 쏠렸습니다(`ImageRenderer` 실측: 필드 폭 200pt에서 컨트롤 x=90~110). Figma `left` variant는 LabelArea가 상시 표시(`hasLabel` 미배선)이므로, **`left`에서는 라벨이 비어도 컨테이너를 유지**하도록 고쳤습니다 (`top`에서만 nil이 LabelArea를 숨김). 수정 후 실측 x=180~200으로 우측 정렬 확인. UIKit `labelAreaStackView.isHidden = labelText == nil && labelPosition == .top` / SwiftUI `if labelText != nil || labelPosition == .left`로 논리 동치를 맞췄고, `labelPosition` didSet에 `refreshLabelArea()`를 추가해 런타임 배치 전환 시에도 즉시 재평가되게 했습니다. 양 패러다임 doc comment와 SPEC §8-9에 반영했습니다.

**3. Examples 카탈로그 — UIKit disabled 미반영 (카탈로그 수정)** — `BezierCheckbox`는 `UIControl`이라 SwiftUI가 environment `\.isEnabled`로 `isEnabled`를 강제 동기화합니다. `updateUIView`에서 넣은 값이 되돌려져 isEnabled 토글이 UIKit 프리뷰에만 반영되지 않았습니다. representable 바깥에 `.disabled(!isEnabled)`를 걸어 해소했습니다.

**4. SPEC 노이즈·참조 정리** — §8-5의 PR 번호(git 메타데이터) 제거, §8-1에 UIKit 저장 프로퍼티만 `fieldDescription`인 이유(`NSObject.description` 충돌) 각주 추가, `BezierFormConstant`의 public 상수 14개에 doc comment 추가.

**5. `.left` inline 컨트롤이 컨테이너 폭까지 늘어남 (UIKit 구현 수정, 리뷰 지적)** — UIKit `.left`에서 `controlContainer.widthAnchor == control.widthAnchor`를 `.defaultHigh`(750)로 걸어 컨테이너에 선호 폭을 준 것이, 컨트롤 자신의 content hugging(250)까지 이겨 **컨트롤을 컨테이너 폭(=최소 120pt)만큼 늘려버렸습니다**. 컨트롤 프레임은 trailing에 정확히 붙어 있어(접근성 프레임 실측 x=374.0 통과) 눈에 띄지 않았지만, 늘어난 폭 안에서 `BezierCheckbox`의 콘텐츠가 leading 정렬로 그려지면서 **렌더 결과는 trailing에서 약 63pt 안쪽**에 놓였습니다 (스크린샷 픽셀 실측: 콘텐츠 우측 끝 UIKit x=932px vs SwiftUI x=1119px, 콘텐츠 폭 컨테이너 폭 기준 좌측 정렬).

Figma 실측(`5969:1905` — 예시 프레임의 left variant 인스턴스)은 **ControlGroup `x=223 w=120`(= 343 trailing flush), 그 안의 컨트롤 슬롯 `x=39 w=81`** 로, 컨트롤이 고유 폭을 유지한 채 그룹 안에서 우측 정렬됨을 못 박습니다. 컨테이너 선호 폭을 컨트롤 폭이 아니라 **최소 폭 상수 120pt에 `.defaultHigh`로 고정**하도록 바꿔 이를 맞췄습니다. 컨트롤이 120pt보다 넓으면 `control.leading >= container.leading`(required)이 컨테이너를 밀어 올려 `clamp(max(120, 컨트롤 폭), 120, 200)`이 되며, 고유 폭이 없는 컨트롤이 0폭으로 접히지 않도록 우선순위 1의 leading pin을 fallback으로 남겼습니다. SwiftUI(`.frame(minWidth:maxWidth:alignment: .topTrailing)` + `fixedSize(horizontal:)`)는 이미 동일 동작이라 무수정입니다.

`.left` + `labelText == nil`의 우측 고정(결함 2)은 LabelArea hugging 1이 남는 폭을 흡수하는 구조 그대로라 회귀 없습니다.

**Y 정렬은 결함이 아님 (실측 확인)** — 같이 지적된 "컨트롤 Y가 label 영역과 어긋난다"는 UIKit 고유 결함이 아니었습니다. 동일 스크린샷에서 필드 상단 기준 체크박스 박스의 top 오프셋이 **UIKit·SwiftUI 모두 105px로 정확히 일치**하고(라벨 글리프 ink top 차이 2px, "사용" 텍스트 4px는 UILabel↔`Text` 라인박스 메트릭 차), 양쪽 모두 Figma의 `items-start`(ControlGroup `y=0`, LabelArea `y=0`)를 따릅니다. 시각적으로 체크박스가 라벨보다 낮아 보이는 것은 `BezierCheckbox`가 **Figma 정의대로** 행 높이 40pt · 상하 패딩 8pt(터치 타깃 DL-094)를 갖고 박스를 세로 중앙에 두기 때문이며, FormField가 보정할 대상이 아닙니다.

## 시뮬레이터 검증 (iPhone 17 / iOS 26.4, 라이트·다크)

접근성 프레임(`idb ui describe-all`) + 스크린샷 픽셀 실측으로 검증했습니다. 캡처 원본은 로컬 `Screenshots-MOB-6351/`(미커밋)에 보관 — 필요 시 코멘트로 첨부합니다.

| 확인 항목 | 실측 | 결과 |
|---|---|---|
| stacked(top) 필드 — 라벨/설명/필수 마커/컨트롤 | 라벨 x=30 (카드 28 + LabelArea 좌측 패딩 2) | ✅ |
| inline(left) 필드 — space-between, 컨트롤 우측 정렬 | 컨트롤 **프레임** 우측 끝 x=374.0 (= 402 − 28) SwiftUI·UIKit 동일. 단 UIKit은 프레임만 맞고 **렌더 콘텐츠가 63pt 안쪽**이었음 → 결함 5로 수정 | ⚠️→✅ |
| inline(left) 필드 — 컨트롤 Y (items-start) | 필드 상단 기준 체크박스 top 오프셋 105px, SwiftUI·UIKit 픽셀 일치 | ✅ |
| **`.left` + `labelText == nil`** — 컨트롤이 우측 유지 | 라벨 제거 후에도 우측 끝 x=374.0 유지 (양 패러다임). 중앙 쏠림 없음 | ✅ |
| errorText — ErrorMessage 행 | 텍스트 시작 x=44.0 = 30 + 아이콘 10 + gap 4, 양 패러다임 동일 | ✅ |
| ErrorMessage 색 (아이콘·텍스트) | 라이트 `#E67F2B`(orange400) 4개 영역 전부 정확 일치 | ✅ |
| RequiredMarker `*` 색 | `#E67F2B` 양 패러다임 일치 | ✅ |
| customContent 슬롯 (FILL width, 높이 100) | 블록 높이 정확히 100.00pt 양 패러다임. 켤 때 카드가 106pt 증가 (= 100 + fieldContentSpacing 6) | ✅ |
| customContent OFF 시 phantom 간격 부재 | 필드 간 delta SwiftUI 140.13 / UIKit 140.00 — 6pt 유령 간격 없음 | ✅ |
| description·isRequired 토글 | 끄면 필드 간 delta 140 → 122 (= 설명 lh 16 + gap 2), 양 패러다임 동일 | ✅ |
| **isEnabled 토글 → UIKit 체크박스** | 체크박스 영역 최저 휘도 38 → 168으로 흐려짐. SwiftUI와 픽셀 동일 | ✅ |
| SwiftUI ↔ UIKit 좌표 정합 | 필드 간 delta 차이 최대 0.13pt (SwiftUI 텍스트 메트릭 반올림) | ✅ |
| 다크모드 — UIKit `traitCollectionDidChange` 토큰 재주입 | 라벨 `#CCCCCC` · 설명 `#666666`(white40) · 필수마커/에러 아이콘·텍스트 `#F79847`(orange300) — 5개 토큰 전부 적응, SwiftUI와 완전 일치 | ✅ |

라이트에서 생성된 UIKit 뷰가 런타임 다크 전환 후 5개 토큰 사이트 전부 정확한 다크 값으로 재주입되는 것을 픽셀로 확인했습니다(측정값이 `orange300` / `white40` 토큰 정의와 정확히 일치).

`labelPosition`의 top ↔ left **런타임 전환**은 카탈로그가 노출하지 않아 인앱 실증은 못 했습니다. 다만 같은 `refreshLabelArea()` 경로를 타는 `labelText` 런타임 변경은 위 `.left` + nil 항목으로 실증됐습니다.

## 테스트

- `xcodebuild -scheme BezierSwift` clean build 통과
- `xcodebuild -scheme BezierExamples` clean build 통과
- Examples 카탈로그 (Form) 추가 — showLabel / showDescription / isRequired / hasError / hasCustomContent / isEnabled 토글
- `showLabel`은 1번(stacked) 필드와 inline 필드에 함께 걸어, SPEC §8-9의 `.left` + 라벨 없음 조합을 카탈로그에서 눈으로 확인할 수 있게 했습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * SwiftUI와 UIKit에서 사용할 수 있는 폼 컨테이너와 폼 필드 컴포넌트를 추가했습니다.
  * 라벨을 상단 또는 좌측으로 배치하고, 설명/필수 표시/오류 메시지/커스텀 콘텐츠를 지원합니다.
  * 폼 필드를 추가·교체할 수 있어 구성을 동적으로 변경할 수 있습니다.
  * 카탈로그에서 “Form” 섹션과 관련 예제를 추가했습니다(키보드 닫기 동작 포함).
* **문서**
  * BezierForm의 레이아웃/상태 규칙을 문서화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
