### PR TITLE
[MOB-6353] BezierSelect 컴포넌트 구현 (UIKit + SwiftUI)

### DIFF
--- a/Examples/BezierExamples/BezierExamples/App/CatalogRegistry.swift
+++ b/Examples/BezierExamples/BezierExamples/App/CatalogRegistry.swift
@@ -34,6 +34,7 @@ enum CatalogRegistry {
     .init(id: "progress-bar", title: "ProgressBar", section: .v3Components, destination: AnyView(ProgressBarCatalog())),
     .init(id: "section", title: "Section", section: .v3Components, destination: AnyView(SectionCatalog())),
     .init(id: "section-item", title: "SectionItem", section: .v3Components, destination: AnyView(SectionItemCatalog())),
+    .init(id: "select", title: "Select", section: .v3Components, destination: AnyView(SelectCatalog())),
     .init(id: "spinner", title: "Spinner", section: .v3Components, destination: AnyView(SpinnerCatalog())),
     .init(id: "switch", title: "Switch", section: .v3Components, destination: AnyView(SwitchCatalog())),
     .init(id: "tag", title: "Tag", section: .v3Components, destination: AnyView(TagCatalog())),

--- a/Examples/BezierExamples/BezierExamples/Components/SelectCatalog.swift
+++ b/Examples/BezierExamples/BezierExamples/Components/SelectCatalog.swift
@@ -1,0 +1,271 @@
+import SwiftUI
+import UIKit
+import BezierSwift
+
+private enum SelectLeadingKind: String, CaseIterable {
+  case none
+  case icon
+  case avatar
+  case custom
+}
+
+private enum SelectOptionSpec {
+  static let titles = ["한국어", "English", "日本語"]
+  static let icons: [BezierIcon] = [.globe, .translate, .star]
+  static let descriptions = ["기본 언어", "영어로 표시", "일본어로 표시"]
+}
+
+struct SelectCatalog: View {
+  @State private var container: BezierSelectContainer = .page
+  @State private var leadingKind: SelectLeadingKind = .icon
+  @State private var selectedIndex = 0
+  @State private var showsSelectLabel = true
+  @State private var showsGroup = true
+  @State private var showsGroupLabel = true
+  @State private var showsDivider = false
+  @State private var hasDescription = false
+  @State private var hasCenterSlot = false
+  @State private var isEnabled = true
+
+  var body: some View {
+    CatalogScreen(title: "Select") {
+      self.controls
+      CatalogSection(.swiftUI) { self.swiftUIPreview }
+      CatalogSection(.uiKit) { self.uiKitPreview }
+    }
+  }
+
+  private var controls: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Picker("container", selection: self.$container) {
+        ForEach(BezierSelectContainer.allCases, id: \.self) { container in
+          Text(String(describing: container)).tag(container)
+        }
+      }
+      .pickerStyle(.segmented)
+
+      Picker("leading", selection: self.$leadingKind) {
+        ForEach(SelectLeadingKind.allCases, id: \.self) { kind in
+          Text(kind.rawValue).tag(kind)
+        }
+      }
+      .pickerStyle(.segmented)
+
+      Picker("selected", selection: self.$selectedIndex) {
+        ForEach(SelectOptionSpec.titles.indices, id: \.self) { index in
+          Text(SelectOptionSpec.titles[index]).tag(index)
+        }
+      }
+      .pickerStyle(.segmented)
+
+      Toggle("select label", isOn: self.$showsSelectLabel)
+      Toggle("group", isOn: self.$showsGroup)
+      Toggle("group label", isOn: self.$showsGroupLabel)
+      Toggle("showsDivider", isOn: self.$showsDivider)
+      Toggle("hasDescription", isOn: self.$hasDescription)
+      Toggle("hasCenterSlot", isOn: self.$hasCenterSlot)
+      Toggle("isEnabled", isOn: self.$isEnabled)
+    }
+    .font(.caption)
+  }
+
+  // MARK: - SwiftUI
+
+  private var swiftUIPreview: some View {
+    SUBezierSelect(
+      container: self.container,
+      labelText: self.showsSelectLabel ? "언어" : nil
+    ) {
+      if self.showsGroup {
+        SUBezierSelectGroup(
+          labelText: self.showsGroupLabel ? "최근 사용" : nil,
+          showsDivider: self.showsDivider
+        ) {
+          self.options
+        }
+      } else {
+        self.options
+      }
+    }
+    .disabled(!self.isEnabled)
+    .padding(24)
+    .frame(maxWidth: .infinity)
+    .background(Color(uiColor: .secondarySystemBackground))
+  }
+
+  @ViewBuilder
+  private var options: some View {
+    ForEach(SelectOptionSpec.titles.indices, id: \.self) { index in
+      SUBezierSelectOption(
+        title: SelectOptionSpec.titles[index],
+        description: self.hasDescription ? SelectOptionSpec.descriptions[index] : nil,
+        leading: self.swiftUILeading(icon: SelectOptionSpec.icons[index]),
+        isSelected: self.selectedIndex == index,
+        onSelect: { self.selectedIndex = index },
+        centerSlot: {
+          // 40pt 정사각을 넘겨 슬롯의 클리핑 높이(24pt)를 눈으로 잴 수 있게 한다.
+          if self.hasCenterSlot {
+            RoundedRectangle(cornerRadius: 4).fill(Color.orange).frame(width: 40, height: 40)
+          }
+        }
+      )
+    }
+  }
+
+  private func swiftUILeading(icon: BezierIcon) -> BezierSelectOptionLeading<AnyView> {
+    switch self.leadingKind {
+    case .none:
+      return .none
+    case .icon:
+      return .icon(icon)
+    case .avatar:
+      return .avatar(AnyView(SUBezierAvatar(image: Image("AvatarSample"), size: .size24)))
+    case .custom:
+      return .custom(AnyView(Circle().fill(Color.orange.opacity(0.4))))
+    }
+  }
+
+  // MARK: - UIKit
+
+  private var uiKitPreview: some View {
+    SelectUIKitRepresentable(
+      container: self.container,
+      leadingKind: self.leadingKind,
+      selectedIndex: self.$selectedIndex,
+      showsSelectLabel: self.showsSelectLabel,
+      showsGroup: self.showsGroup,
+      showsGroupLabel: self.showsGroupLabel,
+      showsDivider: self.showsDivider,
+      hasDescription: self.hasDescription,
+      hasCenterSlot: self.hasCenterSlot,
+      isEnabled: self.isEnabled
+    )
+    .padding(24)
+    .frame(maxWidth: .infinity)
+    .background(Color(uiColor: .secondarySystemBackground))
+  }
+}
+
+private struct SelectUIKitRepresentable: UIViewRepresentable {
+  let container: BezierSelectContainer
+  let leadingKind: SelectLeadingKind
+  @Binding var selectedIndex: Int
+  let showsSelectLabel: Bool
+  let showsGroup: Bool
+  let showsGroupLabel: Bool
+  let showsDivider: Bool
+  let hasDescription: Bool
+  let hasCenterSlot: Bool
+  let isEnabled: Bool
+
+  final class Coordinator {
+    var fillConstraints: [NSLayoutConstraint] = []
+    var centerConstraints: [NSLayoutConstraint] = []
+  }
+
+  func makeCoordinator() -> Coordinator { Coordinator() }
+
+  // page는 폭을 채워야 하고 overlay는 240pt 고정이라, 두 제약 세트를 만들어 두고 update에서 갈아끼운다.
+  // page에 center 제약을 쓰면 intrinsic width가 없어 콘텐츠 폭으로 접히고 라벨이 잘린다.
+  func makeUIView(context: Context) -> UIView {
+    let wrapper = UIView()
+    let select = BezierSelect()
+    select.translatesAutoresizingMaskIntoConstraints = false
+    wrapper.addSubview(select)
+    NSLayoutConstraint.activate([
+      select.topAnchor.constraint(equalTo: wrapper.topAnchor),
+      select.bottomAnchor.constraint(equalTo: wrapper.bottomAnchor),
+    ])
+    context.coordinator.fillConstraints = [
+      select.leadingAnchor.constraint(equalTo: wrapper.leadingAnchor),
+      select.trailingAnchor.constraint(equalTo: wrapper.trailingAnchor),
+    ]
+    context.coordinator.centerConstraints = [
+      select.centerXAnchor.constraint(equalTo: wrapper.centerXAnchor),
+      select.leadingAnchor.constraint(greaterThanOrEqualTo: wrapper.leadingAnchor),
+      select.trailingAnchor.constraint(lessThanOrEqualTo: wrapper.trailingAnchor),
+    ]
+    return wrapper
+  }
+
+  func updateUIView(_ wrapper: UIView, context: Context) {
+    guard let select = wrapper.subviews.compactMap({ $0 as? BezierSelect }).first else { return }
+
+    switch self.container {
+    case .page:
+      NSLayoutConstraint.deactivate(context.coordinator.centerConstraints)
+      NSLayoutConstraint.activate(context.coordinator.fillConstraints)
+    case .overlay:
+      NSLayoutConstraint.deactivate(context.coordinator.fillConstraints)
+      NSLayoutConstraint.activate(context.coordinator.centerConstraints)
+    }
+
+    select.container = self.container
+    select.labelText = self.showsSelectLabel ? "언어" : nil
+
+    let options: [UIView] = SelectOptionSpec.titles.indices.map { index in
+      let option = BezierSelectOption(
+        title: SelectOptionSpec.titles[index],
+        description: self.hasDescription ? SelectOptionSpec.descriptions[index] : nil,
+        leading: self.uiKitLeading(icon: SelectOptionSpec.icons[index]),
+        isSelected: self.selectedIndex == index,
+        onSelect: { self.selectedIndex = index }
+      )
+      // .disabled()는 plain UIView representable 안의 중첩 UIControl까지 내려가지 않으므로 직접 주입한다.
+      option.isEnabled = self.isEnabled
+      if self.hasCenterSlot {
+        // SwiftUI와 동일하게 40pt 정사각을 넘겨 슬롯 클리핑 높이를 잴 수 있게 한다.
+        let badge = UIView()
+        badge.translatesAutoresizingMaskIntoConstraints = false
+        badge.backgroundColor = .orange
+        badge.layer.cornerRadius = 4
+        NSLayoutConstraint.activate([
+          badge.widthAnchor.constraint(equalToConstant: 40),
+          badge.heightAnchor.constraint(equalToConstant: 40),
+        ])
+        option.centerSlot = badge
+      }
+      return option
+    }
+
+    if self.showsGroup {
+      select.contents = [
+        BezierSelectGroup(
+          labelText: self.showsGroupLabel ? "최근 사용" : nil,
+          showsDivider: self.showsDivider,
+          options: options
+        )
+      ]
+    } else {
+      select.contents = options
+    }
+  }
+
+  func sizeThatFits(_ proposal: ProposedViewSize, uiView: UIView, context: Context) -> CGSize? {
+    let fitting = uiView.systemLayoutSizeFitting(
+      CGSize(
+        width: proposal.width ?? BezierOverlayConstant.width,
+        height: UIView.layoutFittingCompressedSize.height
+      ),
+      withHorizontalFittingPriority: .fittingSizeLevel,
+      verticalFittingPriority: .fittingSizeLevel
+    )
+    return CGSize(width: proposal.width ?? fitting.width, height: fitting.height)
+  }
+
+  private func uiKitLeading(icon: BezierIcon) -> BezierSelectOptionLeading<UIView> {
+    switch self.leadingKind {
+    case .none:
+      return .none
+    case .icon:
+      return .icon(icon)
+    case .avatar:
+      return .avatar(BezierAvatar(image: UIImage(named: "AvatarSample"), size: .size24))
+    case .custom:
+      let circle = UIView()
+      circle.backgroundColor = UIColor.orange.withAlphaComponent(0.4)
+      circle.layer.cornerRadius = 12
+      return .custom(circle)
+    }
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierBaseItem/BezierBaseItem.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBaseItem/BezierBaseItem.swift
@@ -273,10 +273,11 @@ public final class BezierBaseItem: UIControl, BezierComponentable {
     self.leadingWidthConstraint?.constant = self.size.leadingLength
     self.leadingHeightConstraint?.constant = self.size.leadingLength
     self.minHeightConstraint?.constant = self.size.minHeight
+    let verticalPadding = self.style.verticalPadding ?? self.size.verticalPadding
     self.directionalLayoutMargins = NSDirectionalEdgeInsets(
-      top: self.size.verticalPadding,
+      top: verticalPadding,
       leading: self.style.horizontalPadding,
-      bottom: self.size.verticalPadding,
+      bottom: verticalPadding,
       trailing: self.style.horizontalPadding
     )
     self.centerStackView.directionalLayoutMargins = NSDirectionalEdgeInsets(

--- a/Sources/BezierSwift/MasterComponent/BezierBaseItem/BezierBaseItemSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBaseItem/BezierBaseItemSpec.swift
@@ -44,6 +44,8 @@ public enum BezierBaseItemSize: CaseIterable {
 /// 파생 `*Item` 컴포넌트가 BaseItem을 composition으로 소유할 때 주입하는 내부 스타일. 기본값은 BaseItem 자체(Figma `_BaseItem`) 스펙과 동일하며, public API로는 노출하지 않는다.
 struct BezierBaseItemStyle {
   var horizontalPadding: CGFloat = BezierBaseItemConstant.horizontalPadding
+  /// `nil`이면 `BezierBaseItemSize.verticalPadding`을 그대로 쓴다.
+  var verticalPadding: CGFloat?
   var cornerRadius: CGFloat = BezierBaseItemConstant.cornerRadius
   var centerLeadingInset: CGFloat = BezierBaseItemConstant.centerLeadingInset
   var titleColor: BCSemanticToken = BezierBaseItemConstant.titleColor

--- a/Sources/BezierSwift/MasterComponent/BezierBaseItem/SUBezierBaseItem.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBaseItem/SUBezierBaseItem.swift
@@ -185,7 +185,7 @@ private struct SUBezierBaseItemContainer: ViewModifier, Themeable {
       // 콘텐츠만 축소 — 배경은 full-size 유지 (press scale 피드백)
       .scaleEffect(self.contentScale)
       .padding(.horizontal, self.style.horizontalPadding)
-      .padding(.vertical, self.size.verticalPadding)
+      .padding(.vertical, self.style.verticalPadding ?? self.size.verticalPadding)
       .frame(minHeight: self.size.minHeight)
       .frame(maxWidth: .infinity, alignment: .leading)
       .background(

--- a/Sources/BezierSwift/MasterComponent/BezierSelect/BezierSelect.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierSelect/BezierSelect.swift
@@ -1,0 +1,139 @@
+//
+//  BezierSelect.swift
+//  BezierSwift
+//
+
+import UIKit
+
+/// 미리 정의된 선택지 중 하나를 고르는 단일 선택 목록 (UIKit). 선택적 라벨 + 선택지 목록으로 구성되며, `container`로 인라인 배치(`page`)와 오버레이 카드(`overlay`) 중 하나를 고른다. 목록 콘텐츠에는 `BezierSelectGroup`/`BezierSelectOption`을 넣는다. 진입 트리거·열림/닫힘·앵커 포지셔닝은 사용처 책임이다. SwiftUI에서는 `SUBezierSelect`를 사용한다.
+public final class BezierSelect: UIView, BezierComponentable {
+  // MARK: - BezierComponentable
+
+  public var colorTheme: BezierColorTheme { .systemBezierColorTheme() }
+  public var componentTheme: BezierComponentTheme = .normal {
+    didSet {
+      self.sectionLabel.componentTheme = self.componentTheme
+      self.overlay.componentTheme = self.componentTheme
+    }
+  }
+
+  // MARK: - Public Properties
+
+  /// 목록을 화면에 얹는 방식 (기본값 `.page`).
+  public var container: BezierSelectContainer = .page {
+    didSet { if oldValue != self.container { self.rebuildContainer() } }
+  }
+
+  /// 목록 상단 라벨 텍스트. `nil`이면 라벨을 숨긴다 (기본값 `nil`).
+  public var labelText: String? {
+    didSet { if oldValue != self.labelText { self.refreshLabel() } }
+  }
+
+  /// 목록에 표시할 콘텐츠 뷰 배열(그룹 또는 선택지). 교체하면 목록을 다시 만든다.
+  public var contents: [UIView] = [] {
+    didSet { self.rebuildContents() }
+  }
+
+  // MARK: - Subviews
+
+  private let rootStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    stackView.alignment = .fill
+    stackView.distribution = .fill
+    stackView.spacing = 0
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    return stackView
+  }()
+
+  private let sectionLabel = BezierSectionLabel(text: "", color: .neutralLight)
+
+  private let contentStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    stackView.alignment = .fill
+    stackView.distribution = .fill
+    stackView.spacing = 0
+    return stackView
+  }()
+
+  private let overlay = BezierOverlay()
+
+  // MARK: - Constraints
+
+  private var containerConstraints: [NSLayoutConstraint] = []
+
+  // MARK: - Init
+
+  /// 표현 방식·라벨 텍스트·목록 콘텐츠(그룹/선택지 배열)로 목록을 만든다.
+  public init(
+    container: BezierSelectContainer = .page,
+    labelText: String? = nil,
+    contents: [UIView] = []
+  ) {
+    self.container = container
+    self.labelText = labelText
+    self.contents = contents
+    super.init(frame: .zero)
+    self.setUp()
+  }
+
+  public required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    self.setUp()
+  }
+
+  // MARK: - Setup
+
+  private func setUp() {
+    self.translatesAutoresizingMaskIntoConstraints = false
+
+    self.rootStackView.addArrangedSubview(self.sectionLabel)
+    self.rootStackView.addArrangedSubview(self.contentStackView)
+
+    self.refreshLabel()
+    self.rebuildContents()
+    self.rebuildContainer()
+  }
+
+  // MARK: - Refresh
+
+  private func rebuildContents() {
+    self.contentStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+    self.contents.forEach { self.contentStackView.addArrangedSubview($0) }
+  }
+
+  private func refreshLabel() {
+    self.sectionLabel.text = self.labelText ?? ""
+    self.sectionLabel.isHidden = (self.labelText?.isEmpty ?? true)
+  }
+
+  private func rebuildContainer() {
+    NSLayoutConstraint.deactivate(self.containerConstraints)
+    self.containerConstraints = []
+    self.overlay.content = nil
+    self.rootStackView.removeFromSuperview()
+    self.overlay.removeFromSuperview()
+
+    switch self.container {
+    case .page:
+      self.addSubview(self.rootStackView)
+      self.containerConstraints = [
+        self.rootStackView.topAnchor.constraint(equalTo: self.topAnchor),
+        self.rootStackView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+        self.rootStackView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+        self.rootStackView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+      ]
+    case .overlay:
+      self.overlay.content = self.rootStackView
+      self.addSubview(self.overlay)
+      self.containerConstraints = [
+        self.overlay.topAnchor.constraint(equalTo: self.topAnchor),
+        self.overlay.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+        self.overlay.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+        self.overlay.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+      ]
+    }
+    NSLayoutConstraint.activate(self.containerConstraints)
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierSelect/BezierSelectGroup.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierSelect/BezierSelectGroup.swift
@@ -1,0 +1,115 @@
+//
+//  BezierSelectGroup.swift
+//  BezierSwift
+//
+
+import UIKit
+
+/// `BezierSelect` 안에서 선택지를 카테고리별로 묶는 그룹 컨테이너 (UIKit). 선택적 라벨 + 선택지 목록 + 선택적 하단 구분선으로 구성된다. 단일 그룹이면 그룹 없이 `BezierSelectOption`을 직접 나열한다. SwiftUI에서는 `SUBezierSelectGroup`을 사용한다.
+public final class BezierSelectGroup: UIView, BezierComponentable {
+  // MARK: - BezierComponentable
+
+  public var colorTheme: BezierColorTheme { .systemBezierColorTheme() }
+  public var componentTheme: BezierComponentTheme = .normal {
+    didSet {
+      self.sectionLabel.componentTheme = self.componentTheme
+      self.divider.componentTheme = self.componentTheme
+    }
+  }
+
+  // MARK: - Public Properties
+
+  /// 그룹 라벨 텍스트. `nil`이면 라벨을 숨긴다 (기본값 `nil`) — 복수 그룹일 때만 지정한다.
+  public var labelText: String? {
+    didSet { if oldValue != self.labelText { self.refreshLabel() } }
+  }
+
+  /// 그룹 하단 구분선 표시 여부 (기본값 `false`).
+  public var showsDivider: Bool = false {
+    didSet { self.divider.isHidden = !self.showsDivider }
+  }
+
+  /// 현재 표시 중인 선택지 뷰 배열. 교체하면 목록을 다시 만든다.
+  public var options: [UIView] = [] {
+    didSet { self.rebuildOptions() }
+  }
+
+  // MARK: - Subviews
+
+  private let rootStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    stackView.alignment = .fill
+    stackView.distribution = .fill
+    stackView.spacing = 0
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    return stackView
+  }()
+
+  private let sectionLabel = BezierSectionLabel(text: "", color: .neutralLight)
+
+  private let optionsStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    stackView.alignment = .fill
+    stackView.distribution = .fill
+    stackView.spacing = 0
+    return stackView
+  }()
+
+  private let divider = BezierDivider()
+
+  // MARK: - Init
+
+  /// 라벨 텍스트·구분선 여부·초기 선택지 배열로 그룹을 만든다.
+  public init(
+    labelText: String? = nil,
+    showsDivider: Bool = false,
+    options: [UIView] = []
+  ) {
+    self.labelText = labelText
+    self.showsDivider = showsDivider
+    self.options = options
+    super.init(frame: .zero)
+    self.setUp()
+  }
+
+  public required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    self.setUp()
+  }
+
+  // MARK: - Setup
+
+  private func setUp() {
+    self.translatesAutoresizingMaskIntoConstraints = false
+
+    self.rootStackView.addArrangedSubview(self.sectionLabel)
+    self.rootStackView.addArrangedSubview(self.optionsStackView)
+    self.rootStackView.addArrangedSubview(self.divider)
+    self.addSubview(self.rootStackView)
+
+    NSLayoutConstraint.activate([
+      self.rootStackView.topAnchor.constraint(equalTo: self.topAnchor),
+      self.rootStackView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+      self.rootStackView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+      self.rootStackView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+    ])
+
+    self.divider.isHidden = !self.showsDivider
+    self.refreshLabel()
+    self.rebuildOptions()
+  }
+
+  // MARK: - Refresh
+
+  private func refreshLabel() {
+    self.sectionLabel.text = self.labelText ?? ""
+    self.sectionLabel.isHidden = (self.labelText?.isEmpty ?? true)
+  }
+
+  private func rebuildOptions() {
+    self.optionsStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+    self.options.forEach { self.optionsStackView.addArrangedSubview($0) }
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierSelect/BezierSelectOption.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierSelect/BezierSelectOption.swift
@@ -1,0 +1,185 @@
+//
+//  BezierSelectOption.swift
+//  BezierSwift
+//
+
+import UIKit
+
+/// `BezierSelect` 목록 안에 넣는 단일 선택지 (UIKit). leading(아이콘/아바타/커스텀) · 제목 · description · centerSlot으로 구성되며, 선택되면 우측에 체크 아이콘이 붙는다. 선택이 값으로 남지 않고 일회성 액션을 실행한다면 `BezierDropdownMenuItem`을, 선택 개념이 없는 일반 리스트 행에는 `BezierBaseItem`을 쓴다. SwiftUI에서는 `SUBezierSelectOption`을 사용한다.
+public final class BezierSelectOption: UIView, BezierComponentable {
+  // MARK: - BezierComponentable
+
+  public var colorTheme: BezierColorTheme { .systemBezierColorTheme() }
+  public var componentTheme: BezierComponentTheme = .normal {
+    didSet {
+      self.baseItem.componentTheme = self.componentTheme
+      self.refreshAppearance()
+    }
+  }
+
+  // MARK: - Public Properties
+
+  /// 선택지 제목. 빈 문자열이면 제목을 숨긴다.
+  public var title: String {
+    get { self.baseItem.title }
+    set { self.baseItem.title = newValue }
+  }
+
+  /// 제목 아래 보조 설명. `nil`/빈 문자열이면 숨긴다.
+  public var itemDescription: String? {
+    get { self.baseItem.itemDescription }
+    set { self.baseItem.itemDescription = newValue }
+  }
+
+  /// leading 콘텐츠 유형(none/icon/avatar/custom) (기본값 `.none`).
+  public var leading: BezierSelectOptionLeading<UIView> = .none {
+    didSet { self.refreshLeading() }
+  }
+
+  /// 제목 우측에 인라인으로 붙는 슬롯 뷰(높이 24, 초과 시 잘린다). `nil`이면 비운다.
+  public var centerSlot: UIView? {
+    didSet {
+      self.baseItem.centerSlot = self.centerSlot.map { self.makeCenterSlotContainer($0) }
+    }
+  }
+
+  /// 현재 선택된 항목인지 여부. `true`면 우측에 체크 아이콘이 표시된다 (기본값 `false`). 한 목록에서 동시에 하나만 `true`가 되도록 하는 것은 사용처 책임이다.
+  public var isSelected: Bool = false {
+    didSet { if oldValue != self.isSelected { self.refreshSelection() } }
+  }
+
+  /// 항목을 탭했을 때 실행되는 선택 핸들러. `nil`이면 비인터랙티브(pressed 없음)가 된다.
+  public var onSelect: (() -> Void)? {
+    get { self.baseItem.onTap }
+    set { self.baseItem.onTap = newValue }
+  }
+
+  /// 항목 활성 여부. `false`면 흐리게(opacity 0.4) 표시되고 입력이 차단된다 (기본값 `true`).
+  public var isEnabled: Bool {
+    get { self.baseItem.isEnabled }
+    set { self.baseItem.isEnabled = newValue }
+  }
+
+  // MARK: - Subviews
+
+  private let baseItem: BezierBaseItem
+
+  private let leadingIconImageView: UIImageView = {
+    let imageView = UIImageView()
+    imageView.contentMode = .scaleAspectFit
+    return imageView
+  }()
+
+  private let checkImageView: UIImageView = {
+    let imageView = UIImageView()
+    imageView.contentMode = .scaleAspectFit
+    imageView.translatesAutoresizingMaskIntoConstraints = false
+    NSLayoutConstraint.activate([
+      imageView.widthAnchor.constraint(equalToConstant: BezierSelectOptionConstant.checkIconLength),
+      imageView.heightAnchor.constraint(equalToConstant: BezierSelectOptionConstant.checkIconLength),
+    ])
+    return imageView
+  }()
+
+  // MARK: - Init
+
+  /// 제목·description·leading·선택 여부·선택 핸들러로 선택지를 만든다. centerSlot은 생성 후 프로퍼티로 지정한다.
+  public init(
+    title: String,
+    description: String? = nil,
+    leading: BezierSelectOptionLeading<UIView> = .none,
+    isSelected: Bool = false,
+    onSelect: (() -> Void)? = nil
+  ) {
+    self.leading = leading
+    self.isSelected = isSelected
+    self.baseItem = BezierBaseItem(
+      size: .medium,
+      title: title,
+      description: description,
+      onTap: onSelect
+    )
+    super.init(frame: .zero)
+    self.setUp()
+  }
+
+  public required init?(coder: NSCoder) {
+    self.baseItem = BezierBaseItem(size: .medium, title: "")
+    super.init(coder: coder)
+    self.setUp()
+  }
+
+  // MARK: - Setup
+
+  private func setUp() {
+    self.translatesAutoresizingMaskIntoConstraints = false
+    self.baseItem.style = BezierSelectOptionConstant.baseItemStyle
+    self.addSubview(self.baseItem)
+    NSLayoutConstraint.activate([
+      self.baseItem.topAnchor.constraint(equalTo: self.topAnchor),
+      self.baseItem.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+      self.baseItem.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+      self.baseItem.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+    ])
+
+    self.checkImageView.image = BezierIcon.check.uiImage?.withRenderingMode(.alwaysTemplate)
+
+    self.refreshLeading()
+    self.refreshSelection()
+    self.refreshAppearance()
+  }
+
+  // MARK: - Slot
+
+  // 슬롯 컨테이너는 intrinsic width가 없어 BaseItem 행의 여분 폭이 hugging 설정과 무관하게
+  // 이 컨테이너로 분배될 수 있다. 콘텐츠를 leading으로 정렬해 컨테이너가 늘어나도 시각 결과가
+  // Figma(centerSlot이 label 바로 옆)와 같게 한다.
+  private func makeCenterSlotContainer(_ view: UIView) -> UIView {
+    let container = UIView()
+    container.clipsToBounds = true
+    container.setContentHuggingPriority(.required, for: .horizontal)
+    container.setContentCompressionResistancePriority(.required, for: .horizontal)
+    view.translatesAutoresizingMaskIntoConstraints = false
+    container.addSubview(view)
+    NSLayoutConstraint.activate([
+      container.heightAnchor.constraint(equalToConstant: BezierSelectOptionConstant.centerSlotHeight),
+      view.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+      view.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+      view.trailingAnchor.constraint(lessThanOrEqualTo: container.trailingAnchor),
+    ])
+    return container
+  }
+
+  // MARK: - Trait
+
+  public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    self.refreshAppearance()
+  }
+
+  // MARK: - Refresh
+
+  private func refreshLeading() {
+    switch self.leading {
+    case .none:
+      self.baseItem.leadingContent = nil
+    case .icon(let icon):
+      self.leadingIconImageView.image = icon.uiImage?.withRenderingMode(.alwaysTemplate)
+      self.baseItem.leadingContent = self.leadingIconImageView
+    case .avatar(let view), .custom(let view):
+      self.baseItem.leadingContent = view
+    }
+    self.refreshAppearance()
+  }
+
+  private func refreshSelection() {
+    self.baseItem.trailingContent = self.isSelected ? self.checkImageView : nil
+  }
+
+  private func refreshAppearance() {
+    if case .icon = self.leading {
+      self.leadingIconImageView.tintColor = BezierSelectOptionConstant.leadingIconColor.palette(self)
+    }
+    self.checkImageView.tintColor = BezierSelectOptionConstant.checkIconColor.palette(self)
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierSelect/BezierSelectSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierSelect/BezierSelectSpec.swift
@@ -1,0 +1,61 @@
+//
+//  BezierSelectSpec.swift
+//  BezierSwift
+//
+
+import CoreGraphics
+
+// MARK: - Container
+
+/// 선택 목록을 화면에 어떻게 얹을지 정하는 표현 방식. Figma `Select`의 `container` 프로퍼티에 대응 (case 이름 = Figma 값). Figma의 `bottomsheet`는 대응 쉘 컴포넌트가 없어 제공하지 않는다 — bottom sheet 안에서는 `.page`를 시트 콘텐츠로 넣는다.
+public enum BezierSelectContainer: CaseIterable {
+  /// 화면에 인라인으로 목록을 그대로 배치한다. bottom sheet·전체 화면 등 이미 확보된 영역 안에 넣을 때 쓰는 기본값이다.
+  case page
+  /// `BezierOverlay` 카드(240pt 고정 폭)로 감싼다. 트리거 근처에 backdrop 없이 띄우는 앵커형 팝오버 맥락(태블릿·넓은 화면)에 쓴다.
+  case overlay
+}
+
+// MARK: - Option Leading
+
+/// 선택 항목의 leading(좌측) 콘텐츠 유형. Figma `Internal/SelectOption`의 `leadingType` 프로퍼티에 대응 (case 이름 = Figma 값). `Content`는 슬롯에 넣을 뷰 타입이다. 한 목록 안에서는 전 항목에 일관되게 쓰거나 전부 생략한다 — 일부만 넣으면 텍스트 시작 위치가 어긋난다.
+public enum BezierSelectOptionLeading<Content> {
+  /// leading 없이 텍스트만 시작하는 항목. 텍스트만으로 선택지가 충분히 구분될 때 쓴다.
+  case none
+  /// `BezierIcon` 자산을 leading 아이콘으로 표시한다 (Figma `leadingIconSource`). 아이콘이 선택지의 유형·의미를 대표할 때 쓴다.
+  case icon(BezierIcon)
+  /// 사람·엔티티를 고르는 목록에서 `BezierAvatar`를 24×24 leading 슬롯에 배치한다 (Figma `leadingType=avatar`).
+  case avatar(Content)
+  /// 위 셋으로 표현되지 않는 임의의 뷰를 24×24 leading 슬롯에 배치한다 (Figma `leadingContent` SLOT).
+  case custom(Content)
+
+  var hasLeadingContent: Bool {
+    if case .none = self { return false }
+    return true
+  }
+}
+
+// MARK: - Constant
+
+/// 선택 항목(`BezierSelectOption` / `SUBezierSelectOption`)의 레이아웃 상수. Figma `Internal/SelectOption` 실측값이다.
+public enum BezierSelectOptionConstant {
+  /// 항목 좌우 패딩.
+  public static let horizontalPadding: CGFloat = 10
+  /// 항목 상하 패딩. 최소 높이 48을 넘기는 경우(description 표시)에만 실제 높이에 반영된다.
+  public static let verticalPadding: CGFloat = 8
+  /// 항목 배경 corner radius. pressed 배경과 콘텐츠 클리핑에 함께 쓰인다.
+  public static let cornerRadius: CGFloat = 16
+  /// 선택 표시 체크 아이콘의 한 변 길이.
+  public static let checkIconLength: CGFloat = 24
+  /// 제목 우측 인라인 슬롯의 고정 높이. 초과하는 콘텐츠는 잘린다.
+  public static let centerSlotHeight: CGFloat = 24
+
+  static let leadingIconColor: BCSemanticToken = .iconNeutralHeavy
+  static let checkIconColor: BCSemanticToken = .iconNeutralHeavier
+
+  static let baseItemStyle = BezierBaseItemStyle(
+    horizontalPadding: BezierSelectOptionConstant.horizontalPadding,
+    verticalPadding: BezierSelectOptionConstant.verticalPadding,
+    cornerRadius: BezierSelectOptionConstant.cornerRadius,
+    centerLeadingInset: 0
+  )
+}

--- a/Sources/BezierSwift/MasterComponent/BezierSelect/SPEC.md
+++ b/Sources/BezierSwift/MasterComponent/BezierSelect/SPEC.md
@@ -1,0 +1,252 @@
+# BezierSelect SPEC
+
+> **SSOT**: [Figma · Mobile-Components / Select (4870:581)](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=4870-581) · [Internal/SelectOption (4670:92)](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=4670-92) · [Internal/SelectGroup (4648:129)](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=4648-129) · [Internal/SelectGroupLabel (4371:28)](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=4371-28)
+> **Design spec doc**: [team-design / bezier-v3 / components / Select-spec.md](https://github.com/channel-io/team-design/blob/main/bezier-v3/components/Select-spec.md) · [BaseOverlay.md](https://github.com/channel-io/team-design/blob/main/bezier-v3/components/BaseOverlay.md) · [BaseItem.md](https://github.com/channel-io/team-design/blob/main/bezier-v3/components/BaseItem.md) (보조 참조 — 값 충돌 시 Figma 파일 우선)
+
+미리 정의된 선택지 중 하나를 고르고, 선택된 항목을 우측 체크 아이콘으로 표시하는 단일 선택 리스트 컴포넌트.
+
+## 1. Component Properties
+
+### Select (CS `4870:581`)
+
+| Figma property key | Type | Default | 옵션 / 값 | 구현 매핑 |
+|---|---|---|---|---|
+| `container` | VARIANT | page | page / bottomsheet / overlay | `BezierSelectContainer` (§9-2) |
+| `hasLabel` | BOOLEAN | false | on / off | 라벨 유무 (`container=page`에서만 렌더) |
+| `content` | SLOT (`1460:39`) | — | `Internal/SelectGroup` 배치 (preferredValues) | content |
+
+총 instance: `container(3) = 3개`
+
+### Internal/SelectGroup (COMPONENT `4648:129`)
+
+| Figma property key | Type | Default | 옵션 / 값 | 구현 매핑 |
+|---|---|---|---|---|
+| `hasLabel` | BOOLEAN | false | on / off | 그룹 라벨 유무 (복수 그룹일 때만 켠다) |
+| `showDivider` | BOOLEAN | false | on / off | 그룹 하단 구분선 |
+| `content` | SLOT (`4648:132`) | — | `Internal/SelectOption` 배치 | options |
+
+단일 COMPONENT — variant 축 없음. 라벨 텍스트 편집은 내부 `Internal/SelectGroupLabel` 인스턴스 프로퍼티로 (CS 레벨 label TEXT prop 없음).
+
+### Internal/SelectGroupLabel (CS `4371:28`)
+
+| Figma property key | Type | Default | 옵션 / 값 | 구현 매핑 |
+|---|---|---|---|---|
+| `color` | VARIANT | neutral-light | `neutral-dark` (`4371:24`) / `neutral-light` (`4371:26`) | 텍스트 색. `Internal/SelectGroup` 내부 인스턴스도 `neutral-light` |
+| `label` | TEXT | "Group Label" | 문자열 | labelText |
+
+총 instance: `color(2) = 2개`
+
+### Internal/SelectOption (CS `4670:92`)
+
+| Figma property key | Type | Default | 옵션 / 값 | 구현 매핑 |
+|---|---|---|---|---|
+| `leadingType` | VARIANT | none | none / icon / avatar / custom | `BezierSelectOptionLeading` |
+| `state` | VARIANT | default | default / pressed / disabled | 인터랙션 상태 (§5) |
+| `content` | TEXT | "Option" | 문자열 | title |
+| `hasDescription` | BOOLEAN | false | on / off | description 유무 |
+| `description` | TEXT | "Description" | 문자열 | description |
+| `hasCenterSlot` | BOOLEAN | false | on / off | centerSlot 유무 |
+| `centerSlot` | SLOT | — | 임의 콘텐츠 | centerSlot |
+| `isSelected` | BOOLEAN | false | on / off | true면 trailing 체크 아이콘 표시 |
+| `leadingIconSource` | INSTANCE_SWAP | icon/plus | 아이콘 인스턴스 (leadingType=icon) | `.icon(BezierIcon)` |
+| `leadingContent` | SLOT | — | 임의 콘텐츠 (leadingType=custom) | `.custom(뷰)` |
+
+총 instance: `leadingType(4) × state(3) = 12개`
+
+## 2. Layout Spec
+
+### Select 루트
+
+| container | 값 |
+|---|---|
+| `page` (`1331:3`) | 세로 스택, gap `0` · padding `0` · 폭 FILL (마스터 목업 폭 `360pt`). `hasLabel` 라벨 → content 순 |
+| `bottomsheet` (`4903:2464`) | `BottomSheet`(`1306:200`) 인스턴스 `360×667pt`. 시트 content 슬롯 padding 상 `12pt` / 좌우 `10pt` |
+| `overlay` (`5150:1162`) | `overlay`(`5078:2253`) 인스턴스 — 폭 `240pt` FIXED · padding `10pt` 균일 · corner radius `32pt`(`radius/32`) · content 폭 `220pt` |
+
+`container=page`의 `hasLabel` 라벨은 `Internal/SelectGroupLabel` 인스턴스이며 루트 기준 x=`10pt`, 폭 `340pt`(= 360 − 10×2)로 배치된다.
+
+### Internal/SelectGroup
+
+| Part | 값 |
+|---|---|
+| 배치 | 세로 스택: GroupLabel(optional) → content → divider(optional), gap `0` |
+| 폭 | 마스터 `260pt` (사용처에서 FILL) |
+| divider | `Divider` 인스턴스 — 선 `1pt` × 폭 FILL, 좌우 인셋 `6pt`, 상하 여백 `6pt` (총 높이 13pt) |
+
+### Internal/SelectGroupLabel
+
+| Part | 값 |
+|---|---|
+| 높이 | 마스터(`4371:28`)와 `container=page` 사용처(`1331:11`)는 min-height `32pt` + HUG. `Internal/SelectGroup` 내부 인스턴스(`4648:130`)만 FIXED `32pt`로 오버라이드 |
+| 좌우 패딩 | `10pt` |
+| corner radius | `8pt` |
+| 텍스트 overflow | 1줄, ellipsis |
+
+### Internal/SelectOption
+
+| Part | 값 |
+|---|---|
+| min height | `48pt`. description 시 콘텐츠 기반으로 늘어나며 Figma 인스턴스 실측은 `55pt`(= 8+24+15+8) — 여기서 15는 description 텍스트 노드의 glyph box 높이이고, 바인딩된 `caption/line-height/medium`은 `16`이다. line-height 기준으로는 `56pt`(= 8+24+16+8)이며 구현은 이쪽을 따른다(§9-12) |
+| padding | 상하 `8pt` / 좌우 `10pt` |
+| corner radius | `16pt` (`radius/16`), overflow clip |
+| 루트 gap | `10pt` (contentWrapper ↔ check 아이콘), 세로 중앙 정렬 |
+| labelWrapper gap | `10pt` (leading ↔ centerContent) — `leadingType≠none`일 때만 |
+| labelRow gap | `4pt` (label ↔ centerSlot) |
+| leading | `24×24pt` 정방형 (icon / avatar / custom 공통) |
+| centerContent 좌측 인셋 | `0` |
+| centerSlot | 폭 HUG × 높이 FIXED, 세로 중앙. **Figma 실측값**: `state=default` `24pt`(y=0) / `state=pressed`·`disabled` `18pt`(y=3) — 세 state의 나머지 지오메트리는 동일하다. **구현은 24pt 고정**(§9-5). 이 행은 Figma 거울이므로 구현값이 아니라 실측값을 적는다 |
+| check 아이콘 | `24×24pt`, 세로 중앙 (`isSelected=true`일 때만) |
+| description 들여쓰기 | `leadingType≠none`이면 `34pt`(= 24 + 10), `none`이면 `0` |
+| label overflow | 1줄 (Figma nowrap — 구현은 truncate) |
+
+## 3. 컬러 토큰 (Figma 사용처 기준)
+
+### Select / overlay (container=overlay)
+
+| 영역 | Token | Figma Variable | Raw |
+|---|---|---|---|
+| overlay 배경 | `surfaceHighest` | `color/surface/highest` | `#FFFFFF` |
+| overlay shadow | `elevationLarge` | `color/elevation/large` | `#00000038` |
+
+`container=page`에는 컬러 레이어 없음 — 순수 레이아웃 컨테이너.
+
+### Internal/SelectGroup
+
+| 영역 | Token | Figma Variable | Raw |
+|---|---|---|---|
+| divider 선 | `borderNeutral` | `color/border/neutral` | `#00000014` |
+
+### Internal/SelectGroupLabel
+
+| color | Token | Figma Variable | Raw |
+|---|---|---|---|
+| `neutral-light` | `textNeutralLighter` | `color/text/neutral/lighter` | `#00000066` |
+| `neutral-dark` | `textNeutral` | `color/text/neutral` | `#000000D9` |
+
+### Internal/SelectOption
+
+| 위치 | Token | Figma Variable | Raw |
+|---|---|---|---|
+| label 텍스트 | `textNeutral` | `color/text/neutral` | `#000000D9` |
+| description 텍스트 | `textNeutralLighter` | `color/text/neutral/lighter` | `#00000066` |
+| leading 아이콘 (leadingType=icon) | `iconNeutralHeavy` | `color/icon/neutral/heavy` | `#00000099` |
+| check 아이콘 (isSelected) | `iconNeutralHeavier` | — *(변수 바인딩 없음)* | `#000000D9` (§9-6) |
+
+| state | 배경 | 기타 |
+|---|---|---|
+| default | 없음 (투명) | — |
+| pressed | `fillNeutralLighter` (`color/fill/neutral/lighter`, `#00000008`) | — |
+| disabled | 없음 | 본체 opacity `opacity/disabled` = 0.4 |
+
+## 4. Typography
+
+### Case A — Typography Token 사용 (전부 토큰)
+
+| 위치 | Token (`BTSemanticToken`) | Figma Style |
+|---|---|---|
+| option label | `.textXLarge(weight: .regular)` | `Typography/text/xlarge` (Inter Regular, size 16, lineHeight 24, letterSpacing `text/letter-spacing/tight` −0.1) |
+| option description | `.captionMedium(weight: .regular)` | `Typography/caption/medium` (Inter Regular, size 12, lineHeight 16, letterSpacing `caption/letter-spacing` 0) |
+| group label | `.textMedium(weight: .bold)` | `Typography/text/medium-bold` (Inter Bold, size 14, lineHeight 18, letterSpacing `text/letter-spacing` 0) |
+
+### Case B — Custom Typography
+
+없음 (모든 텍스트가 토큰 사용).
+
+## 5. State 별 시각 동작 (Internal/SelectOption)
+
+| State | 시각 변화 | 인터랙션 |
+|---|---|---|
+| `default` | 배경 없음 | 활성 |
+| `pressed` | 배경 `fillNeutralLighter` | 활성 (탭 진행 중) |
+| `disabled` | 본체 opacity 0.4, 배경 없음 | 입력 차단 |
+
+`isSelected`는 state와 독립된 BOOLEAN 축이며, true일 때 trailing에 check 아이콘이 추가된다 (세 state 모두에서 동작).
+
+Select / Internal/SelectGroup / Internal/SelectGroupLabel에는 state variant 축 없음 (정적 컨테이너).
+
+## 6. Elevation
+
+| Effect Style | 구성 |
+|---|---|
+| `Elevation/Mobile/3` (container=overlay의 overlay 인스턴스) | DROP_SHADOW · color `color/elevation/large` · offset (0, `elevation/4` = 4) · blur `elevation/20` = 20 · spread 0 |
+
+`container=page`·`container=bottomsheet`의 Select 루트 자체에는 elevation 없음 (bottomsheet의 그림자는 `BottomSheet` 쉘 소유).
+
+## 7. 디자이너 가이드라인 (Figma component description 인용)
+
+### Select (`4870:581`)
+
+- Select 옵션 목록을 BottomSheet 또는 Overlay로 띄워서 제공하거나, 인라인으로 배치한다.
+- `container`: page(인라인 목록 직접 배치) / bottomsheet(BottomSheet로 present) / overlay(앵커형 팝오버로 present — backdrop 없는 floating 카드).
+- `hasLabel`: 그룹 레이블 표시 여부. `content`: 옵션 목록 슬롯 (SelectOption 사용).
+- bottomsheet 사용 시 BottomSheet(Header=false, ContentFooter=false)를 present한다. overlay 사용 시 Overlay 컴포넌트 인스턴스 안에 SelectGroup을 배치해 present한다(backdrop 없음, 태블릿·넓은 화면 등 앵커 기반 맥락).
+- 단일 선택이므로 확인 버튼 없이 항목 선택 즉시 반영.
+- (`container=page`/`bottomsheet`/`overlay` 각 variant description) 항목 선택이 값 표시가 아니라 액션 실행이면 DropdownMenu. (DES-18468) 다중 선택이 필요하면 MultiSelect 사용.
+
+### Internal/SelectGroup (`4648:129`)
+
+- Used within Select only. Do not place standalone. Select 옵션을 카테고리별로 묶는 그룹 컨테이너.
+- `hasLabel`: 그룹 라벨 표시 여부 (기본 false, 복수 그룹일 때만 켠다).
+- `showDivider`: true 시 그룹 하단에 구분선 표시.
+- 단일 그룹일 때는 SelectGroup 없이 SelectOption을 직접 나열할 것.
+
+### Internal/SelectOption (`4670:92`)
+
+- Used within Select only. Do not place standalone. 단일 선택 드롭다운의 개별 선택지 아이템.
+- `leadingType`: none(텍스트 전용) / icon / avatar / custom(SLOT).
+- `isSelected=true` 시 trailing 체크아이콘 자동 표시.
+- `hasDescription=true` 시 높이 자동 확장.
+
+### overlay (`5078:2253` — container=overlay가 내장하는 쉘)
+
+- position 기본 bottom-start, 트리거와 8px 간격, 화면 밖이면 flip, 가장자리 마진 16px (코드 구현 참고용) · backdrop 없음 · 외부 탭 시 닫힘 · 드래그 딜미스 없음.
+
+## 8. 매핑되는 코드 심볼
+
+| 정의 | 파일 |
+|---|---|
+| UIKit 컨테이너 | `BezierSelect.swift` |
+| UIKit 그룹 | `BezierSelectGroup.swift` |
+| UIKit 옵션 | `BezierSelectOption.swift` |
+| SwiftUI 컨테이너 | `SUBezierSelect.swift` |
+| SwiftUI 그룹 | `SUBezierSelectGroup.swift` |
+| SwiftUI 옵션 | `SUBezierSelectOption.swift` |
+| container / leading / constant | `BezierSelectSpec.swift` |
+
+> 재사용 심볼 실재 확인: `BezierOverlay` / `SUBezierOverlay` / `BezierOverlayConstant`(width 240 · padding 10 · cornerRadius 32 · elevation `.mEv3`), `BezierBaseItem` / `SUBezierBaseItem` / `BezierBaseItemStyle`(레이아웃·pressed 배경·press scale·disabled opacity), `BezierSectionLabel` / `SUBezierSectionLabel` + `BezierSectionLabelColor.neutralLight`(그룹 라벨 — 높이 32·좌우 패딩 10·radius 8·`.textMedium(weight: .bold)`·`textNeutralLighter`로 Figma GroupLabel과 동일), `BezierDivider` / `SUBezierDivider` + `BezierDividerConstant`(indentSize 6 · lineThickness 1), `BCSemanticToken`(.textNeutral / .textNeutralLighter / .iconNeutralHeavy / .iconNeutralHeavier / .fillNeutralLighter / .surfaceHighest / .borderNeutral), `BTSemanticToken`(.textXLarge / .captionMedium / .textMedium), `BOGlobalToken.disabled` = 0.4, `BezierIcon.check`.
+
+## 9. Figma 외 · 협의 사항 (구현 결정)
+
+Figma에 없는 구현 아키텍처 결정은 아래에 분리 표기한다. SSOT 값이 아니다.
+
+1. **컴포지션 구조 (MOB-6353 핸드오프)**: SelectOption은 `BezierBaseItem`/`SUBezierBaseItem`을 소유(composition)해 구현한다 (상속 금지 — 채널 정석). 오버레이 패널은 `BezierOverlay`/`SUBezierOverlay` 재사용, 그룹 라벨은 `BezierSectionLabel(color: .neutralLight)` 재사용, 그룹 divider는 `BezierDivider()` 재사용.
+2. **`container=bottomsheet` 미구현**: BezierSwift에는 Figma `BottomSheet`(`1306:200`)에 대응하는 쉘 컴포넌트가 없다(`MasterComponent/` 전수 확인). 해당 variant의 Select 콘텐츠는 `container=page`와 동일한 인라인 리스트이므로, 코드 API의 `BezierSelectContainer`는 `page`/`overlay` 2종만 제공하고 bottom sheet 호스팅은 사용처 책임으로 둔다 (design doc §7 [Mobile] 반응형 "Select가 BottomSheet의 content로 호스팅됨"과 동일 모델).
+3. **BaseItem 내부 스타일 주입**: Figma SelectOption은 BaseItem `medium` 기본값 대비 좌우 패딩 10(↔6)·상하 패딩 8(↔6)·corner radius 16(↔8)·center 좌측 인셋 0(↔2)이 다르다. 이를 위해 internal `BezierBaseItemStyle`에 값을 주입한다 — 상하 패딩 축(`verticalPadding`)은 기존 struct에 없어 옵셔널 필드로 추가하되 `nil`이면 기존 `size.verticalPadding`으로 폴백해 기존 소비자(BaseItem·DropdownMenuItem·SectionItem) 동작과 public API를 모두 그대로 둔다.
+4. **프레젠테이션 스코프 제외**: 열림/닫힘 상태·앵커 포지셔닝·외부 탭 닫힘은 사용처 책임 (BezierOverlay SPEC §9-1 · BezierDropdownMenu SPEC §9-4와 동일 결정). 선택 상태(`isSelected`)의 단일 선택 보장(하나만 true)도 사용처 책임이다 — Figma는 옵션 단위 BOOLEAN만 정의한다.
+5. **centerSlot 높이 24 고정**: Figma는 `state=default`에서 24pt, `pressed`·`disabled`에서 18pt로 centerSlot 프레임 높이가 갈리지만 나머지 지오메트리는 세 state가 완전히 동일하다. 상태에 따라 슬롯 높이가 바뀔 근거가 Figma description·design doc 어디에도 없어 default 값 24pt로 고정 구현한다.
+6. **check 아이콘 색 토큰 매핑**: Figma의 check 인스턴스는 변수 바인딩 없이 raw `#000000D9`로 렌더된다(export SVG의 `fill="black" fill-opacity="0.85"`로 확정, `get_variable_defs` 결과 `{}`). 저장소는 semantic 토큰만 사용하므로 같은 값(light `black85` / dark `white80`)을 갖는 아이콘 계열 토큰 `iconNeutralHeavier`로 매핑한다.
+7. **state 축은 런타임 상태**: Figma `state`(default/pressed/disabled)는 API 옵션이 아니라 런타임 인터랙션 상태로 구현 — pressed는 터치 추적, disabled는 UIKit `isEnabled` / SwiftUI `.disabled()`.
+8. **pressed press-scale**: BaseItem의 press scale 피드백(0.97, 오버슈트 복귀)을 그대로 상속한다 (BaseItem SPEC §7 협의 — Figma 외).
+9. **`hasLabel`/`showDivider`/`has*` boolean 표현**: 코드 API는 `labelText: String?`(nil = 미표시)·`showsDivider: Bool`, 슬롯 계열은 옵셔널/`EmptyView` 분기로 표현 (BezierDropdownMenu §9-7과 동일 관례).
+10. **`container=page` 루트 라벨의 10pt 인셋 미적용**: Figma에서 page 루트의 `hasLabel` 라벨 인스턴스(`1331:11`)는 x=10·폭 340으로 배치되고 라벨 자신도 좌우 패딩 10을 가져 텍스트가 x=20에 온다. 반면 같은 루트의 옵션은 x=0·폭 360이고 옵션 자신의 좌우 패딩 10으로 텍스트가 x=10에 온다 — 라벨 텍스트만 10pt 더 들어간다. 구현은 라벨을 폭 FILL로 두어 텍스트를 x=10에 정렬한다. 근거: ① 이 루트 라벨은 Figma에서 기본 hidden이고 ② 실제 사용 경로인 `Internal/SelectGroup`의 라벨 인스턴스(`4648:130`)는 폭 FILL이라 옵션 텍스트와 정확히 정렬되며 ③ 라벨과 옵션 텍스트의 좌측 정렬이 어긋나는 것은 시각 결함이다. 그룹 라벨과 Select 라벨이 같은 x에 오도록 통일한다.
+11. **그룹 라벨 높이는 min-height 32 + HUG 하나로 통일**: §2대로 Figma는 `Internal/SelectGroup` 내부 라벨 인스턴스(`4648:130`)만 FIXED 32로 오버라이드하고 마스터·page 사용처는 min-height 32 + HUG다. 재사용하는 `BezierSectionLabel`/`SUBezierSectionLabel`은 맥락 구분 없이 min-height 32 + HUG만 제공하며, 라벨이 1줄 고정(ellipsis)이라 두 경우의 렌더 높이가 32pt로 같다. 구분을 코드에 재현하지 않는다.
+12. **description 행 높이는 line-height 16 기준 56pt**: Figma 인스턴스 실측 높이는 55pt지만 이는 description 텍스트 노드가 glyph box(15)로 잡힌 값이고, 노드에 바인딩된 `caption/line-height/medium`은 16이다. iOS는 `BTSemanticToken.captionMedium`의 line-height 16을 그대로 쓰므로 행 높이가 56pt가 된다(시뮬레이터 실측 UIKit·SwiftUI 모두 56.0/56.33pt). 형제 컴포넌트 `BezierDropdownMenu` SPEC도 line-height 16 기준(6+24+16+6=52)으로 기재돼 있다.
+13. **`leadingType=avatar`와 `custom`의 렌더 경로 공유**: Figma는 두 축을 분리하지만 레이아웃은 둘 다 24×24 슬롯으로 동일하다. 코드도 두 case를 모두 제공해 Figma 축을 보존하되 렌더는 같은 경로를 쓴다 — case 구분은 "무엇을 넣는가"(Avatar / 임의 뷰)의 문서적 구분이다.
+
+## 10. Variant 매트릭스
+
+```text
+Select (4870:581, 3):
+  container=page       = 1331:3
+  container=bottomsheet = 4903:2464
+  container=overlay    = 5150:1162
+
+Internal/SelectGroup      = 4648:129   (총 1 — COMPONENT, property만)
+Internal/SelectGroupLabel = color=neutral-dark 4371:24, color=neutral-light 4371:26 (총 2)
+
+Internal/SelectOption (4670:92, 12):
+  leadingType=none,   state=default|pressed|disabled = 4669:1714 | 4669:1720 | 4669:1726
+  leadingType=icon,   state=default|pressed|disabled = 4669:1732 | 4669:1738 | 4669:1744
+  leadingType=avatar, state=default|pressed|disabled = 4669:1750 | 4669:1756 | 4669:1762
+  leadingType=custom, state=default|pressed|disabled = 4669:1768 | 4669:1774 | 4669:1780
+```

--- a/Sources/BezierSwift/MasterComponent/BezierSelect/SUBezierSelect.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierSelect/SUBezierSelect.swift
@@ -1,0 +1,64 @@
+//
+//  SUBezierSelect.swift
+//  BezierSwift
+//
+
+import SwiftUI
+
+/// 미리 정의된 선택지 중 하나를 고르는 단일 선택 목록 (SwiftUI). 선택적 라벨 + 선택지 목록으로 구성되며, `container`로 인라인 배치(`page`)와 오버레이 카드(`overlay`) 중 하나를 고른다. 목록 콘텐츠에는 `SUBezierSelectGroup`/`SUBezierSelectOption`을 넣는다. 진입 트리거·열림/닫힘·앵커 포지셔닝은 사용처 책임이다. UIKit에서는 `BezierSelect`를 사용한다.
+public struct SUBezierSelect<Content: View>: View {
+  private let container: BezierSelectContainer
+  private let labelText: String?
+  private let content: Content
+
+  /// 표현 방식·라벨 텍스트·목록 빌더로 목록을 만든다. 라벨은 목록 전체의 맥락을 나타내며, 그룹별 라벨이 필요하면 `SUBezierSelectGroup`의 `labelText`를 쓴다.
+  public init(
+    container: BezierSelectContainer = .page,
+    labelText: String? = nil,
+    @ViewBuilder content: () -> Content
+  ) {
+    self.container = container
+    self.labelText = labelText
+    self.content = content()
+  }
+
+  public var body: some View {
+    switch self.container {
+    case .page:
+      self.list
+    case .overlay:
+      SUBezierOverlay { self.list }
+    }
+  }
+
+  private var list: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      if let labelText = self.labelText, !labelText.isEmpty {
+        SUBezierSectionLabel(labelText, color: .neutralLight)
+      }
+
+      self.content
+    }
+  }
+}
+
+struct SUBezierSelect_Previews: PreviewProvider {
+  static var previews: some View {
+    VStack(spacing: 32) {
+      SUBezierSelect(labelText: "언어") {
+        SUBezierSelectOption(title: "한국어", isSelected: true, onSelect: {})
+        SUBezierSelectOption(title: "English", onSelect: {})
+        SUBezierSelectOption(title: "日本語", onSelect: {})
+      }
+
+      SUBezierSelect(container: .overlay) {
+        SUBezierSelectGroup(labelText: "정렬 기준") {
+          SUBezierSelectOption(title: "최신순", leading: .icon(.arrowUp), isSelected: true, onSelect: {})
+          SUBezierSelectOption(title: "오래된순", leading: .icon(.arrowDown), onSelect: {})
+        }
+      }
+    }
+    .padding()
+    .background(Color.gray.opacity(0.15))
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierSelect/SUBezierSelectGroup.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierSelect/SUBezierSelectGroup.swift
@@ -1,0 +1,54 @@
+//
+//  SUBezierSelectGroup.swift
+//  BezierSwift
+//
+
+import SwiftUI
+
+/// `SUBezierSelect` 안에서 선택지를 카테고리별로 묶는 그룹 컨테이너 (SwiftUI). 선택적 라벨 + 선택지 목록 + 선택적 하단 구분선으로 구성된다. 단일 그룹이면 그룹 없이 `SUBezierSelectOption`을 직접 나열한다. UIKit에서는 `BezierSelectGroup`을 사용한다.
+public struct SUBezierSelectGroup<Content: View>: View {
+  private let labelText: String?
+  private let showsDivider: Bool
+  private let content: Content
+
+  /// 라벨 텍스트·구분선 여부·선택지 빌더로 그룹을 만든다. 라벨은 복수 그룹일 때만 지정한다.
+  public init(
+    labelText: String? = nil,
+    showsDivider: Bool = false,
+    @ViewBuilder content: () -> Content
+  ) {
+    self.labelText = labelText
+    self.showsDivider = showsDivider
+    self.content = content()
+  }
+
+  public var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      if let labelText = self.labelText, !labelText.isEmpty {
+        SUBezierSectionLabel(labelText, color: .neutralLight)
+      }
+
+      self.content
+
+      if self.showsDivider {
+        SUBezierDivider()
+      }
+    }
+  }
+}
+
+struct SUBezierSelectGroup_Previews: PreviewProvider {
+  static var previews: some View {
+    VStack(spacing: 0) {
+      SUBezierSelectGroup(labelText: "최근 사용", showsDivider: true) {
+        SUBezierSelectOption(title: "한국어", isSelected: true, onSelect: {})
+        SUBezierSelectOption(title: "English", onSelect: {})
+      }
+      SUBezierSelectGroup(labelText: "전체") {
+        SUBezierSelectOption(title: "日本語", onSelect: {})
+        SUBezierSelectOption(title: "Español", onSelect: {})
+      }
+    }
+    .padding()
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierSelect/SUBezierSelectOption.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierSelect/SUBezierSelectOption.swift
@@ -1,0 +1,141 @@
+//
+//  SUBezierSelectOption.swift
+//  BezierSwift
+//
+
+import SwiftUI
+
+/// `SUBezierSelect` 목록 안에 넣는 단일 선택지 (SwiftUI). leading(아이콘/아바타/커스텀) · 제목 · description · centerSlot으로 구성되며, 선택되면 우측에 체크 아이콘이 붙는다. 선택이 값으로 남지 않고 일회성 액션을 실행한다면 `SUBezierDropdownMenuItem`을, 선택 개념이 없는 일반 리스트 행에는 `SUBezierBaseItem`을 쓴다. UIKit에서는 `BezierSelectOption`을 사용한다.
+public struct SUBezierSelectOption<CenterSlot: View>: View, Themeable {
+  @Environment(\.colorScheme) public var colorScheme
+
+  private let title: String
+  private let itemDescription: String?
+  private let leading: BezierSelectOptionLeading<AnyView>
+  private let isSelected: Bool
+  private let onSelect: (() -> Void)?
+  private let centerSlot: CenterSlot
+
+  /// 제목·description·leading·선택 여부·선택 핸들러와 centerSlot 빌더로 선택지를 만든다. 한 목록에서 동시에 하나만 `isSelected`가 되도록 하는 것은 사용처 책임이다.
+  public init(
+    title: String,
+    description: String? = nil,
+    leading: BezierSelectOptionLeading<AnyView> = .none,
+    isSelected: Bool = false,
+    onSelect: (() -> Void)? = nil,
+    @ViewBuilder centerSlot: () -> CenterSlot
+  ) {
+    self.title = title
+    self.itemDescription = description
+    self.leading = leading
+    self.isSelected = isSelected
+    self.onSelect = onSelect
+    self.centerSlot = centerSlot()
+  }
+
+  public var body: some View {
+    // leading 유무를 여기서 분기해 빈 슬롯이 리터럴 EmptyView 타입이 되게 한다
+    // (BaseItem이 타입으로 슬롯 렌더를 거르므로, 옵셔널 뷰를 넘기면 빈 24pt 박스가 남는다).
+    switch self.leading {
+    case .none:
+      self.item(leading: { EmptyView() })
+    case .icon(let icon):
+      self.item(leading: { self.iconView(icon) })
+    case .avatar(let view), .custom(let view):
+      self.item(leading: { view })
+    }
+  }
+
+  private func item<Leading: View>(
+    @ViewBuilder leading: () -> Leading
+  ) -> some View {
+    SUBezierBaseItem(
+      style: BezierSelectOptionConstant.baseItemStyle,
+      size: .medium,
+      title: self.title,
+      description: self.itemDescription,
+      onTap: self.onSelect,
+      leading: leading,
+      centerSlot: { self.centerSlotView },
+      trailing: { self.checkView }
+    )
+  }
+
+  private func iconView(_ icon: BezierIcon) -> some View {
+    icon.image
+      .renderingMode(.template)
+      .resizable()
+      .scaledToFit()
+      .foregroundColor(self.palette(BezierSelectOptionConstant.leadingIconColor))
+  }
+
+  @ViewBuilder
+  private var centerSlotView: some View {
+    if CenterSlot.self != EmptyView.self {
+      self.centerSlot
+        .frame(height: BezierSelectOptionConstant.centerSlotHeight)
+        .clipped()
+    }
+  }
+
+  @ViewBuilder
+  private var checkView: some View {
+    if self.isSelected {
+      BezierIcon.check.image
+        .renderingMode(.template)
+        .resizable()
+        .scaledToFit()
+        .frame(
+          width: BezierSelectOptionConstant.checkIconLength,
+          height: BezierSelectOptionConstant.checkIconLength
+        )
+        .foregroundColor(self.palette(BezierSelectOptionConstant.checkIconColor))
+    }
+  }
+}
+
+// MARK: - Convenience init (centerSlot 생략)
+
+extension SUBezierSelectOption where CenterSlot == EmptyView {
+  /// centerSlot 없이 만드는 편의 이니셜라이저.
+  public init(
+    title: String,
+    description: String? = nil,
+    leading: BezierSelectOptionLeading<AnyView> = .none,
+    isSelected: Bool = false,
+    onSelect: (() -> Void)? = nil
+  ) {
+    self.init(
+      title: title,
+      description: description,
+      leading: leading,
+      isSelected: isSelected,
+      onSelect: onSelect,
+      centerSlot: { EmptyView() }
+    )
+  }
+}
+
+struct SUBezierSelectOption_Previews: PreviewProvider {
+  static var previews: some View {
+    VStack(spacing: 0) {
+      SUBezierSelectOption(title: "한국어", isSelected: true, onSelect: {})
+      SUBezierSelectOption(title: "English", onSelect: {})
+      SUBezierSelectOption(
+        title: "최신순",
+        leading: .icon(.arrowUp),
+        isSelected: true,
+        onSelect: {}
+      )
+      SUBezierSelectOption(
+        title: "오래된순",
+        description: "가장 먼저 등록된 항목부터",
+        leading: .icon(.arrowDown),
+        onSelect: {}
+      )
+      SUBezierSelectOption(title: "비활성 항목", leading: .icon(.lock), onSelect: {})
+        .disabled(true)
+    }
+    .padding()
+  }
+}

--- a/docs/agent/examples-pitfalls.md
+++ b/docs/agent/examples-pitfalls.md
@@ -6,30 +6,49 @@
 
 ## UIKit 브리지
 
-### `UIControl.isEnabled`는 직접 설정해도 되돌려진다
+### disabled를 넘기는 방향은 representable 루트 타입이 가른다
 
-SwiftUI는 `UIViewRepresentable` 안의 `UIControl.isEnabled`를 environment `\.isEnabled`로
-**강제 동기화**한다. factory/update 클로저에서 `isEnabled = false`를 넣어도 즉시 true로
-돌아온다. 데모의 disabled 제어는 representable 바깥에 `.disabled(...)`를 건다.
+SwiftUI의 `\.isEnabled` 강제 동기화는 **representable이 반환하는 루트가 `UIControl`일 때만**
+동작한다. 루트 타입에 따라 조치가 정반대이므로 무엇을 반환하는지부터 확인한다.
+
+| representable 루트 | 증상 | 조치 | 실례 |
+|---|---|---|---|
+| `UIControl` 자신 | factory/update에서 `isEnabled = false`를 넣어도 즉시 true로 되돌려짐 | 바깥에 `.disabled(...)`를 건다 | `CheckboxCatalog.swift` |
+| plain `UIView` wrapper (내부에 `UIControl` 중첩) | `.disabled(...)`가 **중첩된 `UIControl`까지 내려가지 않아** disabled가 아예 시연되지 않음 | 컴포넌트에 `isEnabled`를 직접 주입한다 | `DropdownMenuCatalog.swift` · `SelectCatalog.swift` |
 
 ```swift
+// 루트가 UIControl — 바깥에서 건다
 UIKitWrap({ BezierCheckbox() }, update: { ... })
   .disabled(!self.isEnabled)
+
+// 루트가 wrapper — 안쪽 컴포넌트에 직접 주입한다 (updateUIView)
+option.isEnabled = self.isEnabled
 ```
 
-순수 UIKit 소비자는 영향이 없다 — representable 경로만 해당한다.
+두 번째 케이스는 레이아웃이 멀쩡해 **색으로만 검출된다** — disabled인데 픽셀이 enabled와
+같으면 의심한다. Select에서 슬롯 배지가 `(255,128,0)` 그대로였고, 주입 후 `(247,196,148)`
+= opacity 0.4 합성값이 됐다.
 
-### 폭이 무너지는 두 반대 케이스
+순수 UIKit 소비자는 어느 쪽도 영향이 없다 — representable 경로만 해당한다.
+
+### 폭이 무너지는 세 케이스
 
 `UIKitWrap`은 `systemLayoutSizeFitting(..., withHorizontalFittingPriority: .fittingSizeLevel)`로
-크기를 낸다. 여기서 컴포넌트의 intrinsic width 유무에 따라 정반대 증상이 나온다.
+크기를 낸다. 여기서 컴포넌트의 intrinsic width 유무와 wrapper의 제약 방식에 따라 서로 다른
+증상이 나온다.
 
 | 증상 | 원인 | 조치 | 실례 |
 |---|---|---|---|
 | 아예 안 보임(width 0) | intrinsic width 없는 full-width 뷰(`BezierDivider`) | 전용 representable에서 `sizeThatFits`가 `proposal.width`를 반환 | `DividerCatalog.swift` |
 | full-width로 안 늘어남 | content를 hug하는 intrinsic width 보유(`BezierBanner`) | `makeUIView`가 빈 `UIView` wrapper를 반환하고 컴포넌트를 leading·trailing·top·bottom pin | `BannerCatalog.swift` |
+| 콘텐츠 폭으로 접혀 라벨이 잘림 | intrinsic width 없는 뷰를 wrapper에 `centerXAnchor` + `>=`/`<=`로만 고정 — 부등호는 폭을 **강제하지 못해** hug으로 붕괴한다 | 폭 거동이 다른 variant끼리 제약 세트를 나눠 `updateUIView`에서 교체 | `SelectCatalog.swift` |
 
-`.frame(maxWidth: .infinity)`로는 둘 다 해결되지 않는다 — representable의 렌더 크기는
+세 번째는 폭이 variant마다 다를 때(`BezierSelect`의 `page` = FILL / `overlay` = 240pt 고정)
+나온다. 고정 폭 variant를 center로 두려고 부등호 제약을 쓰면 FILL variant까지 같이 접히므로,
+한 세트로 뭉치지 말고 variant별 제약을 만들어 두고 갈아끼운다. Select에서는 이 붕괴로 옵션
+라벨이 `한국어` 전체 소실 · `En…`으로 잘렸는데, 빌드·코드 리뷰로는 드러나지 않았다.
+
+`.frame(maxWidth: .infinity)`로는 어느 것도 해결되지 않는다 — representable의 렌더 크기는
 `sizeThatFits` 반환값이 지배하고 frame modifier는 UIView의 실제 bounds를 강제하지 못한다.
 wrapper 방식에서 컴포넌트 내부 content가 남는 폭을 채우게 하려면 content의 가로
 `setContentHuggingPriority`를 최저(`UILayoutPriority(1)`)로 둔다 — `.defaultLow`로는 부족하다.


### PR DESCRIPTION
## MOB-6353

https://linear.app/channel/issue/MOB-6353

V3 Select 컴포넌트 패밀리(Select / SelectGroup / SelectOption)를 UIKit + SwiftUI로 구현합니다.

> **Mobile Select는 Web과 구조가 다릅니다.** Web은 input 스타일 trigger + dropdown overlay지만, **Mobile은 trigger를 아예 갖지 않는 inline 단일 선택 리스트**입니다 (Figma `Select` CS `4870:581` 실측 + design doc DL-066 "보더 input 트리거(웹 방식)는 모바일에서 채택하지 않는다"). 진입 트리거는 `SettingsField` 행 등 사용처가 담당하고, 선택 표시는 checkbox가 아니라 **trailing check 아이콘**입니다 (DL-011).

## 구현 내용

### 컴포지션 구조 (재구현 없음 — 기존 V3 컴포넌트 조합)

```
BezierSelect (container: page | overlay)
├── BezierSectionLabel                ← 재사용 (color: .neutralLight — Figma SelectGroupLabel과 동일 스펙)
└── [container=.overlay] BezierOverlay ← 재사용 (240pt · padding 10 · radius 32 · mEv3)
    └── BezierSelectGroup ×N
        ├── BezierSectionLabel        ← 재사용
        ├── BezierSelectOption ×N
        │   └── BezierBaseItem        ← composition 소유 (상속 금지, MOB-6353 핸드오프)
        └── BezierDivider             ← 재사용 (showsDivider 시 그룹 하단)
```

### Select — `BezierSelect` / `SUBezierSelect`

- `container` = Figma `container` VARIANT. `page`(인라인 배치) / `overlay`(`BezierOverlay` 240pt 카드)
- Figma의 `container=bottomsheet`는 **미제공** — BezierSwift에 대응 BottomSheet 쉘 컴포넌트가 없고(`MasterComponent/` 전수 확인), 해당 variant의 Select 콘텐츠는 `page`와 동일한 인라인 리스트라 bottom sheet 호스팅을 사용처 책임으로 뒀습니다 (`SPEC.md` §9-2)
- `labelText`(nil = 미표시) = Figma `hasLabel` + `Internal/SelectGroupLabel`의 `label` TEXT
- 열림/닫힘·앵커 포지셔닝·외부 탭 닫힘, 그리고 **단일 선택 보장(하나만 `isSelected`)은 사용처 책임** — Figma는 옵션 단위 BOOLEAN만 정의합니다 (§9-4)

### SelectGroup — `BezierSelectGroup` / `SUBezierSelectGroup`

- `labelText`(복수 그룹일 때만) + 선택지 목록 + `showsDivider`(그룹 하단 구분선)
- 라벨 = `BezierSectionLabel(color: .neutralLight)` 재사용 — Figma `Internal/SelectGroupLabel`과 레이아웃(32/10/8)·타이포(`textMedium bold`)·색(`textNeutralLighter`) 일치 실측 확인
- divider = `BezierDivider()` 재사용 (기본 인셋 6/1/6이 Figma divider 인스턴스와 동일)

### SelectOption — `BezierSelectOption` / `SUBezierSelectOption`

- `BezierBaseItem`/`SUBezierBaseItem`을 **composition(소유)** — pressed 배경(`fillNeutralLighter`)·press scale(0.97 + 오버슈트 복귀)·disabled(opacity 0.4)·min-height 48·슬롯 gap 10·labelRow gap 4·ellipsis 전부 BaseItem에 위임
- leading `none` / `icon(BezierIcon)` / `avatar(뷰)` / `custom(뷰)` — Figma `leadingType` 4축, 24×24. `avatar`와 `custom`은 렌더 경로를 공유하며 case 구분은 "무엇을 넣는가"의 문서적 구분입니다 (§9-13)
- `isSelected` = Figma BOOLEAN. state(default/pressed/disabled)와 **독립 축**으로, true면 trailing에 24×24 check 아이콘(`BezierIcon.check`, `iconNeutralHeavier`)이 붙습니다
- description: Figma `hasDescription` 지원 (48 → 55pt, 들여쓰기 34/0)
- `centerSlot`: Figma FIXED 높이 24 컨테이너(초과 시 clip)로 감쌈

### BaseItem internal 스타일 주입 (public API 불변)

Figma SelectOption은 BaseItem `medium` 기본값 대비 **좌우 패딩 10(↔6) · 상하 패딩 8(↔6) · radius 16(↔8) · center 인셋 0(↔2)** 이 다릅니다. 상수 하드코딩 대신 기존 internal `BezierBaseItemStyle` 주입으로 해소했습니다.

상하 패딩 축만 struct에 없어 **`verticalPadding: CGFloat?` 옵셔널 필드를 추가**했습니다 — `nil`이면 기존 `size.verticalPadding`으로 폴백하므로 기존 소비자(BaseItem·DropdownMenuItem·SectionItem)의 동작과 public API는 그대로입니다. 이 차이는 description이 있을 때만 드러납니다(55 vs 51pt).

### SwiftUI 빈 슬롯 처리

leading 유무를 `SUBezierSelectOption` body에서 분기 — `.none`이면 리터럴 `EmptyView`가 `SUBezierBaseItem`의 `Leading.self != EmptyView.self` 체크에 걸리도록 하여 빈 24×24 박스를 방지 (핸드오프 ⚠️ 항목). trailing check는 클로저 내부 런타임 조건부로 처리했습니다.

### 함정 문서화

시각 검증에서 찾은 카탈로그 함정 2건(아래 "검증 중 발견·수정한 결함")을 `docs/agent/examples-pitfalls.md`에 추가했습니다 — disabled 전달 방향이 representable 루트 타입에 따라 갈리는 케이스는 기존 "`UIControl.isEnabled`는 직접 설정해도 되돌려진다" 항목을 두 케이스 표로 재구성했고, `centerXAnchor` + 부등호 제약으로 폭이 붕괴하는 케이스는 기존 "폭이 무너지는 두 반대 케이스" 표에 세 번째 행으로 넣었습니다.

## Spec 검증

figma-component-spec 3단계 사이클로 검증했습니다 (Figma = SSOT):

- **Phase 0**: `figma-desktop` MCP가 대상 노드에 빈 canvas를 반환해 원격 `figma` MCP로 확정 (skill의 대조 절차)
- **Phase 1**: Figma 실측 기반 `SPEC.md` 작성 — Select CS `4870:581`(3v) / Internal/SelectOption CS `4670:92`(12v) / Internal/SelectGroup `4648:129` / Internal/SelectGroupLabel CS `4371:28`(2v)
- **Phase 2**: Properties / Layout / Color / Typography / Asset / Spec Noise / Implementation Reference 7종 병렬 검증
  - Color·Typography·Asset·Noise·ImplRef는 1회 통과
  - Properties·Layout 지적 3건 반영: ① `Internal/SelectGroupLabel`의 `label` TEXT property 누락 ② GroupLabel 높이를 "FIXED 32"로 일반화한 오류(마스터·page 사용처는 min-height 32 + HUG, SelectGroup 내부 인스턴스만 FIXED) ③ `color` VARIANT 기본값 `neutral-dark` → `neutral-light` 정정
- **Phase 3**: UIKit·SwiftUI Implementation Validator로 구현–SPEC 일치 확인
- Figma에 없는 구현 결정(BaseItem composition · internal 스타일 주입 · bottomsheet 미제공 · centerSlot 24 고정 · check 색 토큰 매핑 · page 루트 라벨 인셋 정렬 · description 행 높이 line-height 기준 · 프레젠테이션 스코프 제외 등 13건)은 `SPEC.md` §9에 협의 사항으로 분리 기록

**자산 검증**: Figma raw asset 2종(`icon/check`, leading 기본 `icon/plus`) 모두 `BezierIcon` enum + `Icons.xcassets`에 지오메트리가 일치하는 자산이 실재함을 export SVG path 대조로 확인했습니다(check bbox 오차 0.03pt 이내). SF Symbol fallback 없음.

**check 아이콘 색**: Figma 인스턴스는 변수 바인딩 없이 raw `#000000D9`로 렌더됩니다(`get_variable_defs` → `{}`, export SVG `fill="black" fill-opacity="0.85"`). 저장소는 semantic 토큰만 쓰므로 같은 값(light `black85` / dark `white80`)의 `iconNeutralHeavier`로 매핑했습니다 (§9-6).

## 시뮬레이터 검증 (iPhone 17 / iOS 26.4, 라이트·다크)

접근성 프레임 + 스크린샷 픽셀 실측(3x, 0.33pt 해상도)으로 확인했습니다. 캡처 원본은 로컬 `Screenshots-MOB-6353/`(미커밋)에 보관 — 필요 시 코멘트로 첨부합니다.

| 항목 | 실측 결과 | |
|---|---|---|
| UIKit ↔ SwiftUI 패리티 | 동일 구성에서 잉크 범위가 완전 일치 — leading 아이콘 `x 64.00..84.00`, 라벨 `x 96.33..135.67`, check `x 318.33..337.33` | ✅ |
| 행 레이아웃 | 행 높이 `48.00pt`, 좌우 패딩 10(라벨 `x=62`), leading 24 + gap 10 → 제목 `x=96` | ✅ |
| **옵션 탭 → 체크 이동 (UIKit)** | UIKit 행 탭 시 체크가 row1 → row2로 이동, **SwiftUI 섹션도 동시 갱신**(`@Binding` 공유) | ✅ |
| **centerSlot 높이** | default `24.00pt` / disabled `24.00pt` — 양 패러다임 동일 (§9-5 협의대로 고정. Figma는 pressed·disabled 18pt) | ✅ |
| container=overlay | 카드 `x 81.00..321.00` = **240.00pt** 정확, 중앙 정렬, 배경 `#FFFFFF`(surfaceHighest), radius 32(인셋이 `r−√(r²−(r−d)²)` 곡선과 일치), 좌우 대칭 그림자 | ✅ |
| leading=none | 제목 잉크가 `x=62.33`으로 시작 (아이콘 시 96.33) — **빈 24pt 박스 없음**, SwiftUI `EmptyView` 리터럴 분기 실증 | ✅ |
| leading=avatar / custom | 슬롯 `x 62.00..86.00` = **24.00pt** 정확 (양 패러다임) | ✅ |
| hasDescription | 행 48 → **56pt**(=8+24+16+8), description 들여쓰기 34 → `x=96`. BaseItem 기본 패딩 6이면 52pt이므로 **`verticalPadding: 8` 주입이 실측으로 증명됨** | ✅ |
| group label + divider | divider `y` 1.00pt · `x 58.00..344.00`(= 298 − 6×2) · light `(223,223,227)`=black8, dark `(55,55,57)`=white12 — `borderNeutral` 정확 | ✅ |
| pressed | 배경 `(235,235,240)` = `fillNeutralLighter`(black@0.03) 정확, 행 전체 `48×298` 유지, 콘텐츠만 0.97 축소(배지 24.00 → 23.33) | ✅ |
| disabled | 배지 색이 정확히 0.4 합성 — UIKit `(255,128,0)`→`(247,196,148)`, SwiftUI `(255,141,40)`→`(247,202,164)` | ✅ |
| dark mode | 제목 `(210,210,210)`=white80, leading 아이콘 `(164,164,165)`=white60, check `(210,210,210)`=white80, group label `(119,119,120)`=white40 — **UIKit·SwiftUI 값이 전부 동일**하여 UIKit `traitCollectionDidChange` 토큰 재주입 확인 | ✅ |

### 검증 중 발견·수정한 결함 2건 (모두 카탈로그, 빌드·코드리뷰로는 미검출)

1. **UIKit 프리뷰가 콘텐츠 폭으로 접힘** — 래퍼가 `centerXAnchor` + `>=`/`<=`만 걸어 intrinsic width 없는 `container=page`가 hug으로 붕괴, 제목이 잘렸습니다(`한국어` 전체 소실, `En…`). `page`/`overlay`용 제약 세트를 나눠 `updateUIView`에서 교체하도록 수정 (`examples-pitfalls.md`의 "full-width로 안 늘어남" 케이스).
2. **UIKit disabled가 적용되지 않음** — `.disabled()`는 plain `UIView` representable 안에 중첩된 `UIControl`까지 내려가지 않아 disabled 상태가 아예 시연되지 않았습니다(배지 색 무변화로 검출). `DropdownMenuCatalog`와 동일하게 `isEnabled`를 주입하도록 수정.

카탈로그에 `hasCenterSlot` 토글과 avatar 샘플 이미지를 추가했습니다 — 각각 centerSlot 높이·avatar 슬롯을 실측 가능하게 만들기 위한 검증용 보강입니다.

## 빌드

- `xcodebuild -scheme BezierSwift` clean build — `BUILD SUCCEEDED`
- `xcodebuild -scheme BezierExamples` clean build — `BUILD SUCCEEDED`
- 시뮬레이터: iPhone 17 / iOS 26.4 (`2C0B2F04-E8AA-44F6-854B-D7DD5973E5DC`)
