### PR TITLE
feat(color): sync design tokens from core-bezier-system

### DIFF
--- a/Sources/BezierSwift/Foundation/Color/V3/BCGlobalToken.swift
+++ b/Sources/BezierSwift/Foundation/Color/V3/BCGlobalToken.swift
@@ -1,12 +1,7 @@
-//
-//  BCGlobalToken.swift
-//  BezierSwift
-//
-//  Generated from BezierColorV3GlobalToken.js
-//
-
 import SwiftUI
 import UIKit
+
+// core-bezier-system 의 specs/tokens 에서 자동 생성된 파일입니다. 직접 수정하지 마세요.
 
 public enum BCGlobalToken {
   case black0
@@ -23,7 +18,6 @@ public enum BCGlobalToken {
   case black60
   case black70
   case black8
-  case black80
   case black85
   case blue100
   case blue200
@@ -73,34 +67,34 @@ public enum BCGlobalToken {
   case green400_5
   case green500
   case green600
+  case grey100
   case grey100_80
   case grey100_90
+  case grey200
   case grey200_80
   case grey200_90
-  case grey50_80
-  case grey700_80
-  case grey700_90
-  case grey800_80
-  case grey800_90
-  case grey850_80
-  case grey850_90
-  case grey900_0
-  case grey900_90
-  case grey100
-  case grey200
   case grey25
   case grey300
   case grey400
   case grey50
   case grey500
+  case grey50_80
   case grey600
   case grey650
   case grey700
+  case grey700_80
+  case grey700_90
   case grey750
   case grey750_90
   case grey800
+  case grey800_80
+  case grey800_90
   case grey850
+  case grey850_80
+  case grey850_90
   case grey900
+  case grey900_0
+  case grey900_90
   case grey950
   case navy100
   case navy200
@@ -256,27 +250,25 @@ public enum BCGlobalToken {
     case .black15:
       return ColorComponentsWithAlpha(red: 0x00, green: 0x00, blue: 0x00, alpha: 0.15)
     case .black20:
-      return ColorComponentsWithAlpha(red: 0x00, green: 0x00, blue: 0x00, alpha: 0.20)
+      return ColorComponentsWithAlpha(red: 0x00, green: 0x00, blue: 0x00, alpha: 0.2)
     case .black22:
       return ColorComponentsWithAlpha(red: 0x00, green: 0x00, blue: 0x00, alpha: 0.22)
     case .black3:
       return ColorComponentsWithAlpha(red: 0x00, green: 0x00, blue: 0x00, alpha: 0.03)
     case .black30:
-      return ColorComponentsWithAlpha(red: 0x00, green: 0x00, blue: 0x00, alpha: 0.30)
+      return ColorComponentsWithAlpha(red: 0x00, green: 0x00, blue: 0x00, alpha: 0.3)
     case .black40:
-      return ColorComponentsWithAlpha(red: 0x00, green: 0x00, blue: 0x00, alpha: 0.40)
+      return ColorComponentsWithAlpha(red: 0x00, green: 0x00, blue: 0x00, alpha: 0.4)
     case .black5:
       return ColorComponentsWithAlpha(red: 0x00, green: 0x00, blue: 0x00, alpha: 0.05)
     case .black50:
-      return ColorComponentsWithAlpha(red: 0x00, green: 0x00, blue: 0x00, alpha: 0.50)
+      return ColorComponentsWithAlpha(red: 0x00, green: 0x00, blue: 0x00, alpha: 0.5)
     case .black60:
-      return ColorComponentsWithAlpha(red: 0x00, green: 0x00, blue: 0x00, alpha: 0.60)
+      return ColorComponentsWithAlpha(red: 0x00, green: 0x00, blue: 0x00, alpha: 0.6)
     case .black70:
-      return ColorComponentsWithAlpha(red: 0x00, green: 0x00, blue: 0x00, alpha: 0.70)
+      return ColorComponentsWithAlpha(red: 0x00, green: 0x00, blue: 0x00, alpha: 0.7)
     case .black8:
       return ColorComponentsWithAlpha(red: 0x00, green: 0x00, blue: 0x00, alpha: 0.08)
-    case .black80:
-      return ColorComponentsWithAlpha(red: 0x00, green: 0x00, blue: 0x00, alpha: 0.80)
     case .black85:
       return ColorComponentsWithAlpha(red: 0x00, green: 0x00, blue: 0x00, alpha: 0.85)
     case .blue100:
@@ -288,11 +280,11 @@ public enum BCGlobalToken {
     case .blue300_0:
       return ColorComponentsWithAlpha(red: 0x80, green: 0x82, blue: 0xFF, alpha: 0)
     case .blue300_10:
-      return ColorComponentsWithAlpha(red: 0x80, green: 0x82, blue: 0xFF, alpha: 0.10)
+      return ColorComponentsWithAlpha(red: 0x80, green: 0x82, blue: 0xFF, alpha: 0.1)
     case .blue300_18:
       return ColorComponentsWithAlpha(red: 0x80, green: 0x82, blue: 0xFF, alpha: 0.18)
     case .blue300_30:
-      return ColorComponentsWithAlpha(red: 0x80, green: 0x82, blue: 0xFF, alpha: 0.30)
+      return ColorComponentsWithAlpha(red: 0x80, green: 0x82, blue: 0xFF, alpha: 0.3)
     case .blue300_45:
       return ColorComponentsWithAlpha(red: 0x80, green: 0x82, blue: 0xFF, alpha: 0.45)
     case .blue400:
@@ -300,11 +292,11 @@ public enum BCGlobalToken {
     case .blue400_0:
       return ColorComponentsWithAlpha(red: 0x61, green: 0x57, blue: 0xEA, alpha: 0)
     case .blue400_10:
-      return ColorComponentsWithAlpha(red: 0x61, green: 0x57, blue: 0xEA, alpha: 0.10)
+      return ColorComponentsWithAlpha(red: 0x61, green: 0x57, blue: 0xEA, alpha: 0.1)
     case .blue400_20:
-      return ColorComponentsWithAlpha(red: 0x61, green: 0x57, blue: 0xEA, alpha: 0.20)
+      return ColorComponentsWithAlpha(red: 0x61, green: 0x57, blue: 0xEA, alpha: 0.2)
     case .blue400_30:
-      return ColorComponentsWithAlpha(red: 0x61, green: 0x57, blue: 0xEA, alpha: 0.30)
+      return ColorComponentsWithAlpha(red: 0x61, green: 0x57, blue: 0xEA, alpha: 0.3)
     case .blue400_5:
       return ColorComponentsWithAlpha(red: 0x61, green: 0x57, blue: 0xEA, alpha: 0.05)
     case .blue500:
@@ -320,11 +312,11 @@ public enum BCGlobalToken {
     case .cobalt300_0:
       return ColorComponentsWithAlpha(red: 0x5C, green: 0xAD, blue: 0xEF, alpha: 0)
     case .cobalt300_10:
-      return ColorComponentsWithAlpha(red: 0x5C, green: 0xAD, blue: 0xEF, alpha: 0.10)
+      return ColorComponentsWithAlpha(red: 0x5C, green: 0xAD, blue: 0xEF, alpha: 0.1)
     case .cobalt300_18:
       return ColorComponentsWithAlpha(red: 0x5C, green: 0xAD, blue: 0xEF, alpha: 0.18)
     case .cobalt300_30:
-      return ColorComponentsWithAlpha(red: 0x5C, green: 0xAD, blue: 0xEF, alpha: 0.30)
+      return ColorComponentsWithAlpha(red: 0x5C, green: 0xAD, blue: 0xEF, alpha: 0.3)
     case .cobalt300_45:
       return ColorComponentsWithAlpha(red: 0x5C, green: 0xAD, blue: 0xEF, alpha: 0.45)
     case .cobalt400:
@@ -332,11 +324,11 @@ public enum BCGlobalToken {
     case .cobalt400_0:
       return ColorComponentsWithAlpha(red: 0x32, green: 0x92, blue: 0xE3, alpha: 0)
     case .cobalt400_10:
-      return ColorComponentsWithAlpha(red: 0x32, green: 0x92, blue: 0xE3, alpha: 0.10)
+      return ColorComponentsWithAlpha(red: 0x32, green: 0x92, blue: 0xE3, alpha: 0.1)
     case .cobalt400_20:
-      return ColorComponentsWithAlpha(red: 0x32, green: 0x92, blue: 0xE3, alpha: 0.20)
+      return ColorComponentsWithAlpha(red: 0x32, green: 0x92, blue: 0xE3, alpha: 0.2)
     case .cobalt400_30:
-      return ColorComponentsWithAlpha(red: 0x32, green: 0x92, blue: 0xE3, alpha: 0.30)
+      return ColorComponentsWithAlpha(red: 0x32, green: 0x92, blue: 0xE3, alpha: 0.3)
     case .cobalt400_5:
       return ColorComponentsWithAlpha(red: 0x32, green: 0x92, blue: 0xE3, alpha: 0.05)
     case .cobalt500:
@@ -352,11 +344,11 @@ public enum BCGlobalToken {
     case .green300_0:
       return ColorComponentsWithAlpha(red: 0x51, green: 0xC3, blue: 0x71, alpha: 0)
     case .green300_10:
-      return ColorComponentsWithAlpha(red: 0x51, green: 0xC3, blue: 0x71, alpha: 0.10)
+      return ColorComponentsWithAlpha(red: 0x51, green: 0xC3, blue: 0x71, alpha: 0.1)
     case .green300_18:
       return ColorComponentsWithAlpha(red: 0x51, green: 0xC3, blue: 0x71, alpha: 0.18)
     case .green300_30:
-      return ColorComponentsWithAlpha(red: 0x51, green: 0xC3, blue: 0x71, alpha: 0.30)
+      return ColorComponentsWithAlpha(red: 0x51, green: 0xC3, blue: 0x71, alpha: 0.3)
     case .green300_45:
       return ColorComponentsWithAlpha(red: 0x51, green: 0xC3, blue: 0x71, alpha: 0.45)
     case .green400:
@@ -364,47 +356,29 @@ public enum BCGlobalToken {
     case .green400_0:
       return ColorComponentsWithAlpha(red: 0x20, green: 0xAB, blue: 0x55, alpha: 0)
     case .green400_10:
-      return ColorComponentsWithAlpha(red: 0x20, green: 0xAB, blue: 0x55, alpha: 0.10)
+      return ColorComponentsWithAlpha(red: 0x20, green: 0xAB, blue: 0x55, alpha: 0.1)
     case .green400_20:
-      return ColorComponentsWithAlpha(red: 0x20, green: 0xAB, blue: 0x55, alpha: 0.20)
+      return ColorComponentsWithAlpha(red: 0x20, green: 0xAB, blue: 0x55, alpha: 0.2)
     case .green400_30:
-      return ColorComponentsWithAlpha(red: 0x20, green: 0xAB, blue: 0x55, alpha: 0.30)
+      return ColorComponentsWithAlpha(red: 0x20, green: 0xAB, blue: 0x55, alpha: 0.3)
     case .green400_5:
       return ColorComponentsWithAlpha(red: 0x20, green: 0xAB, blue: 0x55, alpha: 0.05)
     case .green500:
       return ColorComponentsWithAlpha(red: 0x35, green: 0x87, blue: 0x61, alpha: 1)
     case .green600:
       return ColorComponentsWithAlpha(red: 0x32, green: 0x70, blue: 0x55, alpha: 1)
-    case .grey100_80:
-      return ColorComponentsWithAlpha(red: 0xF7, green: 0xF7, blue: 0xF8, alpha: 0.80)
-    case .grey100_90:
-      return ColorComponentsWithAlpha(red: 0xF7, green: 0xF7, blue: 0xF8, alpha: 0.90)
-    case .grey200_80:
-      return ColorComponentsWithAlpha(red: 0xEF, green: 0xEF, blue: 0xF0, alpha: 0.80)
-    case .grey200_90:
-      return ColorComponentsWithAlpha(red: 0xEF, green: 0xEF, blue: 0xF0, alpha: 0.90)
-    case .grey50_80:
-      return ColorComponentsWithAlpha(red: 0xFB, green: 0xFB, blue: 0xFB, alpha: 0.80)
-    case .grey700_80:
-      return ColorComponentsWithAlpha(red: 0x3B, green: 0x3B, blue: 0x3F, alpha: 0.80)
-    case .grey700_90:
-      return ColorComponentsWithAlpha(red: 0x3B, green: 0x3B, blue: 0x3F, alpha: 0.90)
-    case .grey800_80:
-      return ColorComponentsWithAlpha(red: 0x29, green: 0x29, blue: 0x2D, alpha: 0.80)
-    case .grey800_90:
-      return ColorComponentsWithAlpha(red: 0x29, green: 0x29, blue: 0x2D, alpha: 0.90)
-    case .grey850_80:
-      return ColorComponentsWithAlpha(red: 0x24, green: 0x24, blue: 0x26, alpha: 0.80)
-    case .grey850_90:
-      return ColorComponentsWithAlpha(red: 0x24, green: 0x24, blue: 0x26, alpha: 0.90)
-    case .grey900_0:
-      return ColorComponentsWithAlpha(red: 0x1D, green: 0x1D, blue: 0x20, alpha: 0)
-    case .grey900_90:
-      return ColorComponentsWithAlpha(red: 0x1D, green: 0x1D, blue: 0x20, alpha: 0.90)
     case .grey100:
       return ColorComponentsWithAlpha(red: 0xF7, green: 0xF7, blue: 0xF8, alpha: 1)
+    case .grey100_80:
+      return ColorComponentsWithAlpha(red: 0xF7, green: 0xF7, blue: 0xF8, alpha: 0.8)
+    case .grey100_90:
+      return ColorComponentsWithAlpha(red: 0xF7, green: 0xF7, blue: 0xF8, alpha: 0.9)
     case .grey200:
       return ColorComponentsWithAlpha(red: 0xEF, green: 0xEF, blue: 0xF0, alpha: 1)
+    case .grey200_80:
+      return ColorComponentsWithAlpha(red: 0xEF, green: 0xEF, blue: 0xF0, alpha: 0.8)
+    case .grey200_90:
+      return ColorComponentsWithAlpha(red: 0xEF, green: 0xEF, blue: 0xF0, alpha: 0.9)
     case .grey25:
       return ColorComponentsWithAlpha(red: 0xFD, green: 0xFD, blue: 0xFD, alpha: 1)
     case .grey300:
@@ -415,22 +389,40 @@ public enum BCGlobalToken {
       return ColorComponentsWithAlpha(red: 0xFB, green: 0xFB, blue: 0xFB, alpha: 1)
     case .grey500:
       return ColorComponentsWithAlpha(red: 0xA7, green: 0xA7, blue: 0xAA, alpha: 1)
+    case .grey50_80:
+      return ColorComponentsWithAlpha(red: 0xFB, green: 0xFB, blue: 0xFB, alpha: 0.8)
     case .grey600:
       return ColorComponentsWithAlpha(red: 0x79, green: 0x79, blue: 0x7E, alpha: 1)
     case .grey650:
       return ColorComponentsWithAlpha(red: 0x5A, green: 0x5A, blue: 0x5F, alpha: 1)
     case .grey700:
       return ColorComponentsWithAlpha(red: 0x3B, green: 0x3B, blue: 0x3F, alpha: 1)
+    case .grey700_80:
+      return ColorComponentsWithAlpha(red: 0x3B, green: 0x3B, blue: 0x3F, alpha: 0.8)
+    case .grey700_90:
+      return ColorComponentsWithAlpha(red: 0x3B, green: 0x3B, blue: 0x3F, alpha: 0.9)
     case .grey750:
       return ColorComponentsWithAlpha(red: 0x31, green: 0x31, blue: 0x35, alpha: 1)
     case .grey750_90:
-      return ColorComponentsWithAlpha(red: 0x31, green: 0x31, blue: 0x35, alpha: 0.90)
+      return ColorComponentsWithAlpha(red: 0x31, green: 0x31, blue: 0x35, alpha: 0.9)
     case .grey800:
       return ColorComponentsWithAlpha(red: 0x29, green: 0x29, blue: 0x2D, alpha: 1)
+    case .grey800_80:
+      return ColorComponentsWithAlpha(red: 0x29, green: 0x29, blue: 0x2D, alpha: 0.8)
+    case .grey800_90:
+      return ColorComponentsWithAlpha(red: 0x29, green: 0x29, blue: 0x2D, alpha: 0.9)
     case .grey850:
       return ColorComponentsWithAlpha(red: 0x24, green: 0x24, blue: 0x26, alpha: 1)
+    case .grey850_80:
+      return ColorComponentsWithAlpha(red: 0x24, green: 0x24, blue: 0x26, alpha: 0.8)
+    case .grey850_90:
+      return ColorComponentsWithAlpha(red: 0x24, green: 0x24, blue: 0x26, alpha: 0.9)
     case .grey900:
       return ColorComponentsWithAlpha(red: 0x1D, green: 0x1D, blue: 0x20, alpha: 1)
+    case .grey900_0:
+      return ColorComponentsWithAlpha(red: 0x1D, green: 0x1D, blue: 0x20, alpha: 0)
+    case .grey900_90:
+      return ColorComponentsWithAlpha(red: 0x1D, green: 0x1D, blue: 0x20, alpha: 0.9)
     case .grey950:
       return ColorComponentsWithAlpha(red: 0x1A, green: 0x1A, blue: 0x1C, alpha: 1)
     case .navy100:
@@ -442,11 +434,11 @@ public enum BCGlobalToken {
     case .navy300_0:
       return ColorComponentsWithAlpha(red: 0x7E, green: 0x89, blue: 0xCD, alpha: 0)
     case .navy300_10:
-      return ColorComponentsWithAlpha(red: 0x7E, green: 0x89, blue: 0xCD, alpha: 0.10)
+      return ColorComponentsWithAlpha(red: 0x7E, green: 0x89, blue: 0xCD, alpha: 0.1)
     case .navy300_18:
       return ColorComponentsWithAlpha(red: 0x7E, green: 0x89, blue: 0xCD, alpha: 0.18)
     case .navy300_30:
-      return ColorComponentsWithAlpha(red: 0x7E, green: 0x89, blue: 0xCD, alpha: 0.30)
+      return ColorComponentsWithAlpha(red: 0x7E, green: 0x89, blue: 0xCD, alpha: 0.3)
     case .navy300_45:
       return ColorComponentsWithAlpha(red: 0x7E, green: 0x89, blue: 0xCD, alpha: 0.45)
     case .navy400:
@@ -454,11 +446,11 @@ public enum BCGlobalToken {
     case .navy400_0:
       return ColorComponentsWithAlpha(red: 0x42, green: 0x4F, blue: 0xAB, alpha: 0)
     case .navy400_10:
-      return ColorComponentsWithAlpha(red: 0x42, green: 0x4F, blue: 0xAB, alpha: 0.10)
+      return ColorComponentsWithAlpha(red: 0x42, green: 0x4F, blue: 0xAB, alpha: 0.1)
     case .navy400_20:
-      return ColorComponentsWithAlpha(red: 0x42, green: 0x4F, blue: 0xAB, alpha: 0.20)
+      return ColorComponentsWithAlpha(red: 0x42, green: 0x4F, blue: 0xAB, alpha: 0.2)
     case .navy400_30:
-      return ColorComponentsWithAlpha(red: 0x42, green: 0x4F, blue: 0xAB, alpha: 0.30)
+      return ColorComponentsWithAlpha(red: 0x42, green: 0x4F, blue: 0xAB, alpha: 0.3)
     case .navy400_5:
       return ColorComponentsWithAlpha(red: 0x42, green: 0x4F, blue: 0xAB, alpha: 0.05)
     case .navy500:
@@ -474,11 +466,11 @@ public enum BCGlobalToken {
     case .olive300_0:
       return ColorComponentsWithAlpha(red: 0xB7, green: 0xC4, blue: 0x27, alpha: 0)
     case .olive300_10:
-      return ColorComponentsWithAlpha(red: 0xB7, green: 0xC4, blue: 0x27, alpha: 0.10)
+      return ColorComponentsWithAlpha(red: 0xB7, green: 0xC4, blue: 0x27, alpha: 0.1)
     case .olive300_18:
       return ColorComponentsWithAlpha(red: 0xB7, green: 0xC4, blue: 0x27, alpha: 0.18)
     case .olive300_30:
-      return ColorComponentsWithAlpha(red: 0xB7, green: 0xC4, blue: 0x27, alpha: 0.30)
+      return ColorComponentsWithAlpha(red: 0xB7, green: 0xC4, blue: 0x27, alpha: 0.3)
     case .olive300_45:
       return ColorComponentsWithAlpha(red: 0xB7, green: 0xC4, blue: 0x27, alpha: 0.45)
     case .olive400:
@@ -486,11 +478,11 @@ public enum BCGlobalToken {
     case .olive400_0:
       return ColorComponentsWithAlpha(red: 0xA9, green: 0xB1, blue: 0x10, alpha: 0)
     case .olive400_10:
-      return ColorComponentsWithAlpha(red: 0xA9, green: 0xB1, blue: 0x10, alpha: 0.10)
+      return ColorComponentsWithAlpha(red: 0xA9, green: 0xB1, blue: 0x10, alpha: 0.1)
     case .olive400_20:
-      return ColorComponentsWithAlpha(red: 0xA9, green: 0xB1, blue: 0x10, alpha: 0.20)
+      return ColorComponentsWithAlpha(red: 0xA9, green: 0xB1, blue: 0x10, alpha: 0.2)
     case .olive400_30:
-      return ColorComponentsWithAlpha(red: 0xA9, green: 0xB1, blue: 0x10, alpha: 0.30)
+      return ColorComponentsWithAlpha(red: 0xA9, green: 0xB1, blue: 0x10, alpha: 0.3)
     case .olive400_5:
       return ColorComponentsWithAlpha(red: 0xA9, green: 0xB1, blue: 0x10, alpha: 0.05)
     case .olive500:
@@ -506,11 +498,11 @@ public enum BCGlobalToken {
     case .orange300_0:
       return ColorComponentsWithAlpha(red: 0xF7, green: 0x98, blue: 0x47, alpha: 0)
     case .orange300_10:
-      return ColorComponentsWithAlpha(red: 0xF7, green: 0x98, blue: 0x47, alpha: 0.10)
+      return ColorComponentsWithAlpha(red: 0xF7, green: 0x98, blue: 0x47, alpha: 0.1)
     case .orange300_18:
       return ColorComponentsWithAlpha(red: 0xF7, green: 0x98, blue: 0x47, alpha: 0.18)
     case .orange300_30:
-      return ColorComponentsWithAlpha(red: 0xF7, green: 0x98, blue: 0x47, alpha: 0.30)
+      return ColorComponentsWithAlpha(red: 0xF7, green: 0x98, blue: 0x47, alpha: 0.3)
     case .orange300_45:
       return ColorComponentsWithAlpha(red: 0xF7, green: 0x98, blue: 0x47, alpha: 0.45)
     case .orange400:
@@ -518,11 +510,11 @@ public enum BCGlobalToken {
     case .orange400_0:
       return ColorComponentsWithAlpha(red: 0xE6, green: 0x7F, blue: 0x2B, alpha: 0)
     case .orange400_10:
-      return ColorComponentsWithAlpha(red: 0xE6, green: 0x7F, blue: 0x2B, alpha: 0.10)
+      return ColorComponentsWithAlpha(red: 0xE6, green: 0x7F, blue: 0x2B, alpha: 0.1)
     case .orange400_20:
-      return ColorComponentsWithAlpha(red: 0xE6, green: 0x7F, blue: 0x2B, alpha: 0.20)
+      return ColorComponentsWithAlpha(red: 0xE6, green: 0x7F, blue: 0x2B, alpha: 0.2)
     case .orange400_30:
-      return ColorComponentsWithAlpha(red: 0xE6, green: 0x7F, blue: 0x2B, alpha: 0.30)
+      return ColorComponentsWithAlpha(red: 0xE6, green: 0x7F, blue: 0x2B, alpha: 0.3)
     case .orange400_5:
       return ColorComponentsWithAlpha(red: 0xE6, green: 0x7F, blue: 0x2B, alpha: 0.05)
     case .orange500:
@@ -538,11 +530,11 @@ public enum BCGlobalToken {
     case .pink300_0:
       return ColorComponentsWithAlpha(red: 0xEC, green: 0x6F, blue: 0xD3, alpha: 0)
     case .pink300_10:
-      return ColorComponentsWithAlpha(red: 0xEC, green: 0x6F, blue: 0xD3, alpha: 0.10)
+      return ColorComponentsWithAlpha(red: 0xEC, green: 0x6F, blue: 0xD3, alpha: 0.1)
     case .pink300_18:
       return ColorComponentsWithAlpha(red: 0xEC, green: 0x6F, blue: 0xD3, alpha: 0.18)
     case .pink300_30:
-      return ColorComponentsWithAlpha(red: 0xEC, green: 0x6F, blue: 0xD3, alpha: 0.30)
+      return ColorComponentsWithAlpha(red: 0xEC, green: 0x6F, blue: 0xD3, alpha: 0.3)
     case .pink300_45:
       return ColorComponentsWithAlpha(red: 0xEC, green: 0x6F, blue: 0xD3, alpha: 0.45)
     case .pink400:
@@ -550,11 +542,11 @@ public enum BCGlobalToken {
     case .pink400_0:
       return ColorComponentsWithAlpha(red: 0xD6, green: 0x4B, blue: 0xB5, alpha: 0)
     case .pink400_10:
-      return ColorComponentsWithAlpha(red: 0xD6, green: 0x4B, blue: 0xB5, alpha: 0.10)
+      return ColorComponentsWithAlpha(red: 0xD6, green: 0x4B, blue: 0xB5, alpha: 0.1)
     case .pink400_20:
-      return ColorComponentsWithAlpha(red: 0xD6, green: 0x4B, blue: 0xB5, alpha: 0.20)
+      return ColorComponentsWithAlpha(red: 0xD6, green: 0x4B, blue: 0xB5, alpha: 0.2)
     case .pink400_30:
-      return ColorComponentsWithAlpha(red: 0xD6, green: 0x4B, blue: 0xB5, alpha: 0.30)
+      return ColorComponentsWithAlpha(red: 0xD6, green: 0x4B, blue: 0xB5, alpha: 0.3)
     case .pink400_5:
       return ColorComponentsWithAlpha(red: 0xD6, green: 0x4B, blue: 0xB5, alpha: 0.05)
     case .pink500:
@@ -570,11 +562,11 @@ public enum BCGlobalToken {
     case .purple300_0:
       return ColorComponentsWithAlpha(red: 0xA9, green: 0x70, blue: 0xFF, alpha: 0)
     case .purple300_10:
-      return ColorComponentsWithAlpha(red: 0xA9, green: 0x70, blue: 0xFF, alpha: 0.10)
+      return ColorComponentsWithAlpha(red: 0xA9, green: 0x70, blue: 0xFF, alpha: 0.1)
     case .purple300_18:
       return ColorComponentsWithAlpha(red: 0xA9, green: 0x70, blue: 0xFF, alpha: 0.18)
     case .purple300_30:
-      return ColorComponentsWithAlpha(red: 0xA9, green: 0x70, blue: 0xFF, alpha: 0.30)
+      return ColorComponentsWithAlpha(red: 0xA9, green: 0x70, blue: 0xFF, alpha: 0.3)
     case .purple300_45:
       return ColorComponentsWithAlpha(red: 0xA9, green: 0x70, blue: 0xFF, alpha: 0.45)
     case .purple400:
@@ -582,11 +574,11 @@ public enum BCGlobalToken {
     case .purple400_0:
       return ColorComponentsWithAlpha(red: 0x8E, green: 0x57, blue: 0xE7, alpha: 0)
     case .purple400_10:
-      return ColorComponentsWithAlpha(red: 0x8E, green: 0x57, blue: 0xE7, alpha: 0.10)
+      return ColorComponentsWithAlpha(red: 0x8E, green: 0x57, blue: 0xE7, alpha: 0.1)
     case .purple400_20:
-      return ColorComponentsWithAlpha(red: 0x8E, green: 0x57, blue: 0xE7, alpha: 0.20)
+      return ColorComponentsWithAlpha(red: 0x8E, green: 0x57, blue: 0xE7, alpha: 0.2)
     case .purple400_30:
-      return ColorComponentsWithAlpha(red: 0x8E, green: 0x57, blue: 0xE7, alpha: 0.30)
+      return ColorComponentsWithAlpha(red: 0x8E, green: 0x57, blue: 0xE7, alpha: 0.3)
     case .purple400_5:
       return ColorComponentsWithAlpha(red: 0x8E, green: 0x57, blue: 0xE7, alpha: 0.05)
     case .purple500:
@@ -602,11 +594,11 @@ public enum BCGlobalToken {
     case .red300_0:
       return ColorComponentsWithAlpha(red: 0xF3, green: 0x68, blue: 0x68, alpha: 0)
     case .red300_10:
-      return ColorComponentsWithAlpha(red: 0xF3, green: 0x68, blue: 0x68, alpha: 0.10)
+      return ColorComponentsWithAlpha(red: 0xF3, green: 0x68, blue: 0x68, alpha: 0.1)
     case .red300_18:
       return ColorComponentsWithAlpha(red: 0xF3, green: 0x68, blue: 0x68, alpha: 0.18)
     case .red300_30:
-      return ColorComponentsWithAlpha(red: 0xF3, green: 0x68, blue: 0x68, alpha: 0.30)
+      return ColorComponentsWithAlpha(red: 0xF3, green: 0x68, blue: 0x68, alpha: 0.3)
     case .red300_45:
       return ColorComponentsWithAlpha(red: 0xF3, green: 0x68, blue: 0x68, alpha: 0.45)
     case .red400:
@@ -614,11 +606,11 @@ public enum BCGlobalToken {
     case .red400_0:
       return ColorComponentsWithAlpha(red: 0xE1, green: 0x53, blue: 0x5D, alpha: 0)
     case .red400_10:
-      return ColorComponentsWithAlpha(red: 0xE1, green: 0x53, blue: 0x5D, alpha: 0.10)
+      return ColorComponentsWithAlpha(red: 0xE1, green: 0x53, blue: 0x5D, alpha: 0.1)
     case .red400_20:
-      return ColorComponentsWithAlpha(red: 0xE1, green: 0x53, blue: 0x5D, alpha: 0.20)
+      return ColorComponentsWithAlpha(red: 0xE1, green: 0x53, blue: 0x5D, alpha: 0.2)
     case .red400_30:
-      return ColorComponentsWithAlpha(red: 0xE1, green: 0x53, blue: 0x5D, alpha: 0.30)
+      return ColorComponentsWithAlpha(red: 0xE1, green: 0x53, blue: 0x5D, alpha: 0.3)
     case .red400_5:
       return ColorComponentsWithAlpha(red: 0xE1, green: 0x53, blue: 0x5D, alpha: 0.05)
     case .red500:
@@ -634,11 +626,11 @@ public enum BCGlobalToken {
     case .teal300_0:
       return ColorComponentsWithAlpha(red: 0x40, green: 0xD3, blue: 0xC5, alpha: 0)
     case .teal300_10:
-      return ColorComponentsWithAlpha(red: 0x40, green: 0xD3, blue: 0xC5, alpha: 0.10)
+      return ColorComponentsWithAlpha(red: 0x40, green: 0xD3, blue: 0xC5, alpha: 0.1)
     case .teal300_18:
       return ColorComponentsWithAlpha(red: 0x40, green: 0xD3, blue: 0xC5, alpha: 0.18)
     case .teal300_30:
-      return ColorComponentsWithAlpha(red: 0x40, green: 0xD3, blue: 0xC5, alpha: 0.30)
+      return ColorComponentsWithAlpha(red: 0x40, green: 0xD3, blue: 0xC5, alpha: 0.3)
     case .teal300_45:
       return ColorComponentsWithAlpha(red: 0x40, green: 0xD3, blue: 0xC5, alpha: 0.45)
     case .teal400:
@@ -646,11 +638,11 @@ public enum BCGlobalToken {
     case .teal400_0:
       return ColorComponentsWithAlpha(red: 0x09, green: 0xB2, blue: 0xAC, alpha: 0)
     case .teal400_10:
-      return ColorComponentsWithAlpha(red: 0x09, green: 0xB2, blue: 0xAC, alpha: 0.10)
+      return ColorComponentsWithAlpha(red: 0x09, green: 0xB2, blue: 0xAC, alpha: 0.1)
     case .teal400_20:
-      return ColorComponentsWithAlpha(red: 0x09, green: 0xB2, blue: 0xAC, alpha: 0.20)
+      return ColorComponentsWithAlpha(red: 0x09, green: 0xB2, blue: 0xAC, alpha: 0.2)
     case .teal400_30:
-      return ColorComponentsWithAlpha(red: 0x09, green: 0xB2, blue: 0xAC, alpha: 0.30)
+      return ColorComponentsWithAlpha(red: 0x09, green: 0xB2, blue: 0xAC, alpha: 0.3)
     case .teal400_5:
       return ColorComponentsWithAlpha(red: 0x09, green: 0xB2, blue: 0xAC, alpha: 0.05)
     case .teal500:
@@ -664,27 +656,27 @@ public enum BCGlobalToken {
     case .white12:
       return ColorComponentsWithAlpha(red: 0xFF, green: 0xFF, blue: 0xFF, alpha: 0.12)
     case .white20:
-      return ColorComponentsWithAlpha(red: 0xFF, green: 0xFF, blue: 0xFF, alpha: 0.20)
+      return ColorComponentsWithAlpha(red: 0xFF, green: 0xFF, blue: 0xFF, alpha: 0.2)
     case .white22:
       return ColorComponentsWithAlpha(red: 0xFF, green: 0xFF, blue: 0xFF, alpha: 0.22)
     case .white3:
       return ColorComponentsWithAlpha(red: 0xFF, green: 0xFF, blue: 0xFF, alpha: 0.03)
     case .white30:
-      return ColorComponentsWithAlpha(red: 0xFF, green: 0xFF, blue: 0xFF, alpha: 0.30)
+      return ColorComponentsWithAlpha(red: 0xFF, green: 0xFF, blue: 0xFF, alpha: 0.3)
     case .white40:
-      return ColorComponentsWithAlpha(red: 0xFF, green: 0xFF, blue: 0xFF, alpha: 0.40)
+      return ColorComponentsWithAlpha(red: 0xFF, green: 0xFF, blue: 0xFF, alpha: 0.4)
     case .white5:
       return ColorComponentsWithAlpha(red: 0xFF, green: 0xFF, blue: 0xFF, alpha: 0.05)
     case .white50:
-      return ColorComponentsWithAlpha(red: 0xFF, green: 0xFF, blue: 0xFF, alpha: 0.50)
+      return ColorComponentsWithAlpha(red: 0xFF, green: 0xFF, blue: 0xFF, alpha: 0.5)
     case .white60:
-      return ColorComponentsWithAlpha(red: 0xFF, green: 0xFF, blue: 0xFF, alpha: 0.60)
+      return ColorComponentsWithAlpha(red: 0xFF, green: 0xFF, blue: 0xFF, alpha: 0.6)
     case .white8:
       return ColorComponentsWithAlpha(red: 0xFF, green: 0xFF, blue: 0xFF, alpha: 0.08)
     case .white80:
-      return ColorComponentsWithAlpha(red: 0xFF, green: 0xFF, blue: 0xFF, alpha: 0.80)
+      return ColorComponentsWithAlpha(red: 0xFF, green: 0xFF, blue: 0xFF, alpha: 0.8)
     case .white90:
-      return ColorComponentsWithAlpha(red: 0xFF, green: 0xFF, blue: 0xFF, alpha: 0.90)
+      return ColorComponentsWithAlpha(red: 0xFF, green: 0xFF, blue: 0xFF, alpha: 0.9)
     case .yellow100:
       return ColorComponentsWithAlpha(red: 0xFF, green: 0xE3, blue: 0x8F, alpha: 1)
     case .yellow200:
@@ -694,11 +686,11 @@ public enum BCGlobalToken {
     case .yellow300_0:
       return ColorComponentsWithAlpha(red: 0xF0, green: 0xBE, blue: 0x27, alpha: 0)
     case .yellow300_10:
-      return ColorComponentsWithAlpha(red: 0xF0, green: 0xBE, blue: 0x27, alpha: 0.10)
+      return ColorComponentsWithAlpha(red: 0xF0, green: 0xBE, blue: 0x27, alpha: 0.1)
     case .yellow300_18:
       return ColorComponentsWithAlpha(red: 0xF0, green: 0xBE, blue: 0x27, alpha: 0.18)
     case .yellow300_30:
-      return ColorComponentsWithAlpha(red: 0xF0, green: 0xBE, blue: 0x27, alpha: 0.30)
+      return ColorComponentsWithAlpha(red: 0xF0, green: 0xBE, blue: 0x27, alpha: 0.3)
     case .yellow300_45:
       return ColorComponentsWithAlpha(red: 0xF0, green: 0xBE, blue: 0x27, alpha: 0.45)
     case .yellow400:
@@ -706,11 +698,11 @@ public enum BCGlobalToken {
     case .yellow400_0:
       return ColorComponentsWithAlpha(red: 0xED, green: 0xAE, blue: 0x0D, alpha: 0)
     case .yellow400_10:
-      return ColorComponentsWithAlpha(red: 0xED, green: 0xAE, blue: 0x0D, alpha: 0.10)
+      return ColorComponentsWithAlpha(red: 0xED, green: 0xAE, blue: 0x0D, alpha: 0.1)
     case .yellow400_20:
-      return ColorComponentsWithAlpha(red: 0xED, green: 0xAE, blue: 0x0D, alpha: 0.20)
+      return ColorComponentsWithAlpha(red: 0xED, green: 0xAE, blue: 0x0D, alpha: 0.2)
     case .yellow400_30:
-      return ColorComponentsWithAlpha(red: 0xED, green: 0xAE, blue: 0x0D, alpha: 0.30)
+      return ColorComponentsWithAlpha(red: 0xED, green: 0xAE, blue: 0x0D, alpha: 0.3)
     case .yellow400_5:
       return ColorComponentsWithAlpha(red: 0xED, green: 0xAE, blue: 0x0D, alpha: 0.05)
     case .yellow500:
@@ -718,13 +710,5 @@ public enum BCGlobalToken {
     case .yellow600:
       return ColorComponentsWithAlpha(red: 0x9E, green: 0x75, blue: 0x04, alpha: 1)
     }
-  }
-
-  public var color: Color {
-    self.value.color
-  }
-
-  public var uiColor: UIColor {
-    self.value.uiColor
   }
 }

--- a/Sources/BezierSwift/Foundation/Color/V3/BCSemanticToken.swift
+++ b/Sources/BezierSwift/Foundation/Color/V3/BCSemanticToken.swift
@@ -1,14 +1,8 @@
-//
-//  BCSemanticToken.swift
-//  BezierSwift
-//
-//  Generated from BezierColorV3SemanticToken-Light.js and BezierColorV3SemanticToken-Dark.js
-//
-
 import UIKit
 
+// core-bezier-system 의 specs/tokens 에서 자동 생성된 파일입니다. 직접 수정하지 마세요.
+
 public enum BCSemanticToken: Equatable {
-  // MARK: - Border
   case borderAbsoluteWhite
   case borderDetach
   case borderDetachHigh
@@ -18,104 +12,89 @@ public enum BCSemanticToken: Equatable {
   case borderNeutral
   case borderNeutralHeavier
   case borderNeutralHeavy
-
-  // MARK: - Dim
+  case chartThemeDefault01
+  case chartThemeDefault02
+  case chartThemeDefault03
+  case chartThemeDefault04
+  case chartThemeDefault05
+  case chartThemeDefault06
+  case chartThemeDefault07
+  case chartThemeDefault08
+  case chartThemeDefault09
+  case chartThemeDefault10
   case dimAbsoluteBlack
   case dimAbsoluteBlackHeavy
   case dimAbsoluteWhite
   case dimAbsoluteWhiteHeavy
-
-  // MARK: - Elevation
   case elevationBase
   case elevationBaseInner
   case elevationLarge
   case elevationMedium
   case elevationSmall
   case elevationXlarge
-
-  // MARK: - Fill Absolute
   case fillAbsoluteBlack
   case fillAbsoluteBlackLight
   case fillAbsoluteBlackTransparent
   case fillAbsoluteWhite
   case fillAbsoluteWhiteLight
   case fillAbsoluteWhiteTransparent
-
-  // MARK: - Fill Accent Blue
   case fillAccentBlue
   case fillAccentBlueHeavier
   case fillAccentBlueHeavy
   case fillAccentBlueTransparent
-
-  // MARK: - Fill Accent Cobalt
   case fillAccentCobalt
   case fillAccentCobaltHeavier
   case fillAccentCobaltHeavy
   case fillAccentCobaltTransparent
-
-  // MARK: - Fill Accent Green
   case fillAccentGreen
   case fillAccentGreenHeavier
   case fillAccentGreenHeavy
   case fillAccentGreenTransparent
-
-  // MARK: - Fill Accent Navy
   case fillAccentNavy
   case fillAccentNavyHeavier
   case fillAccentNavyHeavy
   case fillAccentNavyTransparent
-
-  // MARK: - Fill Accent Olive
   case fillAccentOlive
   case fillAccentOliveHeavier
   case fillAccentOliveHeavy
   case fillAccentOliveTransparent
-
-  // MARK: - Fill Accent Orange
   case fillAccentOrange
   case fillAccentOrangeHeavier
   case fillAccentOrangeHeavy
   case fillAccentOrangeTransparent
-
-  // MARK: - Fill Accent Pink
   case fillAccentPink
   case fillAccentPinkHeavier
   case fillAccentPinkHeavy
   case fillAccentPinkTransparent
-
-  // MARK: - Fill Accent Purple
   case fillAccentPurple
   case fillAccentPurpleHeavier
   case fillAccentPurpleHeavy
   case fillAccentPurpleTransparent
-
-  // MARK: - Fill Accent Red
   case fillAccentRed
   case fillAccentRedHeavier
   case fillAccentRedHeavy
   case fillAccentRedTransparent
-
-  // MARK: - Fill Accent Teal
   case fillAccentTeal
   case fillAccentTealHeavier
   case fillAccentTealHeavy
   case fillAccentTealTransparent
-
-  // MARK: - Fill Accent Yellow
   case fillAccentYellow
   case fillAccentYellowHeavier
   case fillAccentYellowHeavy
   case fillAccentYellowTransparent
-
-  // MARK: - Fill Semantic
   case fillAction
   case fillActionLight
   case fillActionLighter
   case fillActionTransparent
+  case fillBright
   case fillCritical
   case fillCriticalLight
   case fillCriticalLighter
   case fillCriticalTransparent
+  case fillGrey
+  case fillGreyHeavier
+  case fillGreyHeavy
+  case fillGreyLight
   case fillHighlight
   case fillHighlightLight
   case fillHighlightLighter
@@ -136,19 +115,6 @@ public enum BCSemanticToken: Equatable {
   case fillWarningLight
   case fillWarningLighter
   case fillWarningTransparent
-
-  // MARK: - Fill Grey
-  case fillBright
-  case fillGrey
-  case fillGreyHeavier
-  case fillGreyHeavy
-  case fillGreyLight
-
-  // MARK: - Gradient
-  case gradientAccentGreen
-  case gradientAccentGreenLight
-
-  // MARK: - Icon
   case iconAbsoluteBlack
   case iconAbsoluteWhite
   case iconAccentBlue
@@ -165,22 +131,16 @@ public enum BCSemanticToken: Equatable {
   case iconAction
   case iconCritical
   case iconHighlight
+  case iconInverseHeavier
   case iconNeutral
   case iconNeutralHeavier
   case iconNeutralHeavy
   case iconSuccess
   case iconWarning
-  case iconInverseHeavier
-
-  // MARK: - State
-  case stateAction
-  case stateActionLight
   case stateActive
   case stateDefault
+  case stateFocus
   case stateWarning
-  case stateWarningLight
-
-  // MARK: - Surface
   case surface
   case surfaceGlass
   case surfaceGlassHigh
@@ -190,8 +150,6 @@ public enum BCSemanticToken: Equatable {
   case surfaceHigher
   case surfaceHighest
   case surfaceLow
-
-  // MARK: - Text
   case textAbsoluteBlack
   case textAbsoluteWhite
   case textAccentBlue
@@ -208,53 +166,18 @@ public enum BCSemanticToken: Equatable {
   case textAction
   case textCritical
   case textHighlight
+  case textInverse
   case textNeutral
   case textNeutralHeaviest
   case textNeutralLight
   case textNeutralLighter
   case textSuccess
   case textWarning
-  case textInverse
 
-  // MARK: - Chart
-  case chartThemeDefault01
-  case chartThemeDefault02
-  case chartThemeDefault03
-  case chartThemeDefault04
-  case chartThemeDefault05
-  case chartThemeDefault06
-  case chartThemeDefault07
-  case chartThemeDefault08
-  case chartThemeDefault09
-  case chartThemeDefault10
-
-  case custom(light: ColorComponentsWithAlpha, dark: ColorComponentsWithAlpha)
-}
-
-// MARK: - SemanticColorProtocol
-extension BCSemanticToken: SemanticColorProtocol {
-  public var light: ColorComponentsWithAlpha { self.paletteSet.light }
-  public var dark: ColorComponentsWithAlpha { self.paletteSet.dark }
-  
-}
-
-// MARK: - Pressed Color Method
-extension BCSemanticToken {
-  public var pressedColor: BCSemanticToken {
-    return .custom(
-      light: ColorUtils.getPressedColor(originalColor: self.light, colorTheme: .light),
-      dark: ColorUtils.getPressedColor(originalColor: self.dark, colorTheme: .dark)
-    )
-  }
-}
-
-// MARK: - Private Methods
-extension BCSemanticToken {
   typealias PaletteSet = (light: ColorComponentsWithAlpha, dark: ColorComponentsWithAlpha)
 
-  private var paletteSet: PaletteSet {
+  var paletteSet: PaletteSet {
     switch self {
-    // MARK: - Border
     case .borderAbsoluteWhite:
       return (light: BCGlobalToken.white100.value, dark: BCGlobalToken.white100.value)
     case .borderDetach:
@@ -273,8 +196,26 @@ extension BCSemanticToken {
       return (light: BCGlobalToken.black40.value, dark: BCGlobalToken.white40.value)
     case .borderNeutralHeavy:
       return (light: BCGlobalToken.black15.value, dark: BCGlobalToken.white20.value)
-
-    // MARK: - Dim
+    case .chartThemeDefault01:
+      return (light: ColorComponentsWithAlpha(red: 0x7C, green: 0x72, blue: 0xFD, alpha: 1), dark: ColorComponentsWithAlpha(red: 0x7C, green: 0x72, blue: 0xFD, alpha: 1))
+    case .chartThemeDefault02:
+      return (light: ColorComponentsWithAlpha(red: 0x81, green: 0xDF, blue: 0xDD, alpha: 1), dark: ColorComponentsWithAlpha(red: 0x81, green: 0xDF, blue: 0xDD, alpha: 1))
+    case .chartThemeDefault03:
+      return (light: ColorComponentsWithAlpha(red: 0xFC, green: 0x97, blue: 0x83, alpha: 1), dark: ColorComponentsWithAlpha(red: 0xFC, green: 0x97, blue: 0x83, alpha: 1))
+    case .chartThemeDefault04:
+      return (light: ColorComponentsWithAlpha(red: 0xB1, green: 0x59, blue: 0x6A, alpha: 1), dark: ColorComponentsWithAlpha(red: 0xB1, green: 0x59, blue: 0x6A, alpha: 1))
+    case .chartThemeDefault05:
+      return (light: ColorComponentsWithAlpha(red: 0xFE, green: 0x71, blue: 0xBA, alpha: 1), dark: ColorComponentsWithAlpha(red: 0xFE, green: 0x71, blue: 0xBA, alpha: 1))
+    case .chartThemeDefault06:
+      return (light: ColorComponentsWithAlpha(red: 0xC9, green: 0x71, blue: 0xEC, alpha: 1), dark: ColorComponentsWithAlpha(red: 0xC9, green: 0x71, blue: 0xEC, alpha: 1))
+    case .chartThemeDefault07:
+      return (light: ColorComponentsWithAlpha(red: 0x4A, green: 0x75, blue: 0xE3, alpha: 1), dark: ColorComponentsWithAlpha(red: 0x4A, green: 0x75, blue: 0xE3, alpha: 1))
+    case .chartThemeDefault08:
+      return (light: ColorComponentsWithAlpha(red: 0x80, green: 0xB6, blue: 0xFD, alpha: 1), dark: ColorComponentsWithAlpha(red: 0x80, green: 0xB6, blue: 0xFD, alpha: 1))
+    case .chartThemeDefault09:
+      return (light: ColorComponentsWithAlpha(red: 0xFB, green: 0x90, blue: 0xF1, alpha: 1), dark: ColorComponentsWithAlpha(red: 0xFB, green: 0x90, blue: 0xF1, alpha: 1))
+    case .chartThemeDefault10:
+      return (light: ColorComponentsWithAlpha(red: 0xB4, green: 0xD6, blue: 0xE5, alpha: 1), dark: ColorComponentsWithAlpha(red: 0xB4, green: 0xD6, blue: 0xE5, alpha: 1))
     case .dimAbsoluteBlack:
       return (light: BCGlobalToken.black40.value, dark: BCGlobalToken.black40.value)
     case .dimAbsoluteBlackHeavy:
@@ -283,8 +224,6 @@ extension BCSemanticToken {
       return (light: BCGlobalToken.white40.value, dark: BCGlobalToken.white40.value)
     case .dimAbsoluteWhiteHeavy:
       return (light: BCGlobalToken.white60.value, dark: BCGlobalToken.white80.value)
-
-    // MARK: - Elevation
     case .elevationBase:
       return (light: BCGlobalToken.black5.value, dark: BCGlobalToken.black5.value)
     case .elevationBaseInner:
@@ -297,8 +236,6 @@ extension BCSemanticToken {
       return (light: BCGlobalToken.black8.value, dark: BCGlobalToken.black8.value)
     case .elevationXlarge:
       return (light: BCGlobalToken.black30.value, dark: BCGlobalToken.black30.value)
-
-    // MARK: - Fill Absolute
     case .fillAbsoluteBlack:
       return (light: BCGlobalToken.black100.value, dark: BCGlobalToken.black100.value)
     case .fillAbsoluteBlackLight:
@@ -311,8 +248,6 @@ extension BCSemanticToken {
       return (light: BCGlobalToken.white20.value, dark: BCGlobalToken.white20.value)
     case .fillAbsoluteWhiteTransparent:
       return (light: BCGlobalToken.white0.value, dark: BCGlobalToken.white0.value)
-
-    // MARK: - Fill Accent Blue
     case .fillAccentBlue:
       return (light: BCGlobalToken.blue400_10.value, dark: BCGlobalToken.blue300_18.value)
     case .fillAccentBlueHeavier:
@@ -321,8 +256,6 @@ extension BCSemanticToken {
       return (light: BCGlobalToken.blue400_20.value, dark: BCGlobalToken.blue300_30.value)
     case .fillAccentBlueTransparent:
       return (light: BCGlobalToken.blue400_0.value, dark: BCGlobalToken.blue300_0.value)
-
-    // MARK: - Fill Accent Cobalt
     case .fillAccentCobalt:
       return (light: BCGlobalToken.cobalt400_10.value, dark: BCGlobalToken.cobalt300_18.value)
     case .fillAccentCobaltHeavier:
@@ -331,8 +264,6 @@ extension BCSemanticToken {
       return (light: BCGlobalToken.cobalt400_20.value, dark: BCGlobalToken.cobalt300_30.value)
     case .fillAccentCobaltTransparent:
       return (light: BCGlobalToken.cobalt400_0.value, dark: BCGlobalToken.cobalt300_0.value)
-
-    // MARK: - Fill Accent Green
     case .fillAccentGreen:
       return (light: BCGlobalToken.green400_10.value, dark: BCGlobalToken.green300_18.value)
     case .fillAccentGreenHeavier:
@@ -341,8 +272,6 @@ extension BCSemanticToken {
       return (light: BCGlobalToken.green400_20.value, dark: BCGlobalToken.green300_30.value)
     case .fillAccentGreenTransparent:
       return (light: BCGlobalToken.green400_0.value, dark: BCGlobalToken.green300_0.value)
-
-    // MARK: - Fill Accent Navy
     case .fillAccentNavy:
       return (light: BCGlobalToken.navy400_10.value, dark: BCGlobalToken.navy300_18.value)
     case .fillAccentNavyHeavier:
@@ -351,8 +280,6 @@ extension BCSemanticToken {
       return (light: BCGlobalToken.navy400_20.value, dark: BCGlobalToken.navy300_30.value)
     case .fillAccentNavyTransparent:
       return (light: BCGlobalToken.navy400_0.value, dark: BCGlobalToken.navy300_0.value)
-
-    // MARK: - Fill Accent Olive
     case .fillAccentOlive:
       return (light: BCGlobalToken.olive400_10.value, dark: BCGlobalToken.olive300_18.value)
     case .fillAccentOliveHeavier:
@@ -361,8 +288,6 @@ extension BCSemanticToken {
       return (light: BCGlobalToken.olive400_20.value, dark: BCGlobalToken.olive300_30.value)
     case .fillAccentOliveTransparent:
       return (light: BCGlobalToken.olive400_0.value, dark: BCGlobalToken.olive300_0.value)
-
-    // MARK: - Fill Accent Orange
     case .fillAccentOrange:
       return (light: BCGlobalToken.orange400_10.value, dark: BCGlobalToken.orange300_18.value)
     case .fillAccentOrangeHeavier:
@@ -371,8 +296,6 @@ extension BCSemanticToken {
       return (light: BCGlobalToken.orange400_20.value, dark: BCGlobalToken.orange300_30.value)
     case .fillAccentOrangeTransparent:
       return (light: BCGlobalToken.orange400_0.value, dark: BCGlobalToken.orange300_0.value)
-
-    // MARK: - Fill Accent Pink
     case .fillAccentPink:
       return (light: BCGlobalToken.pink400_10.value, dark: BCGlobalToken.pink300_18.value)
     case .fillAccentPinkHeavier:
@@ -381,8 +304,6 @@ extension BCSemanticToken {
       return (light: BCGlobalToken.pink400_20.value, dark: BCGlobalToken.pink300_30.value)
     case .fillAccentPinkTransparent:
       return (light: BCGlobalToken.pink400_0.value, dark: BCGlobalToken.pink300_0.value)
-
-    // MARK: - Fill Accent Purple
     case .fillAccentPurple:
       return (light: BCGlobalToken.purple400_10.value, dark: BCGlobalToken.purple300_18.value)
     case .fillAccentPurpleHeavier:
@@ -391,8 +312,6 @@ extension BCSemanticToken {
       return (light: BCGlobalToken.purple400_20.value, dark: BCGlobalToken.purple300_30.value)
     case .fillAccentPurpleTransparent:
       return (light: BCGlobalToken.purple400_0.value, dark: BCGlobalToken.purple300_0.value)
-
-    // MARK: - Fill Accent Red
     case .fillAccentRed:
       return (light: BCGlobalToken.red400_10.value, dark: BCGlobalToken.red300_18.value)
     case .fillAccentRedHeavier:
@@ -401,8 +320,6 @@ extension BCSemanticToken {
       return (light: BCGlobalToken.red400_20.value, dark: BCGlobalToken.red300_30.value)
     case .fillAccentRedTransparent:
       return (light: BCGlobalToken.red400_0.value, dark: BCGlobalToken.red300_0.value)
-
-    // MARK: - Fill Accent Teal
     case .fillAccentTeal:
       return (light: BCGlobalToken.teal400_10.value, dark: BCGlobalToken.teal300_18.value)
     case .fillAccentTealHeavier:
@@ -411,8 +328,6 @@ extension BCSemanticToken {
       return (light: BCGlobalToken.teal400_20.value, dark: BCGlobalToken.teal300_30.value)
     case .fillAccentTealTransparent:
       return (light: BCGlobalToken.teal400_0.value, dark: BCGlobalToken.teal300_0.value)
-
-    // MARK: - Fill Accent Yellow
     case .fillAccentYellow:
       return (light: BCGlobalToken.yellow400_10.value, dark: BCGlobalToken.yellow300_18.value)
     case .fillAccentYellowHeavier:
@@ -421,8 +336,6 @@ extension BCSemanticToken {
       return (light: BCGlobalToken.yellow400_20.value, dark: BCGlobalToken.yellow300_30.value)
     case .fillAccentYellowTransparent:
       return (light: BCGlobalToken.yellow400_0.value, dark: BCGlobalToken.yellow300_0.value)
-
-    // MARK: - Fill Semantic
     case .fillAction:
       return (light: BCGlobalToken.blue400.value, dark: BCGlobalToken.blue300.value)
     case .fillActionLight:
@@ -431,6 +344,8 @@ extension BCSemanticToken {
       return (light: BCGlobalToken.blue400_10.value, dark: BCGlobalToken.blue300_18.value)
     case .fillActionTransparent:
       return (light: BCGlobalToken.blue400_0.value, dark: BCGlobalToken.blue300_0.value)
+    case .fillBright:
+      return (light: BCGlobalToken.grey25.value, dark: BCGlobalToken.grey650.value)
     case .fillCritical:
       return (light: BCGlobalToken.red400.value, dark: BCGlobalToken.red300.value)
     case .fillCriticalLight:
@@ -439,6 +354,14 @@ extension BCSemanticToken {
       return (light: BCGlobalToken.red400_10.value, dark: BCGlobalToken.red300_18.value)
     case .fillCriticalTransparent:
       return (light: BCGlobalToken.red400_0.value, dark: BCGlobalToken.red300_0.value)
+    case .fillGrey:
+      return (light: BCGlobalToken.grey50.value, dark: BCGlobalToken.grey850.value)
+    case .fillGreyHeavier:
+      return (light: BCGlobalToken.grey200.value, dark: BCGlobalToken.grey750.value)
+    case .fillGreyHeavy:
+      return (light: BCGlobalToken.grey100.value, dark: BCGlobalToken.grey800.value)
+    case .fillGreyLight:
+      return (light: BCGlobalToken.grey25.value, dark: BCGlobalToken.grey900.value)
     case .fillHighlight:
       return (light: BCGlobalToken.cobalt400.value, dark: BCGlobalToken.cobalt300.value)
     case .fillHighlightLight:
@@ -479,26 +402,6 @@ extension BCSemanticToken {
       return (light: BCGlobalToken.orange400_10.value, dark: BCGlobalToken.orange300_18.value)
     case .fillWarningTransparent:
       return (light: BCGlobalToken.orange400_0.value, dark: BCGlobalToken.orange300_0.value)
-
-    // MARK: - Fill Grey
-    case .fillBright:
-      return (light: BCGlobalToken.grey25.value, dark: BCGlobalToken.grey650.value)
-    case .fillGrey:
-      return (light: BCGlobalToken.grey50.value, dark: BCGlobalToken.grey850.value)
-    case .fillGreyHeavier:
-      return (light: BCGlobalToken.grey200.value, dark: BCGlobalToken.grey750.value)
-    case .fillGreyHeavy:
-      return (light: BCGlobalToken.grey100.value, dark: BCGlobalToken.grey800.value)
-    case .fillGreyLight:
-      return (light: BCGlobalToken.grey25.value, dark: BCGlobalToken.grey900.value)
-
-    // MARK: - Gradient
-    case .gradientAccentGreen:
-      return (light: BCGlobalToken.green400.value, dark: BCGlobalToken.green400.value)
-    case .gradientAccentGreenLight:
-      return (light: BCGlobalToken.green300.value, dark: BCGlobalToken.green300.value)
-
-    // MARK: - Icon
     case .iconAbsoluteBlack:
       return (light: BCGlobalToken.black100.value, dark: BCGlobalToken.black100.value)
     case .iconAbsoluteWhite:
@@ -531,6 +434,8 @@ extension BCSemanticToken {
       return (light: BCGlobalToken.red400.value, dark: BCGlobalToken.red300.value)
     case .iconHighlight:
       return (light: BCGlobalToken.cobalt400.value, dark: BCGlobalToken.cobalt300.value)
+    case .iconInverseHeavier:
+      return (light: BCGlobalToken.white100.value, dark: BCGlobalToken.black85.value)
     case .iconNeutral:
       return (light: BCGlobalToken.black40.value, dark: BCGlobalToken.white40.value)
     case .iconNeutralHeavier:
@@ -541,24 +446,14 @@ extension BCSemanticToken {
       return (light: BCGlobalToken.green400.value, dark: BCGlobalToken.green300.value)
     case .iconWarning:
       return (light: BCGlobalToken.orange400.value, dark: BCGlobalToken.orange300.value)
-    case .iconInverseHeavier:
-      return (light: BCGlobalToken.white100.value, dark: BCGlobalToken.black85.value)
-
-    // MARK: - State
-    case .stateAction:
-      return (light: BCGlobalToken.blue400.value, dark: BCGlobalToken.blue300.value)
-    case .stateActionLight:
-      return (light: BCGlobalToken.blue400_30.value, dark: BCGlobalToken.blue300_45.value)
     case .stateActive:
-      return (light: BCGlobalToken.black80.value, dark: BCGlobalToken.white80.value)
+      return (light: BCGlobalToken.black85.value, dark: BCGlobalToken.white40.value)
     case .stateDefault:
       return (light: BCGlobalToken.black15.value, dark: BCGlobalToken.white20.value)
+    case .stateFocus:
+      return (light: BCGlobalToken.black40.value, dark: BCGlobalToken.white40.value)
     case .stateWarning:
       return (light: BCGlobalToken.orange400.value, dark: BCGlobalToken.orange300.value)
-    case .stateWarningLight:
-      return (light: BCGlobalToken.orange400_30.value, dark: BCGlobalToken.orange300.value)
-
-    // MARK: - Surface
     case .surface:
       return (light: BCGlobalToken.white100.value, dark: BCGlobalToken.grey900.value)
     case .surfaceGlass:
@@ -577,8 +472,6 @@ extension BCSemanticToken {
       return (light: BCGlobalToken.white100.value, dark: BCGlobalToken.grey750.value)
     case .surfaceLow:
       return (light: BCGlobalToken.grey50.value, dark: BCGlobalToken.grey950.value)
-
-    // MARK: - Text
     case .textAbsoluteBlack:
       return (light: BCGlobalToken.black100.value, dark: BCGlobalToken.black100.value)
     case .textAbsoluteWhite:
@@ -611,6 +504,8 @@ extension BCSemanticToken {
       return (light: BCGlobalToken.red400.value, dark: BCGlobalToken.red300.value)
     case .textHighlight:
       return (light: BCGlobalToken.cobalt400.value, dark: BCGlobalToken.cobalt300.value)
+    case .textInverse:
+      return (light: BCGlobalToken.white100.value, dark: BCGlobalToken.black85.value)
     case .textNeutral:
       return (light: BCGlobalToken.black85.value, dark: BCGlobalToken.white80.value)
     case .textNeutralHeaviest:
@@ -623,37 +518,6 @@ extension BCSemanticToken {
       return (light: BCGlobalToken.green400.value, dark: BCGlobalToken.green300.value)
     case .textWarning:
       return (light: BCGlobalToken.orange400.value, dark: BCGlobalToken.orange300.value)
-    case .textInverse:
-      return (light: BCGlobalToken.white100.value, dark: BCGlobalToken.black85.value)
-    // MARK: - Chart
-    // Figma SSOT에서 chart 토큰은 global 토큰 alias 없이 직접 색상값으로 정의됨 (light/dark 동일).
-    case .chartThemeDefault01:
-      return Self.chartColor(0x7C, 0x72, 0xFD)
-    case .chartThemeDefault02:
-      return Self.chartColor(0x81, 0xDF, 0xDD)
-    case .chartThemeDefault03:
-      return Self.chartColor(0xFC, 0x97, 0x83)
-    case .chartThemeDefault04:
-      return Self.chartColor(0xB1, 0x59, 0x6A)
-    case .chartThemeDefault05:
-      return Self.chartColor(0xFE, 0x71, 0xBA)
-    case .chartThemeDefault06:
-      return Self.chartColor(0xC9, 0x71, 0xEC)
-    case .chartThemeDefault07:
-      return Self.chartColor(0x4A, 0x75, 0xE3)
-    case .chartThemeDefault08:
-      return Self.chartColor(0x80, 0xB6, 0xFD)
-    case .chartThemeDefault09:
-      return Self.chartColor(0xFB, 0x90, 0xF1)
-    case .chartThemeDefault10:
-      return Self.chartColor(0xB4, 0xD6, 0xE5)
-    case .custom(let light, let dark):
-      return (light: light, dark: dark)
     }
-  }
-
-  private static func chartColor(_ r: Double, _ g: Double, _ b: Double) -> PaletteSet {
-    let color = ColorComponentsWithAlpha(red: r, green: g, blue: b, alpha: 1)
-    return (light: color, dark: color)
   }
 }


### PR DESCRIPTION
core-bezier-system 의 `specs/tokens` 변경을 반영한 자동 PR 입니다.

- source commit: channel-io/core-bezier-system@a418faf27889ecf9a1bed196ef9eff5acb3da12a
- workflow run: https://github.com/channel-io/core-bezier-system/actions/runs/30459601980

색상 소스는 SSOT 기준으로 **전량 재생성**됩니다. 생성 파일을 직접 수정하지 마세요.
Figma 에 없는 토큰은 제거되므로, 참조하던 코드가 있다면 함께 정리해야 합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 색상 토큰 구성이 정리되고 일부 회색 및 상태·텍스트 토큰이 제거되었습니다.
  * 새로운 `stateFocus` 색상 토큰이 추가되었습니다.
  * 일부 상태 토큰의 라이트·다크 테마 색상 매핑이 업데이트되었습니다.
  * 차트 색상 토큰의 색상 값 적용 방식이 개선되었습니다.

* **호환성 변경**
  * `black80` 토큰이 제거되었습니다.
  * 사용자 정의 색상 토큰과 일부 액션·경고·텍스트 토큰이 더 이상 제공되지 않습니다.
  * 토큰에서 직접 `Color` 및 `UIColor`로 변환하는 공개 API가 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->