### PR TITLE
[MOB-6354] BezierMultiSelect 컴포넌트 구현 (UIKit + SwiftUI)

### DIFF
--- a/Examples/BezierExamples/BezierExamples/App/CatalogRegistry.swift
+++ b/Examples/BezierExamples/BezierExamples/App/CatalogRegistry.swift
@@ -31,6 +31,7 @@ enum CatalogRegistry {
     .init(id: "form-group", title: "FormGroup", section: .v3Components, destination: AnyView(FormGroupCatalog())),
     .init(id: "icon-button", title: "IconButton", section: .v3Components, destination: AnyView(IconButtonCatalog())),
     .init(id: "modal", title: "Modal", section: .v3Components, destination: AnyView(ModalCatalog())),
+    .init(id: "multi-select", title: "MultiSelect", section: .v3Components, destination: AnyView(MultiSelectCatalog())),
     .init(id: "overlay", title: "Overlay", section: .v3Components, destination: AnyView(OverlayCatalog())),
     .init(id: "progress-bar", title: "ProgressBar", section: .v3Components, destination: AnyView(ProgressBarCatalog())),
     .init(id: "search", title: "Search", section: .v3Components, destination: AnyView(SearchCatalog())),

--- a/Examples/BezierExamples/BezierExamples/Components/MultiSelectCatalog.swift
+++ b/Examples/BezierExamples/BezierExamples/Components/MultiSelectCatalog.swift
@@ -1,0 +1,279 @@
+import SwiftUI
+import UIKit
+import BezierSwift
+
+private enum MultiSelectLeadingKind: String, CaseIterable {
+  case none
+  case icon
+  case avatar
+  case custom
+}
+
+private enum MultiSelectOptionSpec {
+  static let titles = ["긴급", "VIP 고객", "재문의"]
+  static let icons: [BezierIcon] = [.tag, .star, .person]
+  static let descriptions = ["즉시 응대가 필요한 문의", "결제 이력 상위 10%", "같은 주제로 다시 문의함"]
+}
+
+struct MultiSelectCatalog: View {
+  @State private var container: BezierMultiSelectContainer = .page
+  @State private var leadingKind: MultiSelectLeadingKind = .icon
+  @State private var selectedIndices: Set<Int> = [0, 1]
+  @State private var showsMultiSelectLabel = true
+  @State private var showsGroup = true
+  @State private var showsGroupLabel = true
+  @State private var hasDescription = false
+  @State private var hasCenterSlot = false
+  @State private var isEnabled = true
+
+  var body: some View {
+    CatalogScreen(title: "MultiSelect") {
+      self.controls
+      CatalogSection(.swiftUI) { self.swiftUIPreview }
+      CatalogSection(.uiKit) { self.uiKitPreview }
+    }
+  }
+
+  private var controls: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Picker("container", selection: self.$container) {
+        ForEach(BezierMultiSelectContainer.allCases, id: \.self) { container in
+          Text(String(describing: container)).tag(container)
+        }
+      }
+      .pickerStyle(.segmented)
+
+      Picker("leading", selection: self.$leadingKind) {
+        ForEach(MultiSelectLeadingKind.allCases, id: \.self) { kind in
+          Text(kind.rawValue).tag(kind)
+        }
+      }
+      .pickerStyle(.segmented)
+
+      // 복수 선택이라 단일 Picker로는 표현할 수 없어 항목별 토글을 나열한다.
+      HStack(spacing: 8) {
+        ForEach(MultiSelectOptionSpec.titles.indices, id: \.self) { index in
+          Button(MultiSelectOptionSpec.titles[index]) { self.toggle(index) }
+            .buttonStyle(.bordered)
+            .tint(self.selectedIndices.contains(index) ? .accentColor : .gray)
+        }
+      }
+
+      Toggle("multiSelect label", isOn: self.$showsMultiSelectLabel)
+      Toggle("group", isOn: self.$showsGroup)
+      Toggle("group label", isOn: self.$showsGroupLabel)
+      Toggle("hasDescription", isOn: self.$hasDescription)
+      Toggle("hasCenterSlot", isOn: self.$hasCenterSlot)
+      Toggle("isEnabled", isOn: self.$isEnabled)
+    }
+    .font(.caption)
+  }
+
+  private func toggle(_ index: Int) {
+    if self.selectedIndices.contains(index) {
+      self.selectedIndices.remove(index)
+    } else {
+      self.selectedIndices.insert(index)
+    }
+  }
+
+  // MARK: - SwiftUI
+
+  private var swiftUIPreview: some View {
+    SUBezierMultiSelect(
+      container: self.container,
+      labelText: self.showsMultiSelectLabel ? "태그" : nil
+    ) {
+      if self.showsGroup {
+        SUBezierMultiSelectGroup(labelText: self.showsGroupLabel ? "최근 사용" : nil) {
+          self.options
+        }
+      } else {
+        self.options
+      }
+    }
+    .disabled(!self.isEnabled)
+    .padding(24)
+    .frame(maxWidth: .infinity)
+    .background(Color(uiColor: .secondarySystemBackground))
+  }
+
+  @ViewBuilder
+  private var options: some View {
+    ForEach(MultiSelectOptionSpec.titles.indices, id: \.self) { index in
+      SUBezierMultiSelectOption(
+        title: MultiSelectOptionSpec.titles[index],
+        description: self.hasDescription ? MultiSelectOptionSpec.descriptions[index] : nil,
+        leading: self.swiftUILeading(icon: MultiSelectOptionSpec.icons[index]),
+        isSelected: self.selectedIndices.contains(index),
+        onToggle: { self.toggle(index) },
+        centerSlot: {
+          // 40pt 정사각을 넘겨 슬롯의 클리핑 높이(24pt)를 눈으로 잴 수 있게 한다.
+          if self.hasCenterSlot {
+            RoundedRectangle(cornerRadius: 4).fill(Color.orange).frame(width: 40, height: 40)
+          }
+        }
+      )
+    }
+  }
+
+  private func swiftUILeading(icon: BezierIcon) -> BezierMultiSelectOptionLeading<AnyView> {
+    switch self.leadingKind {
+    case .none:
+      return .none
+    case .icon:
+      return .icon(icon)
+    case .avatar:
+      return .avatar(AnyView(SUBezierAvatar(image: Image("AvatarSample"), size: .size24)))
+    case .custom:
+      return .custom(AnyView(Circle().fill(Color.orange.opacity(0.4))))
+    }
+  }
+
+  // MARK: - UIKit
+
+  private var uiKitPreview: some View {
+    MultiSelectUIKitRepresentable(
+      container: self.container,
+      leadingKind: self.leadingKind,
+      selectedIndices: self.$selectedIndices,
+      showsMultiSelectLabel: self.showsMultiSelectLabel,
+      showsGroup: self.showsGroup,
+      showsGroupLabel: self.showsGroupLabel,
+      hasDescription: self.hasDescription,
+      hasCenterSlot: self.hasCenterSlot,
+      isEnabled: self.isEnabled
+    )
+    .padding(24)
+    .frame(maxWidth: .infinity)
+    .background(Color(uiColor: .secondarySystemBackground))
+  }
+}
+
+private struct MultiSelectUIKitRepresentable: UIViewRepresentable {
+  let container: BezierMultiSelectContainer
+  let leadingKind: MultiSelectLeadingKind
+  @Binding var selectedIndices: Set<Int>
+  let showsMultiSelectLabel: Bool
+  let showsGroup: Bool
+  let showsGroupLabel: Bool
+  let hasDescription: Bool
+  let hasCenterSlot: Bool
+  let isEnabled: Bool
+
+  final class Coordinator {
+    var fillConstraints: [NSLayoutConstraint] = []
+    var centerConstraints: [NSLayoutConstraint] = []
+  }
+
+  func makeCoordinator() -> Coordinator { Coordinator() }
+
+  // page는 폭을 채워야 하고 overlay는 240pt 고정이라, 두 제약 세트를 만들어 두고 update에서 갈아끼운다.
+  // page에 center 제약을 쓰면 intrinsic width가 없어 콘텐츠 폭으로 접히고 라벨이 잘린다.
+  func makeUIView(context: Context) -> UIView {
+    let wrapper = UIView()
+    let multiSelect = BezierMultiSelect()
+    multiSelect.translatesAutoresizingMaskIntoConstraints = false
+    wrapper.addSubview(multiSelect)
+    NSLayoutConstraint.activate([
+      multiSelect.topAnchor.constraint(equalTo: wrapper.topAnchor),
+      multiSelect.bottomAnchor.constraint(equalTo: wrapper.bottomAnchor),
+    ])
+    context.coordinator.fillConstraints = [
+      multiSelect.leadingAnchor.constraint(equalTo: wrapper.leadingAnchor),
+      multiSelect.trailingAnchor.constraint(equalTo: wrapper.trailingAnchor),
+    ]
+    context.coordinator.centerConstraints = [
+      multiSelect.centerXAnchor.constraint(equalTo: wrapper.centerXAnchor),
+      multiSelect.leadingAnchor.constraint(greaterThanOrEqualTo: wrapper.leadingAnchor),
+      multiSelect.trailingAnchor.constraint(lessThanOrEqualTo: wrapper.trailingAnchor),
+    ]
+    return wrapper
+  }
+
+  func updateUIView(_ wrapper: UIView, context: Context) {
+    guard let multiSelect = wrapper.subviews.compactMap({ $0 as? BezierMultiSelect }).first else { return }
+
+    switch self.container {
+    case .page:
+      NSLayoutConstraint.deactivate(context.coordinator.centerConstraints)
+      NSLayoutConstraint.activate(context.coordinator.fillConstraints)
+    case .overlay:
+      NSLayoutConstraint.deactivate(context.coordinator.fillConstraints)
+      NSLayoutConstraint.activate(context.coordinator.centerConstraints)
+    }
+
+    multiSelect.container = self.container
+    multiSelect.labelText = self.showsMultiSelectLabel ? "태그" : nil
+
+    let options: [UIView] = MultiSelectOptionSpec.titles.indices.map { index in
+      let option = BezierMultiSelectOption(
+        title: MultiSelectOptionSpec.titles[index],
+        description: self.hasDescription ? MultiSelectOptionSpec.descriptions[index] : nil,
+        leading: self.uiKitLeading(icon: MultiSelectOptionSpec.icons[index]),
+        isSelected: self.selectedIndices.contains(index),
+        onToggle: {
+          if self.selectedIndices.contains(index) {
+            self.selectedIndices.remove(index)
+          } else {
+            self.selectedIndices.insert(index)
+          }
+        }
+      )
+      // .disabled()는 plain UIView representable 안의 중첩 UIControl까지 내려가지 않으므로 직접 주입한다.
+      option.isEnabled = self.isEnabled
+      if self.hasCenterSlot {
+        // SwiftUI와 동일하게 40pt 정사각을 넘겨 슬롯 클리핑 높이를 잴 수 있게 한다.
+        let badge = UIView()
+        badge.translatesAutoresizingMaskIntoConstraints = false
+        badge.backgroundColor = .orange
+        badge.layer.cornerRadius = 4
+        NSLayoutConstraint.activate([
+          badge.widthAnchor.constraint(equalToConstant: 40),
+          badge.heightAnchor.constraint(equalToConstant: 40),
+        ])
+        option.centerSlot = badge
+      }
+      return option
+    }
+
+    if self.showsGroup {
+      multiSelect.contents = [
+        BezierMultiSelectGroup(
+          labelText: self.showsGroupLabel ? "최근 사용" : nil,
+          options: options
+        )
+      ]
+    } else {
+      multiSelect.contents = options
+    }
+  }
+
+  func sizeThatFits(_ proposal: ProposedViewSize, uiView: UIView, context: Context) -> CGSize? {
+    let fitting = uiView.systemLayoutSizeFitting(
+      CGSize(
+        width: proposal.width ?? BezierOverlayConstant.width,
+        height: UIView.layoutFittingCompressedSize.height
+      ),
+      withHorizontalFittingPriority: .fittingSizeLevel,
+      verticalFittingPriority: .fittingSizeLevel
+    )
+    return CGSize(width: proposal.width ?? fitting.width, height: fitting.height)
+  }
+
+  private func uiKitLeading(icon: BezierIcon) -> BezierMultiSelectOptionLeading<UIView> {
+    switch self.leadingKind {
+    case .none:
+      return .none
+    case .icon:
+      return .icon(icon)
+    case .avatar:
+      return .avatar(BezierAvatar(image: UIImage(named: "AvatarSample"), size: .size24))
+    case .custom:
+      let circle = UIView()
+      circle.backgroundColor = UIColor.orange.withAlphaComponent(0.4)
+      circle.layer.cornerRadius = 12
+      return .custom(circle)
+    }
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierMultiSelect/BezierMultiSelect.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierMultiSelect/BezierMultiSelect.swift
@@ -1,0 +1,141 @@
+//
+//  BezierMultiSelect.swift
+//  BezierSwift
+//
+
+import UIKit
+
+/// 미리 정의된 선택지 중 여러 개를 고르는 복수 선택 목록 (UIKit). 선택적 라벨 + 선택지 목록으로 구성되며, `container`로 인라인 배치(`page`)와 오버레이 카드(`overlay`) 중 하나를 고른다. 목록 콘텐츠에는 `BezierMultiSelectGroup`/`BezierMultiSelectOption`을 넣는다. 진입 트리거·열림/닫힘·앵커 포지셔닝과 선택 집합 보관은 사용처 책임이다. SwiftUI에서는 `SUBezierMultiSelect`를 사용한다.
+public final class BezierMultiSelect: UIView, BezierComponentable {
+  // MARK: - BezierComponentable
+
+  public var colorTheme: BezierColorTheme { .systemBezierColorTheme() }
+  public var componentTheme: BezierComponentTheme = .normal {
+    didSet {
+      self.sectionLabel.componentTheme = self.componentTheme
+      self.overlay.componentTheme = self.componentTheme
+    }
+  }
+
+  // MARK: - Public Properties
+
+  /// 목록을 화면에 얹는 방식 (기본값 `.page`).
+  public var container: BezierMultiSelectContainer = .page {
+    didSet { if oldValue != self.container { self.rebuildContainer() } }
+  }
+
+  /// 목록 상단 라벨 텍스트. `nil`이면 라벨을 숨긴다 (기본값 `nil`). `container`가 `.overlay`면 렌더되지 않는다 — 오버레이 안에서 라벨이 필요하면 `BezierMultiSelectGroup`의 `labelText`를 쓴다.
+  public var labelText: String? {
+    didSet { if oldValue != self.labelText { self.refreshLabel() } }
+  }
+
+  /// 목록에 표시할 콘텐츠 뷰 배열(그룹 또는 선택지). 교체하면 목록을 다시 만든다.
+  public var contents: [UIView] = [] {
+    didSet { self.rebuildContents() }
+  }
+
+  // MARK: - Subviews
+
+  private let rootStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    stackView.alignment = .fill
+    stackView.distribution = .fill
+    stackView.spacing = 0
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    return stackView
+  }()
+
+  private let sectionLabel = BezierSectionLabel(text: "", color: .neutralLight)
+
+  private let contentStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    stackView.alignment = .fill
+    stackView.distribution = .fill
+    stackView.spacing = 0
+    return stackView
+  }()
+
+  private let overlay = BezierOverlay()
+
+  // MARK: - Constraints
+
+  private var containerConstraints: [NSLayoutConstraint] = []
+
+  // MARK: - Init
+
+  /// 표현 방식·라벨 텍스트·목록 콘텐츠(그룹/선택지 배열)로 목록을 만든다.
+  public init(
+    container: BezierMultiSelectContainer = .page,
+    labelText: String? = nil,
+    contents: [UIView] = []
+  ) {
+    self.container = container
+    self.labelText = labelText
+    self.contents = contents
+    super.init(frame: .zero)
+    self.setUp()
+  }
+
+  public required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    self.setUp()
+  }
+
+  // MARK: - Setup
+
+  private func setUp() {
+    self.translatesAutoresizingMaskIntoConstraints = false
+
+    self.rootStackView.addArrangedSubview(self.sectionLabel)
+    self.rootStackView.addArrangedSubview(self.contentStackView)
+
+    self.refreshLabel()
+    self.rebuildContents()
+    self.rebuildContainer()
+  }
+
+  // MARK: - Refresh
+
+  private func rebuildContents() {
+    self.contentStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+    self.contents.forEach { self.contentStackView.addArrangedSubview($0) }
+  }
+
+  private func refreshLabel() {
+    let text = self.labelText ?? ""
+    self.sectionLabel.text = text
+    self.sectionLabel.isHidden = text.isEmpty || self.container != .page
+  }
+
+  private func rebuildContainer() {
+    NSLayoutConstraint.deactivate(self.containerConstraints)
+    self.containerConstraints = []
+    self.overlay.content = nil
+    self.rootStackView.removeFromSuperview()
+    self.overlay.removeFromSuperview()
+
+    switch self.container {
+    case .page:
+      self.addSubview(self.rootStackView)
+      self.containerConstraints = [
+        self.rootStackView.topAnchor.constraint(equalTo: self.topAnchor),
+        self.rootStackView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+        self.rootStackView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+        self.rootStackView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+      ]
+    case .overlay:
+      self.overlay.content = self.rootStackView
+      self.addSubview(self.overlay)
+      self.containerConstraints = [
+        self.overlay.topAnchor.constraint(equalTo: self.topAnchor),
+        self.overlay.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+        self.overlay.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+        self.overlay.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+      ]
+    }
+    NSLayoutConstraint.activate(self.containerConstraints)
+    self.refreshLabel()
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierMultiSelect/BezierMultiSelectGroup.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierMultiSelect/BezierMultiSelectGroup.swift
@@ -1,0 +1,101 @@
+//
+//  BezierMultiSelectGroup.swift
+//  BezierSwift
+//
+
+import UIKit
+
+/// `BezierMultiSelect` 안에서 선택지를 카테고리별로 묶는 그룹 컨테이너 (UIKit). 선택적 라벨 + 선택지 목록으로 구성된다. 단일 그룹이면 그룹 없이 `BezierMultiSelectOption`을 직접 나열한다. 구분선은 이 컨테이너가 제공하지 않으므로 필요하면 사용처가 `BezierDivider`를 형제로 배치한다. SwiftUI에서는 `SUBezierMultiSelectGroup`을 사용한다.
+public final class BezierMultiSelectGroup: UIView, BezierComponentable {
+  // MARK: - BezierComponentable
+
+  public var colorTheme: BezierColorTheme { .systemBezierColorTheme() }
+  public var componentTheme: BezierComponentTheme = .normal {
+    didSet { self.sectionLabel.componentTheme = self.componentTheme }
+  }
+
+  // MARK: - Public Properties
+
+  /// 그룹 라벨 텍스트. `nil`이면 라벨을 숨긴다 (기본값 `nil`) — 복수 그룹일 때만 지정한다.
+  public var labelText: String? {
+    didSet { if oldValue != self.labelText { self.refreshLabel() } }
+  }
+
+  /// 현재 표시 중인 선택지 뷰 배열. 교체하면 목록을 다시 만든다.
+  public var options: [UIView] = [] {
+    didSet { self.rebuildOptions() }
+  }
+
+  // MARK: - Subviews
+
+  private let rootStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    stackView.alignment = .fill
+    stackView.distribution = .fill
+    stackView.spacing = 0
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    return stackView
+  }()
+
+  private let sectionLabel = BezierSectionLabel(text: "", color: .neutralLight)
+
+  private let optionsStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    stackView.alignment = .fill
+    stackView.distribution = .fill
+    stackView.spacing = 0
+    return stackView
+  }()
+
+  // MARK: - Init
+
+  /// 라벨 텍스트·초기 선택지 배열로 그룹을 만든다.
+  public init(
+    labelText: String? = nil,
+    options: [UIView] = []
+  ) {
+    self.labelText = labelText
+    self.options = options
+    super.init(frame: .zero)
+    self.setUp()
+  }
+
+  public required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    self.setUp()
+  }
+
+  // MARK: - Setup
+
+  private func setUp() {
+    self.translatesAutoresizingMaskIntoConstraints = false
+
+    self.rootStackView.addArrangedSubview(self.sectionLabel)
+    self.rootStackView.addArrangedSubview(self.optionsStackView)
+    self.addSubview(self.rootStackView)
+
+    NSLayoutConstraint.activate([
+      self.rootStackView.topAnchor.constraint(equalTo: self.topAnchor),
+      self.rootStackView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+      self.rootStackView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+      self.rootStackView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+    ])
+
+    self.refreshLabel()
+    self.rebuildOptions()
+  }
+
+  // MARK: - Refresh
+
+  private func refreshLabel() {
+    self.sectionLabel.text = self.labelText ?? ""
+    self.sectionLabel.isHidden = (self.labelText?.isEmpty ?? true)
+  }
+
+  private func rebuildOptions() {
+    self.optionsStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+    self.options.forEach { self.optionsStackView.addArrangedSubview($0) }
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierMultiSelect/BezierMultiSelectOption.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierMultiSelect/BezierMultiSelectOption.swift
@@ -1,0 +1,185 @@
+//
+//  BezierMultiSelectOption.swift
+//  BezierSwift
+//
+
+import UIKit
+
+/// `BezierMultiSelect` 목록 안에 넣는 복수 선택지 (UIKit). leading(아이콘/아바타/커스텀) · 제목 · description · centerSlot으로 구성되며, 선택되면 우측에 체크 아이콘이 붙는다. 한 목록에서 여러 항목이 동시에 선택될 수 있다 — 하나만 고르게 하려면 `BezierSelectOption`을, 선택이 값으로 남지 않고 일회성 액션을 실행한다면 `BezierDropdownMenuItem`을 쓴다. SwiftUI에서는 `SUBezierMultiSelectOption`을 사용한다.
+public final class BezierMultiSelectOption: UIView, BezierComponentable {
+  // MARK: - BezierComponentable
+
+  public var colorTheme: BezierColorTheme { .systemBezierColorTheme() }
+  public var componentTheme: BezierComponentTheme = .normal {
+    didSet {
+      self.baseItem.componentTheme = self.componentTheme
+      self.refreshAppearance()
+    }
+  }
+
+  // MARK: - Public Properties
+
+  /// 선택지 제목. 빈 문자열이면 제목을 숨긴다.
+  public var title: String {
+    get { self.baseItem.title }
+    set { self.baseItem.title = newValue }
+  }
+
+  /// 제목 아래 보조 설명. `nil`/빈 문자열이면 숨긴다.
+  public var itemDescription: String? {
+    get { self.baseItem.itemDescription }
+    set { self.baseItem.itemDescription = newValue }
+  }
+
+  /// leading 콘텐츠 유형(none/icon/avatar/custom) (기본값 `.none`).
+  public var leading: BezierMultiSelectOptionLeading<UIView> = .none {
+    didSet { self.refreshLeading() }
+  }
+
+  /// 제목 우측에 인라인으로 붙는 슬롯 뷰(높이 24, 초과 시 잘린다). `nil`이면 비운다.
+  public var centerSlot: UIView? {
+    didSet {
+      self.baseItem.centerSlot = self.centerSlot.map { self.makeCenterSlotContainer($0) }
+    }
+  }
+
+  /// 현재 선택된 항목인지 여부. `true`면 우측에 체크 아이콘이 표시된다 (기본값 `false`). 복수 선택이므로 한 목록에서 여러 항목이 동시에 `true`일 수 있고, 선택 집합의 보관과 토글은 사용처 책임이다.
+  public var isSelected: Bool = false {
+    didSet { if oldValue != self.isSelected { self.refreshSelection() } }
+  }
+
+  /// 항목을 탭했을 때 실행되는 토글 핸들러. 사용처가 이 항목의 `isSelected`를 뒤집어 다시 주입한다. `nil`이면 비인터랙티브(pressed 없음)가 된다.
+  public var onToggle: (() -> Void)? {
+    get { self.baseItem.onTap }
+    set { self.baseItem.onTap = newValue }
+  }
+
+  /// 항목 활성 여부. `false`면 흐리게(opacity 0.4) 표시되고 입력이 차단된다 (기본값 `true`).
+  public var isEnabled: Bool {
+    get { self.baseItem.isEnabled }
+    set { self.baseItem.isEnabled = newValue }
+  }
+
+  // MARK: - Subviews
+
+  private let baseItem: BezierBaseItem
+
+  private let leadingIconImageView: UIImageView = {
+    let imageView = UIImageView()
+    imageView.contentMode = .scaleAspectFit
+    return imageView
+  }()
+
+  private let checkImageView: UIImageView = {
+    let imageView = UIImageView()
+    imageView.contentMode = .scaleAspectFit
+    imageView.translatesAutoresizingMaskIntoConstraints = false
+    NSLayoutConstraint.activate([
+      imageView.widthAnchor.constraint(equalToConstant: BezierMultiSelectOptionConstant.checkIconLength),
+      imageView.heightAnchor.constraint(equalToConstant: BezierMultiSelectOptionConstant.checkIconLength),
+    ])
+    return imageView
+  }()
+
+  // MARK: - Init
+
+  /// 제목·description·leading·선택 여부·토글 핸들러로 선택지를 만든다. centerSlot은 생성 후 프로퍼티로 지정한다.
+  public init(
+    title: String,
+    description: String? = nil,
+    leading: BezierMultiSelectOptionLeading<UIView> = .none,
+    isSelected: Bool = false,
+    onToggle: (() -> Void)? = nil
+  ) {
+    self.leading = leading
+    self.isSelected = isSelected
+    self.baseItem = BezierBaseItem(
+      size: .medium,
+      title: title,
+      description: description,
+      onTap: onToggle
+    )
+    super.init(frame: .zero)
+    self.setUp()
+  }
+
+  public required init?(coder: NSCoder) {
+    self.baseItem = BezierBaseItem(size: .medium, title: "")
+    super.init(coder: coder)
+    self.setUp()
+  }
+
+  // MARK: - Setup
+
+  private func setUp() {
+    self.translatesAutoresizingMaskIntoConstraints = false
+    self.baseItem.style = BezierMultiSelectOptionConstant.baseItemStyle
+    self.addSubview(self.baseItem)
+    NSLayoutConstraint.activate([
+      self.baseItem.topAnchor.constraint(equalTo: self.topAnchor),
+      self.baseItem.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+      self.baseItem.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+      self.baseItem.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+    ])
+
+    self.checkImageView.image = BezierIcon.check.uiImage?.withRenderingMode(.alwaysTemplate)
+
+    self.refreshLeading()
+    self.refreshSelection()
+    self.refreshAppearance()
+  }
+
+  // MARK: - Slot
+
+  // 슬롯 컨테이너는 intrinsic width가 없어 BaseItem 행의 여분 폭이 hugging 설정과 무관하게
+  // 이 컨테이너로 분배될 수 있다. 콘텐츠를 leading으로 정렬해 컨테이너가 늘어나도 시각 결과가
+  // Figma(centerSlot이 label 바로 옆)와 같게 한다.
+  private func makeCenterSlotContainer(_ view: UIView) -> UIView {
+    let container = UIView()
+    container.clipsToBounds = true
+    container.setContentHuggingPriority(.required, for: .horizontal)
+    container.setContentCompressionResistancePriority(.required, for: .horizontal)
+    view.translatesAutoresizingMaskIntoConstraints = false
+    container.addSubview(view)
+    NSLayoutConstraint.activate([
+      container.heightAnchor.constraint(equalToConstant: BezierMultiSelectOptionConstant.centerSlotHeight),
+      view.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+      view.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+      view.trailingAnchor.constraint(lessThanOrEqualTo: container.trailingAnchor),
+    ])
+    return container
+  }
+
+  // MARK: - Trait
+
+  public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    self.refreshAppearance()
+  }
+
+  // MARK: - Refresh
+
+  private func refreshLeading() {
+    switch self.leading {
+    case .none:
+      self.baseItem.leadingContent = nil
+    case .icon(let icon):
+      self.leadingIconImageView.image = icon.uiImage?.withRenderingMode(.alwaysTemplate)
+      self.baseItem.leadingContent = self.leadingIconImageView
+    case .avatar(let view), .custom(let view):
+      self.baseItem.leadingContent = view
+    }
+    self.refreshAppearance()
+  }
+
+  private func refreshSelection() {
+    self.baseItem.trailingContent = self.isSelected ? self.checkImageView : nil
+  }
+
+  private func refreshAppearance() {
+    if case .icon = self.leading {
+      self.leadingIconImageView.tintColor = BezierMultiSelectOptionConstant.leadingIconColor.palette(self)
+    }
+    self.checkImageView.tintColor = BezierMultiSelectOptionConstant.checkIconColor.palette(self)
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierMultiSelect/BezierMultiSelectSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierMultiSelect/BezierMultiSelectSpec.swift
@@ -1,0 +1,56 @@
+//
+//  BezierMultiSelectSpec.swift
+//  BezierSwift
+//
+
+import CoreGraphics
+
+// MARK: - Container
+
+/// 선택 목록을 화면에 어떻게 얹을지 정하는 표현 방식. Figma `MultiSelect`의 `container` 프로퍼티에 대응 (case 이름 = Figma 값). Figma의 `bottomsheet`는 대응 쉘 컴포넌트가 없어 제공하지 않는다 — bottom sheet 안에서는 `.page`를 시트 콘텐츠로 넣고 Cancel/Save 버튼은 시트 쪽에서 붙인다.
+public enum BezierMultiSelectContainer: CaseIterable {
+  /// 화면에 인라인으로 목록을 그대로 배치한다. bottom sheet·전체 화면 등 이미 확보된 영역 안에 넣을 때 쓰는 기본값이다.
+  case page
+  /// `BezierOverlay` 카드(240pt 고정 폭)로 감싼다. 트리거 근처에 backdrop 없이 띄우는 앵커형 팝오버 맥락(태블릿·넓은 화면)에 쓴다. 이 맥락에서는 항목 탭이 그 자리에서 즉시 반영되므로 확정 버튼을 두지 않는다.
+  case overlay
+}
+
+// MARK: - Option Leading
+
+/// 선택 항목의 leading(좌측) 콘텐츠 유형. Figma `Internal/MultiSelectOption`의 `leadingType` 프로퍼티에 대응 (case 이름 = Figma 값). `Content`는 슬롯에 넣을 뷰 타입이다. 한 목록 안에서는 전 항목에 일관되게 쓰거나 전부 생략한다 — 일부만 넣으면 텍스트 시작 위치가 어긋난다.
+public enum BezierMultiSelectOptionLeading<Content> {
+  /// leading 없이 텍스트만 시작하는 항목. 텍스트만으로 선택지가 충분히 구분될 때 쓴다.
+  case none
+  /// `BezierIcon` 자산을 leading 아이콘으로 표시한다 (Figma `leadingIconSource`). 아이콘이 선택지의 유형·의미를 대표할 때 쓴다.
+  case icon(BezierIcon)
+  /// 사람·엔티티를 고르는 목록에서 `BezierAvatar`를 24×24 leading 슬롯에 배치한다 (Figma `leadingType=avatar`).
+  case avatar(Content)
+  /// 위 셋으로 표현되지 않는 임의의 뷰를 24×24 leading 슬롯에 배치한다 (Figma `leadingContent` SLOT).
+  case custom(Content)
+}
+
+// MARK: - Constant
+
+/// 선택 항목(`BezierMultiSelectOption` / `SUBezierMultiSelectOption`)의 레이아웃 상수. Figma `Internal/MultiSelectOption` 실측값이다.
+public enum BezierMultiSelectOptionConstant {
+  /// 항목 좌우 패딩.
+  public static let horizontalPadding: CGFloat = 10
+  /// 항목 상하 패딩. 최소 높이 48을 넘기는 경우(description 표시)에만 실제 높이에 반영된다.
+  public static let verticalPadding: CGFloat = 6
+  /// 항목 배경 corner radius. pressed 배경과 콘텐츠 클리핑에 함께 쓰인다.
+  public static let cornerRadius: CGFloat = 16
+  /// 선택 표시 체크 아이콘의 한 변 길이.
+  public static let checkIconLength: CGFloat = 20
+  /// 제목 우측 인라인 슬롯의 고정 높이. 초과하는 콘텐츠는 잘린다.
+  public static let centerSlotHeight: CGFloat = 24
+
+  static let leadingIconColor: BCSemanticToken = .iconNeutralHeavy
+  static let checkIconColor: BCSemanticToken = .iconNeutralHeavier
+
+  static let baseItemStyle = BezierBaseItemStyle(
+    horizontalPadding: BezierMultiSelectOptionConstant.horizontalPadding,
+    verticalPadding: BezierMultiSelectOptionConstant.verticalPadding,
+    cornerRadius: BezierMultiSelectOptionConstant.cornerRadius,
+    centerLeadingInset: 0
+  )
+}

--- a/Sources/BezierSwift/MasterComponent/BezierMultiSelect/SPEC.md
+++ b/Sources/BezierSwift/MasterComponent/BezierMultiSelect/SPEC.md
@@ -11,9 +11,11 @@
 
 | Figma property key | Type | Default | 옵션 / 값 | 구현 매핑 |
 |---|---|---|---|---|
-| `container` | VARIANT | page | page / bottomsheet / overlay | `BezierMultiSelectContainer` (§9-2) |
+| `container` | VARIANT | page | page / bottomsheet / overlay | `BezierMultiSelectContainer` — `page`·`overlay`만 제공. **`bottomsheet`는 Figma에만 있고 코드 API에 없다** (§9-2) |
 | `hasLabel` | BOOLEAN | false | on / off | 라벨 유무 (`container=page`에서만 렌더) |
 | `content` | SLOT | — | `Internal/MultiSelectGroup` / `Internal/MultiSelectOption` 배치 | content |
+
+> §1~§5는 Figma 거울이라 Figma에 존재하는 variant를 모두 싣는다. **"구현 매핑" 열에 미제공이라고 적힌 값은 코드 API에 없다** — 지원 범위는 §9의 구현 결정이 결정한다.
 
 총 instance: `container(3) = 3개`
 
@@ -213,6 +215,8 @@ MultiSelect / Internal/MultiSelectGroup / Internal/MultiSelectGroupLabel에는 s
 - width: content SLOT에 맞춰 HUG, min 160 / max 280px 클램프 · position 기본 bottom-start, 트리거와 8px 간격, 화면 밖이면 flip, 가장자리 마진 16px (코드 구현 참고용) · backdrop 없음 · 외부 탭 시 닫힘 · 드래그 딜미스 없음.
 - Mobile Select/MultiSelect의 container=overlay variant가 backdrop 없는 앵커형 팝오버로 옵션 목록을 표시할 때 이 셸을 내장한다.
 
+> **폭 값 충돌 아님 — 대상이 다르다.** 위 `HUG 160~280px`는 **쉘 컴포넌트 단독(`5078:2253`)의 description 문구**다. `container=overlay`(`5150:2921`)가 실제로 내장한 인스턴스는 §2 실측대로 **폭 `240pt` FIXED**(content `220pt`)이고, 구현 계약도 이쪽이다(`BezierOverlayConstant.width = 240`). 이 절은 description 인용이므로, 레이아웃 값이 §2와 다를 때는 **§2 실측이 우선한다** (§9-15).
+
 ## 8. 매핑되는 코드 심볼
 
 | 정의 | 파일 |
@@ -245,6 +249,7 @@ Figma에 없는 구현 아키텍처 결정은 아래에 분리 표기한다. SSO
 12. **label은 1줄 truncate**: §2대로 Figma MultiSelectOption의 label 텍스트에는 truncation 설정이 없어 폭이 부족하면 여러 줄로 흐른다. 구현은 `BezierBaseItem`/`SUBezierBaseItem`의 title 렌더(`numberOfLines = 1` · `.lineLimit(1)` + tail truncate)를 그대로 상속해 1줄로 자른다. 근거: ① 선택 목록의 행 높이가 항목 텍스트 길이에 따라 들쭉날쭉해지면 스캔이 어렵다 ② 형제 그룹 라벨은 같은 Figma 파일에서 명시적으로 nowrap+ellipsis다 ③ BaseItem은 공유 레이어라 이 컴포넌트를 위해 title 줄 수 정책을 바꾸지 않는다. description은 BaseItem이 `numberOfLines = 0`으로 wrap하며 이는 Figma의 wrap 거동과 일치한다.
 13. **`labelText`는 `container=.page`에서만 렌더**: §2대로 Figma `hasLabel`은 page variant에만 노출되고 overlay variant에는 라벨 노드 자체가 없다. 코드의 `labelText`는 두 container에 공통 프로퍼티로 두되(container를 런타임에 바꿀 수 있어야 하므로) 렌더는 `.page`에서만 한다. `.overlay`에서 라벨이 필요하면 Figma가 그 맥락에서 쓰는 경로 — `BezierMultiSelectGroup`/`SUBezierMultiSelectGroup`의 `labelText` — 를 쓴다. doc comment에 이 조건을 명시해 조용한 no-op이 되지 않게 했다.
 14. **centerSlot 고정 높이 클리핑**: Figma는 centerSlot을 높이 FIXED 24pt로 두지만 clip 속성은 부모 `centerContent`에만 있다(§2). 구현은 슬롯 컨테이너 자체에 24pt 고정 + 클리핑을 걸어 초과 콘텐츠가 행 높이를 밀지 않게 한다 — 고정 높이를 실제로 강제하는 수단이며, SwiftUI `.frame(height:)`는 단독으로는 초과 콘텐츠를 넘치게 그린다.
+15. **overlay 폭은 §2 실측 240pt 고정**: §7이 인용한 쉘 description은 폭을 `HUG · min 160 / max 280px`로 적지만, 이는 `overlay`(`5078:2253`) 컴포넌트 단독의 일반 계약이다. MultiSelect가 내장한 인스턴스(`5150:2921`)는 §2 실측대로 `240pt` FIXED이고 `BezierOverlay`도 `BezierOverlayConstant.width = 240`으로 이미 고정돼 있어, 구현은 240pt를 따른다. 앵커 폭에 맞춰 늘어나는 HUG 오버레이가 필요해지면 `BezierOverlay` 쪽 결정 사항이지 이 컴포넌트에서 갈라질 값이 아니다.
 
 ## 10. Variant 매트릭스
 

--- a/Sources/BezierSwift/MasterComponent/BezierMultiSelect/SPEC.md
+++ b/Sources/BezierSwift/MasterComponent/BezierMultiSelect/SPEC.md
@@ -1,0 +1,265 @@
+# BezierMultiSelect SPEC
+
+> **SSOT**: [Figma · Mobile-Components / MultiSelect (4903:6133)](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=4903-6133) · [Internal/MultiSelectOption (1352:42)](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=1352-42) · [Internal/MultiSelectGroup (4648:12419)](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=4648-12419) · [Internal/MultiSelectGroupLabel (4373:20)](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=4373-20)
+> **Design spec doc**: [team-design / bezier-v3 / components / MultiSelect-spec.md](https://github.com/channel-io/team-design/blob/main/bezier-v3/components/MultiSelect-spec.md) · [BaseOverlay.md](https://github.com/channel-io/team-design/blob/main/bezier-v3/components/BaseOverlay.md) · [BaseItem.md](https://github.com/channel-io/team-design/blob/main/bezier-v3/components/BaseItem.md) · [BaseGroupLabel.md](https://github.com/channel-io/team-design/blob/main/bezier-v3/components/BaseGroupLabel.md) (보조 참조 — 값 충돌 시 Figma 파일 우선)
+
+여러 선택지를 동시에 고르고, 선택된 항목마다 우측 체크 아이콘을 표시하는 복수 선택 리스트 컴포넌트.
+
+## 1. Component Properties
+
+### MultiSelect (CS `4903:6133`)
+
+| Figma property key | Type | Default | 옵션 / 값 | 구현 매핑 |
+|---|---|---|---|---|
+| `container` | VARIANT | page | page / bottomsheet / overlay | `BezierMultiSelectContainer` (§9-2) |
+| `hasLabel` | BOOLEAN | false | on / off | 라벨 유무 (`container=page`에서만 렌더) |
+| `content` | SLOT | — | `Internal/MultiSelectGroup` / `Internal/MultiSelectOption` 배치 | content |
+
+총 instance: `container(3) = 3개`
+
+### Internal/MultiSelectGroup (COMPONENT `4648:12419`)
+
+| Figma property key | Type | Default | 옵션 / 값 | 구현 매핑 |
+|---|---|---|---|---|
+| `hasLabel` | BOOLEAN | false | on / off | 그룹 라벨 유무 (복수 그룹일 때만 켠다) |
+| `content` | SLOT (`4648:12422`) | — | `Internal/MultiSelectOption` 배치 | options |
+
+단일 COMPONENT — variant 축 없음. 라벨 텍스트 편집은 내부 `Internal/MultiSelectGroupLabel` 인스턴스(`4648:12420`) 프로퍼티로 (CS 레벨 label TEXT prop 없음). **divider 프로퍼티 없음** — component description이 "구분선 미지원 — 필요 시 외부에 Divider 인스턴스를 배치할 것"으로 명시한다.
+
+### Internal/MultiSelectGroupLabel (CS `4373:20`)
+
+| Figma property key | Type | Default | 옵션 / 값 | 구현 매핑 |
+|---|---|---|---|---|
+| `color` | VARIANT | neutral-light | `neutral-dark` (`4373:16`) / `neutral-light` (`4373:18`) | 텍스트 색. `Internal/MultiSelectGroup` 내부 인스턴스도 `neutral-light` |
+| `label` | TEXT | "Group Label" | 문자열 | labelText |
+
+총 instance: `color(2) = 2개`
+
+### Internal/MultiSelectOption (CS `1352:42`)
+
+| Figma property key | Type | Default | 옵션 / 값 | 구현 매핑 |
+|---|---|---|---|---|
+| `leadingType` | VARIANT | none | none / icon / avatar / custom | `BezierMultiSelectOptionLeading` |
+| `state` | VARIANT | default | default / pressed / disabled | 인터랙션 상태 (§5) |
+| `content` | TEXT | "Option" | 문자열 | title |
+| `hasDescription` | BOOLEAN | false | on / off | description 유무 |
+| `description` | TEXT | "Description" | 문자열 | description |
+| `hasCenterSlot` | BOOLEAN | false | on / off | centerSlot 유무 |
+| `centerSlot` | SLOT | — | 임의 콘텐츠 | centerSlot |
+| `isSelected` | BOOLEAN | false | on / off | true면 trailing 체크 아이콘 표시 |
+| `leadingIconSource` | INSTANCE_SWAP | icon/plus | 아이콘 인스턴스 (leadingType=icon) | `.icon(BezierIcon)` |
+| `leadingContent` | SLOT | — | 임의 콘텐츠 (leadingType=custom) | `.custom(뷰)` |
+
+총 instance: `leadingType(4) × state(3) = 12개`
+
+## 2. Layout Spec
+
+### MultiSelect 루트
+
+| container | 값 |
+|---|---|
+| `page` (`1332:3`) | 세로 스택, gap `0` · padding `0` · overflow clip · 폭 FILL (마스터 목업 폭 `360pt`). `hasLabel` 라벨 → content 순 |
+| `bottomsheet` (`4903:6058`) | `BottomSheet`(`1306:200`) 인스턴스 `360×667pt`. 시트 content 슬롯 padding 상 `12pt` / 좌우 `10pt`. content = `Internal/MultiSelectGroup`(`340×144`) + `buttonsArea`(`340×72`) |
+| `overlay` (`5150:2921`) | `overlay`(`5078:2253`) 인스턴스 — 폭 `240pt` FIXED · padding `10pt` 균일 · corner radius `32pt`(`radius/32`) · content 폭 `220pt`. **footer 없음** |
+
+`container=page`의 `hasLabel` 라벨은 `Internal/MultiSelectGroupLabel` 인스턴스(`1332:11`)이며 폭 FILL로 배치된다.
+
+`hasLabel`은 **`container=page` variant에만 노출된다** — `1332:3`의 property 타입은 `{ container, hasLabel, content }`인데 `5150:2921`(overlay)은 `{ container }`뿐이고 라벨 노드도 없다. overlay·bottomsheet variant는 대신 `Internal/MultiSelectGroup`을 내장하며 그 그룹이 자기 `hasLabel`을 갖는다.
+
+`container=bottomsheet`의 `buttonsArea`(`0:56`)는 Button 인스턴스 2개(각 `166×44pt`)를 gap `8pt`로 가로 배치하며 영역 padding은 상 `12pt` / 하 `16pt` / 좌우 `0`이다. 이 footer는 이 variant에만 있다 (§9-2).
+
+### Internal/MultiSelectGroup
+
+| Part | 값 |
+|---|---|
+| 배치 | 세로 스택: GroupLabel(optional) → content, gap `0` |
+| 폭 | 마스터 `260pt` (사용처에서 FILL) |
+
+### Internal/MultiSelectGroupLabel
+
+| Part | 값 |
+|---|---|
+| 높이 | min-height `32pt` + HUG |
+| 좌우 패딩 | `10pt` |
+| corner radius | `8pt` |
+| 폭 | 마스터 `260pt`, 사용처 인스턴스(`1332:11` · `4648:12420`)는 FILL |
+| 텍스트 overflow | 1줄, ellipsis (`whitespace-nowrap` + `text-ellipsis`) |
+
+### Internal/MultiSelectOption
+
+| Part | 값 |
+|---|---|
+| min height | `48pt`. description 시 콘텐츠 기반으로 늘어나며 Figma 인스턴스 실측은 `52pt`(= 6+24+16+6) |
+| padding | 상하 `6pt` / 좌우 `10pt` |
+| corner radius | `16pt` (루트에 clip 없음 — clip은 `centerContent`에만 있다) |
+| 루트 gap | `10pt` (contentWrapper ↔ check 아이콘), 세로 중앙 정렬 |
+| labelWrapper gap | `10pt` (leading ↔ centerContent) — `leadingType≠none`일 때만 |
+| labelRow gap | `4pt` (label ↔ centerSlot) |
+| leading | `24×24pt` 정방형 (icon / avatar / custom 공통) |
+| centerContent 좌측 인셋 | `0` |
+| centerContent | overflow clip |
+| centerSlot | 폭 HUG × 높이 FIXED `24pt`, 세로 중앙 |
+| check 아이콘 | `20×20pt`, 세로 중앙 (`isSelected=true`일 때만) |
+| description 들여쓰기 | `leadingType≠none`이면 `34pt`(= 24 + 10), `none`이면 `0` |
+| label overflow | truncation 설정 없음 — 폭 FILL + `word-break: break-word`. 같은 파일의 `Internal/MultiSelectGroupLabel` 텍스트가 `whitespace-nowrap` + `text-ellipsis`를 갖는 것과 대비된다 (구현은 1줄 truncate — §9-12) |
+
+`leadingType=custom` variant만 `labelRow`·`centerSlot` 레이어가 없고 `centerContent`가 label을 직속으로 담는다 — 나머지 9개 variant(`none`/`icon`/`avatar` × 3 state)에만 `labelRow`가 있다 (§9-6).
+
+## 3. 컬러 토큰 (Figma 사용처 기준)
+
+### MultiSelect / overlay (container=overlay)
+
+| 영역 | Token | Figma Variable | Raw |
+|---|---|---|---|
+| overlay 배경 | `surfaceHighest` | `color/surface/highest` | `#FFFFFF` |
+| overlay shadow | `elevationLarge` | `color/elevation/large` | `#00000038` |
+
+`container=page`에는 컬러 레이어 없음 — 순수 레이아웃 컨테이너.
+
+### Internal/MultiSelectGroupLabel
+
+| color | Token | Figma Variable | Raw |
+|---|---|---|---|
+| `neutral-light` | `textNeutralLighter` | `color/text/neutral/lighter` | `#00000066` |
+| `neutral-dark` | `textNeutral` | `color/text/neutral` | `#000000D9` |
+
+### Internal/MultiSelectOption
+
+| 위치 | Token | Figma Variable | Raw |
+|---|---|---|---|
+| label 텍스트 | `textNeutral` | `color/text/neutral` | `#000000D9` |
+| description 텍스트 | `textNeutralLighter` | `color/text/neutral/lighter` | `#00000066` |
+| leading 아이콘 (leadingType=icon) | `iconNeutralHeavy` | `color/icon/neutral/heavy` | `#00000099` |
+| check 아이콘 (isSelected) | `iconNeutralHeavier` | `color/icon/neutral/heavier` | `#000000D9` |
+
+두 아이콘 색은 export SVG로 교차 확인했다 — check `fill="black" fill-opacity="0.85"`, leading `fill="black" fill-opacity="0.6"`.
+
+| state | 배경 | 기타 |
+|---|---|---|
+| default | 없음 (투명) | — |
+| pressed | `fillNeutralLighter` (`color/fill/neutral/lighter`, `#00000008`) | — |
+| disabled | 없음 | 본체 opacity `opacity/disabled` = 0.4 |
+
+## 4. Typography
+
+### Case A — Typography Token 사용 (전부 토큰)
+
+| 위치 | Token (`BTSemanticToken`) | Figma Style |
+|---|---|---|
+| option label | `.textXLarge(weight: .regular)` | `Typography/text/xlarge` (Inter Regular, size 16, lineHeight 24, letterSpacing `text/letter-spacing/tight` −0.1) |
+| option description | `.captionMedium(weight: .regular)` | `Typography/caption/medium` (Inter Regular, size 12, lineHeight 16, letterSpacing `caption/letter-spacing` 0) |
+| group label | `.textMedium(weight: .bold)` | `Typography/text/medium-bold` (Inter Bold, size 14, lineHeight 18, letterSpacing `text/letter-spacing` 0) |
+
+### Case B — Custom Typography
+
+없음 (모든 텍스트가 토큰 사용).
+
+## 5. State 별 시각 동작 (Internal/MultiSelectOption)
+
+| State | 시각 변화 | 인터랙션 |
+|---|---|---|
+| `default` | 배경 없음 | 활성 |
+| `pressed` | 배경 `fillNeutralLighter` | 활성 (탭 진행 중) |
+| `disabled` | 본체 opacity 0.4, 배경 없음 | 입력 차단 |
+
+`isSelected`는 state와 독립된 BOOLEAN 축이며, true일 때 trailing에 check 아이콘이 추가된다 (세 state 모두에서 동작). **여러 항목이 동시에 `isSelected=true`일 수 있다.**
+
+MultiSelect / Internal/MultiSelectGroup / Internal/MultiSelectGroupLabel에는 state variant 축 없음 (정적 컨테이너).
+
+## 6. Elevation
+
+| Effect Style | 구성 |
+|---|---|
+| `Elevation/Mobile/3` (container=overlay의 overlay 인스턴스) | DROP_SHADOW · color `color/elevation/large` · offset (0, `elevation/4` = 4) · blur `elevation/20` = 20 · spread 0 |
+
+`container=page`·`container=bottomsheet`의 MultiSelect 루트 자체에는 elevation 없음 (bottomsheet의 그림자는 `BottomSheet` 쉘 소유).
+
+## 7. 디자이너 가이드라인 (Figma component description 인용)
+
+### MultiSelect (`4903:6133`)
+
+- MultiSelect 옵션 목록을 BottomSheet 또는 Overlay로 띄워서 제공하거나, 인라인으로 배치한다.
+- `container`: page(인라인 목록 직접 배치) / bottomsheet(BottomSheet로 present) / overlay(앵커형 팝오버로 present — backdrop 없는 floating 카드).
+- `hasLabel`: 그룹 레이블 표시 여부. `content`: 옵션 목록 슬롯 (MultiSelectOption 사용).
+- "bottomsheet·overlay 사용 시 모두 variant 자체에 Cancel/Save 2버튼 footer가 네이티브로 내장되어 있다(DL-098). Cancel=선택 취소, Save=선택 일괄 반영." — 이 문장은 `container=overlay` variant(`5150:2921`)의 실제 레이어 구조와 어긋난다. overlay variant에는 footer 노드가 없다 (§9-3).
+
+### container=page (`1332:3`) · container=overlay (`5150:2921`) variant description
+
+- "MultiSelectGroupLabel과 MultiSelectItem 리스트를 묶는 복수 선택 컨테이너. 항목 탭 시 Checkbox 토글. Sheet 내 사용 시 확인 버튼으로 일괄 반영. 단일 선택 컨텍스트에서 사용 금지. 항목 탭 즉시 반영 금지." — "Checkbox 토글"은 CS 레벨 description이 명시한 `DL-011 reversal`(leading Checkbox 폐기, trailing checkIcon으로 일원화)과 어긋나며 레이어에도 Checkbox가 없다 (§9-3).
+
+### Internal/MultiSelectGroup (`4648:12419`)
+
+- Used within MultiSelect only. Do not place standalone. MultiSelect 옵션을 카테고리별로 묶는 그룹 컨테이너. 내부에 MultiSelectGroupLabel 인스턴스 + content SLOT을 포함한다.
+- `hasLabel`: 그룹 라벨 표시 여부 (기본 false, 복수 그룹일 때만 켠다).
+- 구분선 미지원 — 필요 시 외부에 Divider 인스턴스를 배치할 것.
+- 단일 그룹일 때는 MultiSelectGroup 없이 MultiSelectOption을 직접 나열할 것.
+
+### Internal/MultiSelectGroupLabel (`4373:20`)
+
+- Used within MultiSelect only. Do not place standalone. MultiSelect의 오버레이 그룹 헤더. label: string만 받으며 슬롯 없음.
+- `color`: neutral-light(기본) / neutral-dark. `label`: 그룹 헤더 텍스트.
+- 안티패턴: content ReactNode · help · trailingContent 불가 — 필요 시 SectionLabel 사용.
+
+### Internal/MultiSelectOption (`1352:42`)
+
+- Used within MultiSelect only. Do not place standalone. MultiSelect 내 복수 선택 항목. 우측 checkIcon(selected=true 시 자동)으로 선택 상태 표시. Checkbox leading 폐기(DL-011 reversal).
+- `leadingType`: none / icon / avatar / custom.
+- `state`: Figma 전용 프로퍼티(코드 prop 아님). default / pressed / disabled.
+- `selected`: false / true — trailing checkIcon 자동 제어.
+- `hasDescription`: true 시 하단 보조 텍스트 표시.
+
+### overlay (`5078:2253` — container=overlay가 내장하는 쉘)
+
+- width: content SLOT에 맞춰 HUG, min 160 / max 280px 클램프 · position 기본 bottom-start, 트리거와 8px 간격, 화면 밖이면 flip, 가장자리 마진 16px (코드 구현 참고용) · backdrop 없음 · 외부 탭 시 닫힘 · 드래그 딜미스 없음.
+- Mobile Select/MultiSelect의 container=overlay variant가 backdrop 없는 앵커형 팝오버로 옵션 목록을 표시할 때 이 셸을 내장한다.
+
+## 8. 매핑되는 코드 심볼
+
+| 정의 | 파일 |
+|---|---|
+| UIKit 컨테이너 | `BezierMultiSelect.swift` |
+| UIKit 그룹 | `BezierMultiSelectGroup.swift` |
+| UIKit 옵션 | `BezierMultiSelectOption.swift` |
+| SwiftUI 컨테이너 | `SUBezierMultiSelect.swift` |
+| SwiftUI 그룹 | `SUBezierMultiSelectGroup.swift` |
+| SwiftUI 옵션 | `SUBezierMultiSelectOption.swift` |
+| container / leading / constant | `BezierMultiSelectSpec.swift` |
+
+> 재사용 심볼 실재 확인: `BezierOverlay` / `SUBezierOverlay` + `BezierOverlayConstant`(width 240 · padding 10 · cornerRadius 32 · elevation `.mEv3` · backgroundColor `.surfaceHighest`), `BezierBaseItem` / `SUBezierBaseItem` + `BezierBaseItemStyle`(레이아웃·pressed 배경·press scale·disabled opacity) + `BezierBaseItemConstant`(slotSpacing 10 · titleRowSpacing 4) + `BezierBaseItemSize.medium`(minHeight 48 · verticalPadding 6 · leadingLength 24), `BezierSectionLabel` / `SUBezierSectionLabel` + `BezierSectionLabelColor.neutralLight` + `BezierSectionConstant`(labelHeight 32 · labelHorizontalPadding 10 · labelCornerRadius 8 · labelTypography `.textMedium(weight: .bold)`), `BCSemanticToken`(.textNeutral / .textNeutralLighter / .iconNeutralHeavy / .iconNeutralHeavier / .fillNeutralLighter / .surfaceHighest), `BTSemanticToken`(.textXLarge / .captionMedium / .textMedium), `BOGlobalToken.disabled` = 0.4, `BezierIcon.check`.
+
+## 9. Figma 외 · 협의 사항 (구현 결정)
+
+Figma에 없는 구현 아키텍처 결정은 아래에 분리 표기한다. SSOT 값이 아니다.
+
+1. **컴포지션 구조 (MOB-6354 핸드오프)**: MultiSelectOption은 `BezierBaseItem`/`SUBezierBaseItem`을 소유(composition)해 구현한다 (상속 금지 — 채널 정석). 오버레이 패널은 `BezierOverlay`/`SUBezierOverlay` 재사용, 그룹 라벨은 `BezierSectionLabel(color: .neutralLight)` 재사용.
+2. **`container=bottomsheet` 미구현**: BezierSwift에는 Figma `BottomSheet`(`1306:200`)에 대응하는 쉘 컴포넌트가 없다(`MasterComponent/` 전수 확인). 해당 variant의 MultiSelect 콘텐츠는 `container=page`와 동일한 인라인 리스트이므로, 코드 API의 `BezierMultiSelectContainer`는 `page`/`overlay` 2종만 제공하고 bottom sheet 호스팅과 §2의 Cancel/Save `buttonsArea` 재현은 사용처 책임으로 둔다 (`BezierSelect` SPEC §9-2와 동일 결정).
+3. **stale description 미반영**: §7이 인용한 Figma description 중 "overlay에도 Cancel/Save footer 내장", "항목 탭 시 Checkbox 토글", "항목 탭 즉시 반영 금지"는 같은 파일의 레이어 구조와 어긋난다 — overlay variant(`5150:2921`)에는 footer 노드가 없고, 12개 option variant 어디에도 Checkbox 노드가 없다(trailing `icon/check` 20×20뿐). 구현은 레이어 구조를 따른다. design doc도 DL-011(Checkbox 폐기)·DL-103(overlay는 footer 없이 탭 즉시 토글)으로 같은 방향이다.
+4. **BaseItem 내부 스타일 주입**: Figma MultiSelectOption은 BaseItem `medium` 기본값 대비 좌우 패딩 10(↔6)·corner radius 16(↔8)·center 좌측 인셋 0(↔2)이 다르다. 이를 위해 internal `BezierBaseItemStyle`에 값을 주입한다. 상하 패딩 6은 `BezierBaseItemSize.medium.verticalPadding`과 우연히 같지만 §2의 Figma 실측값을 코드에 명시하기 위해 함께 주입한다 — 폴백에 의존하면 BaseItem 기본값이 바뀔 때 이 컴포넌트가 조용히 따라간다.
+5. **프레젠테이션·선택 상태 스코프 제외**: 열림/닫힘 상태·앵커 포지셔닝·외부 탭 닫힘은 사용처 책임 (BezierOverlay SPEC §9-1 · BezierSelect SPEC §9-4와 동일 결정). 선택 집합(`isSelected` 조합)의 보관·토글도 사용처 책임이다 — Figma는 옵션 단위 BOOLEAN만 정의한다. 단일 선택 컴포넌트와 달리 "하나만 true" 제약이 없다.
+6. **centerSlot을 4개 leading 유형 전부에 제공**: Figma는 `hasCenterSlot`/`centerSlot`을 CS 레벨 프로퍼티로 정의하면서도 레이어는 `leadingType=custom` 9→12번째 variant를 제외한 9개에만 `labelRow`를 뒀다(§2). 코드는 leading 유형과 무관하게 하나의 렌더 경로를 쓰므로 네 유형 모두에서 centerSlot이 동작한다. leading 유형별로 슬롯 지원을 갈라 놓을 근거가 description·design doc 어디에도 없다.
+7. **state 축은 런타임 상태**: Figma `state`(default/pressed/disabled)는 API 옵션이 아니라 런타임 인터랙션 상태로 구현 — pressed는 터치 추적, disabled는 UIKit `isEnabled` / SwiftUI `.disabled()`. Figma option description도 "state: Figma 전용 프로퍼티(코드 prop 아님)"로 명시한다.
+8. **pressed press-scale**: BaseItem의 press scale 피드백(0.97, 오버슈트 복귀)을 그대로 상속한다 (BaseItem SPEC §7 협의 — Figma 외).
+9. **`hasLabel`/`has*` boolean 표현**: 코드 API는 `labelText: String?`(nil = 미표시)로, 슬롯 계열은 옵셔널/`EmptyView` 분기로 표현 (BezierSelect §9-9 · BezierDropdownMenu §9-7과 동일 관례).
+10. **그룹 divider API 미제공**: `Internal/MultiSelectGroup`에는 divider 프로퍼티가 없고 description이 "필요 시 외부에 Divider 인스턴스를 배치할 것"으로 지시한다. `BezierMultiSelectGroup`도 divider 프로퍼티를 두지 않으며, 구분선이 필요하면 사용처가 `BezierDivider`/`SUBezierDivider`를 형제로 배치한다. 형제 컴포넌트 `BezierSelectGroup`이 `showsDivider`를 갖는 것은 그쪽 Figma 그룹(`4648:129`)이 `showDivider` 프로퍼티를 갖기 때문이며, 이 컴포넌트에 이식할 근거가 아니다.
+11. **`leadingType=avatar`와 `custom`의 렌더 경로 공유**: Figma는 두 축을 분리하지만 레이아웃은 둘 다 24×24 슬롯으로 동일하다. 코드도 두 case를 모두 제공해 Figma 축을 보존하되 렌더는 같은 경로를 쓴다 — case 구분은 "무엇을 넣는가"(`BezierAvatar` 인스턴스 / 임의 뷰)의 문서적 구분이다. Figma `leadingType=avatar`의 leading은 `Avatar` 컴포넌트 인스턴스(size 24)이므로 사용처는 `.avatar(_:)`에 `BezierAvatar`/`SUBezierAvatar`를 넣는다.
+12. **label은 1줄 truncate**: §2대로 Figma MultiSelectOption의 label 텍스트에는 truncation 설정이 없어 폭이 부족하면 여러 줄로 흐른다. 구현은 `BezierBaseItem`/`SUBezierBaseItem`의 title 렌더(`numberOfLines = 1` · `.lineLimit(1)` + tail truncate)를 그대로 상속해 1줄로 자른다. 근거: ① 선택 목록의 행 높이가 항목 텍스트 길이에 따라 들쭉날쭉해지면 스캔이 어렵다 ② 형제 그룹 라벨은 같은 Figma 파일에서 명시적으로 nowrap+ellipsis다 ③ BaseItem은 공유 레이어라 이 컴포넌트를 위해 title 줄 수 정책을 바꾸지 않는다. description은 BaseItem이 `numberOfLines = 0`으로 wrap하며 이는 Figma의 wrap 거동과 일치한다.
+13. **`labelText`는 `container=.page`에서만 렌더**: §2대로 Figma `hasLabel`은 page variant에만 노출되고 overlay variant에는 라벨 노드 자체가 없다. 코드의 `labelText`는 두 container에 공통 프로퍼티로 두되(container를 런타임에 바꿀 수 있어야 하므로) 렌더는 `.page`에서만 한다. `.overlay`에서 라벨이 필요하면 Figma가 그 맥락에서 쓰는 경로 — `BezierMultiSelectGroup`/`SUBezierMultiSelectGroup`의 `labelText` — 를 쓴다. doc comment에 이 조건을 명시해 조용한 no-op이 되지 않게 했다.
+14. **centerSlot 고정 높이 클리핑**: Figma는 centerSlot을 높이 FIXED 24pt로 두지만 clip 속성은 부모 `centerContent`에만 있다(§2). 구현은 슬롯 컨테이너 자체에 24pt 고정 + 클리핑을 걸어 초과 콘텐츠가 행 높이를 밀지 않게 한다 — 고정 높이를 실제로 강제하는 수단이며, SwiftUI `.frame(height:)`는 단독으로는 초과 콘텐츠를 넘치게 그린다.
+
+## 10. Variant 매트릭스
+
+```text
+MultiSelect (4903:6133, 3):
+  container=page        = 1332:3
+  container=bottomsheet = 4903:6058
+  container=overlay     = 5150:2921
+
+Internal/MultiSelectGroup      = 4648:12419  (총 1 — COMPONENT, property만)
+Internal/MultiSelectGroupLabel = color=neutral-dark 4373:16, color=neutral-light 4373:18 (총 2)
+
+Internal/MultiSelectOption (1352:42, 12):
+  leadingType=none,   state=default|pressed|disabled = 4675:90  | 4675:102 | 4675:114
+  leadingType=icon,   state=default|pressed|disabled = 4675:126 | 4675:144 | 4675:162
+  leadingType=avatar, state=default|pressed|disabled = 4676:102 | 4676:128 | 4676:152
+  leadingType=custom, state=default|pressed|disabled = 4676:176 | 4676:190 | 4676:204
+```

--- a/Sources/BezierSwift/MasterComponent/BezierMultiSelect/SUBezierMultiSelect.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierMultiSelect/SUBezierMultiSelect.swift
@@ -1,0 +1,64 @@
+//
+//  SUBezierMultiSelect.swift
+//  BezierSwift
+//
+
+import SwiftUI
+
+/// 미리 정의된 선택지 중 여러 개를 고르는 복수 선택 목록 (SwiftUI). 선택적 라벨 + 선택지 목록으로 구성되며, `container`로 인라인 배치(`page`)와 오버레이 카드(`overlay`) 중 하나를 고른다. 목록 콘텐츠에는 `SUBezierMultiSelectGroup`/`SUBezierMultiSelectOption`을 넣는다. 진입 트리거·열림/닫힘·앵커 포지셔닝과 선택 집합 보관은 사용처 책임이다. UIKit에서는 `BezierMultiSelect`를 사용한다.
+public struct SUBezierMultiSelect<Content: View>: View {
+  private let container: BezierMultiSelectContainer
+  private let labelText: String?
+  private let content: Content
+
+  /// 표현 방식·라벨 텍스트·목록 빌더로 목록을 만든다. 라벨은 목록 전체의 맥락을 나타내며 `container`가 `.page`일 때만 렌더된다 — `.overlay`에서 라벨이 필요하면 `SUBezierMultiSelectGroup`의 `labelText`를 쓴다.
+  public init(
+    container: BezierMultiSelectContainer = .page,
+    labelText: String? = nil,
+    @ViewBuilder content: () -> Content
+  ) {
+    self.container = container
+    self.labelText = labelText
+    self.content = content()
+  }
+
+  public var body: some View {
+    switch self.container {
+    case .page:
+      self.list(showsLabel: true)
+    case .overlay:
+      SUBezierOverlay { self.list(showsLabel: false) }
+    }
+  }
+
+  private func list(showsLabel: Bool) -> some View {
+    VStack(alignment: .leading, spacing: 0) {
+      if showsLabel, let labelText = self.labelText, !labelText.isEmpty {
+        SUBezierSectionLabel(labelText, color: .neutralLight)
+      }
+
+      self.content
+    }
+  }
+}
+
+struct SUBezierMultiSelect_Previews: PreviewProvider {
+  static var previews: some View {
+    VStack(spacing: 32) {
+      SUBezierMultiSelect(labelText: "태그") {
+        SUBezierMultiSelectOption(title: "긴급", isSelected: true, onToggle: {})
+        SUBezierMultiSelectOption(title: "VIP 고객", isSelected: true, onToggle: {})
+        SUBezierMultiSelectOption(title: "재문의", onToggle: {})
+      }
+
+      SUBezierMultiSelect(container: .overlay) {
+        SUBezierMultiSelectGroup(labelText: "담당자") {
+          SUBezierMultiSelectOption(title: "김하나", leading: .icon(.person), isSelected: true, onToggle: {})
+          SUBezierMultiSelectOption(title: "이두리", leading: .icon(.person), onToggle: {})
+        }
+      }
+    }
+    .padding()
+    .background(Color.gray.opacity(0.15))
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierMultiSelect/SUBezierMultiSelectGroup.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierMultiSelect/SUBezierMultiSelectGroup.swift
@@ -1,0 +1,48 @@
+//
+//  SUBezierMultiSelectGroup.swift
+//  BezierSwift
+//
+
+import SwiftUI
+
+/// `SUBezierMultiSelect` 안에서 선택지를 카테고리별로 묶는 그룹 컨테이너 (SwiftUI). 선택적 라벨 + 선택지 목록으로 구성된다. 단일 그룹이면 그룹 없이 `SUBezierMultiSelectOption`을 직접 나열한다. 구분선은 이 컨테이너가 제공하지 않으므로 필요하면 사용처가 `SUBezierDivider`를 형제로 배치한다. UIKit에서는 `BezierMultiSelectGroup`을 사용한다.
+public struct SUBezierMultiSelectGroup<Content: View>: View {
+  private let labelText: String?
+  private let content: Content
+
+  /// 라벨 텍스트·선택지 빌더로 그룹을 만든다. 라벨은 복수 그룹일 때만 지정한다.
+  public init(
+    labelText: String? = nil,
+    @ViewBuilder content: () -> Content
+  ) {
+    self.labelText = labelText
+    self.content = content()
+  }
+
+  public var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      if let labelText = self.labelText, !labelText.isEmpty {
+        SUBezierSectionLabel(labelText, color: .neutralLight)
+      }
+
+      self.content
+    }
+  }
+}
+
+struct SUBezierMultiSelectGroup_Previews: PreviewProvider {
+  static var previews: some View {
+    VStack(spacing: 0) {
+      SUBezierMultiSelectGroup(labelText: "우선순위") {
+        SUBezierMultiSelectOption(title: "긴급", isSelected: true, onToggle: {})
+        SUBezierMultiSelectOption(title: "높음", isSelected: true, onToggle: {})
+      }
+      SUBezierDivider()
+      SUBezierMultiSelectGroup(labelText: "카테고리") {
+        SUBezierMultiSelectOption(title: "결제", onToggle: {})
+        SUBezierMultiSelectOption(title: "배송", isSelected: true, onToggle: {})
+      }
+    }
+    .padding()
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierMultiSelect/SUBezierMultiSelectOption.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierMultiSelect/SUBezierMultiSelectOption.swift
@@ -34,8 +34,9 @@ public struct SUBezierMultiSelectOption<CenterSlot: View>: View, Themeable {
   }
 
   public var body: some View {
-    // leading 유무를 여기서 분기해 빈 슬롯이 리터럴 EmptyView 타입이 되게 한다
-    // (BaseItem이 타입으로 슬롯 렌더를 거르므로, 옵셔널 뷰를 넘기면 빈 24pt 박스가 남는다).
+    // 빈 슬롯은 리터럴 EmptyView 타입으로 넘겨야 한다 — BaseItem이 슬롯 타입으로 렌더를 거르는데
+    // @ViewBuilder의 if는 결과를 Optional로 감싸 EmptyView로 특수화되지 않고, 그러면 BaseItem이
+    // 슬롯을 제거하지 못한다. leading은 여기서, centerSlot은 item(leading:)에서 분기한다.
     switch self.leading {
     case .none:
       self.item(leading: { EmptyView() })
@@ -46,8 +47,20 @@ public struct SUBezierMultiSelectOption<CenterSlot: View>: View, Themeable {
     }
   }
 
+  @ViewBuilder
   private func item<Leading: View>(
     @ViewBuilder leading: () -> Leading
+  ) -> some View {
+    if CenterSlot.self == EmptyView.self {
+      self.baseItem(leading: leading, centerSlot: { EmptyView() })
+    } else {
+      self.baseItem(leading: leading, centerSlot: { self.centerSlotView })
+    }
+  }
+
+  private func baseItem<Leading: View, Center: View>(
+    @ViewBuilder leading: () -> Leading,
+    @ViewBuilder centerSlot: () -> Center
   ) -> some View {
     SUBezierBaseItem(
       style: BezierMultiSelectOptionConstant.baseItemStyle,
@@ -56,7 +69,7 @@ public struct SUBezierMultiSelectOption<CenterSlot: View>: View, Themeable {
       description: self.itemDescription,
       onTap: self.onToggle,
       leading: leading,
-      centerSlot: { self.centerSlotView },
+      centerSlot: centerSlot,
       trailing: { self.checkView }
     )
   }
@@ -69,13 +82,10 @@ public struct SUBezierMultiSelectOption<CenterSlot: View>: View, Themeable {
       .foregroundColor(self.palette(BezierMultiSelectOptionConstant.leadingIconColor))
   }
 
-  @ViewBuilder
   private var centerSlotView: some View {
-    if CenterSlot.self != EmptyView.self {
-      self.centerSlot
-        .frame(height: BezierMultiSelectOptionConstant.centerSlotHeight)
-        .clipped()
-    }
+    self.centerSlot
+      .frame(height: BezierMultiSelectOptionConstant.centerSlotHeight)
+      .clipped()
   }
 
   @ViewBuilder

--- a/Sources/BezierSwift/MasterComponent/BezierMultiSelect/SUBezierMultiSelectOption.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierMultiSelect/SUBezierMultiSelectOption.swift
@@ -1,0 +1,142 @@
+//
+//  SUBezierMultiSelectOption.swift
+//  BezierSwift
+//
+
+import SwiftUI
+
+/// `SUBezierMultiSelect` 목록 안에 넣는 복수 선택지 (SwiftUI). leading(아이콘/아바타/커스텀) · 제목 · description · centerSlot으로 구성되며, 선택되면 우측에 체크 아이콘이 붙는다. 한 목록에서 여러 항목이 동시에 선택될 수 있다 — 하나만 고르게 하려면 `SUBezierSelectOption`을, 선택이 값으로 남지 않고 일회성 액션을 실행한다면 `SUBezierDropdownMenuItem`을 쓴다. UIKit에서는 `BezierMultiSelectOption`을 사용한다.
+public struct SUBezierMultiSelectOption<CenterSlot: View>: View, Themeable {
+  @Environment(\.colorScheme) public var colorScheme
+
+  private let title: String
+  private let itemDescription: String?
+  private let leading: BezierMultiSelectOptionLeading<AnyView>
+  private let isSelected: Bool
+  private let onToggle: (() -> Void)?
+  private let centerSlot: CenterSlot
+
+  /// 제목·description·leading·선택 여부·토글 핸들러와 centerSlot 빌더로 선택지를 만든다. 복수 선택이므로 여러 항목이 동시에 `isSelected`일 수 있고, 선택 집합의 보관과 토글은 사용처 책임이다.
+  public init(
+    title: String,
+    description: String? = nil,
+    leading: BezierMultiSelectOptionLeading<AnyView> = .none,
+    isSelected: Bool = false,
+    onToggle: (() -> Void)? = nil,
+    @ViewBuilder centerSlot: () -> CenterSlot
+  ) {
+    self.title = title
+    self.itemDescription = description
+    self.leading = leading
+    self.isSelected = isSelected
+    self.onToggle = onToggle
+    self.centerSlot = centerSlot()
+  }
+
+  public var body: some View {
+    // leading 유무를 여기서 분기해 빈 슬롯이 리터럴 EmptyView 타입이 되게 한다
+    // (BaseItem이 타입으로 슬롯 렌더를 거르므로, 옵셔널 뷰를 넘기면 빈 24pt 박스가 남는다).
+    switch self.leading {
+    case .none:
+      self.item(leading: { EmptyView() })
+    case .icon(let icon):
+      self.item(leading: { self.iconView(icon) })
+    case .avatar(let view), .custom(let view):
+      self.item(leading: { view })
+    }
+  }
+
+  private func item<Leading: View>(
+    @ViewBuilder leading: () -> Leading
+  ) -> some View {
+    SUBezierBaseItem(
+      style: BezierMultiSelectOptionConstant.baseItemStyle,
+      size: .medium,
+      title: self.title,
+      description: self.itemDescription,
+      onTap: self.onToggle,
+      leading: leading,
+      centerSlot: { self.centerSlotView },
+      trailing: { self.checkView }
+    )
+  }
+
+  private func iconView(_ icon: BezierIcon) -> some View {
+    icon.image
+      .renderingMode(.template)
+      .resizable()
+      .scaledToFit()
+      .foregroundColor(self.palette(BezierMultiSelectOptionConstant.leadingIconColor))
+  }
+
+  @ViewBuilder
+  private var centerSlotView: some View {
+    if CenterSlot.self != EmptyView.self {
+      self.centerSlot
+        .frame(height: BezierMultiSelectOptionConstant.centerSlotHeight)
+        .clipped()
+    }
+  }
+
+  @ViewBuilder
+  private var checkView: some View {
+    if self.isSelected {
+      BezierIcon.check.image
+        .renderingMode(.template)
+        .resizable()
+        .scaledToFit()
+        .frame(
+          width: BezierMultiSelectOptionConstant.checkIconLength,
+          height: BezierMultiSelectOptionConstant.checkIconLength
+        )
+        .foregroundColor(self.palette(BezierMultiSelectOptionConstant.checkIconColor))
+    }
+  }
+}
+
+// MARK: - Convenience init (centerSlot 생략)
+
+extension SUBezierMultiSelectOption where CenterSlot == EmptyView {
+  /// centerSlot 없이 만드는 편의 이니셜라이저.
+  public init(
+    title: String,
+    description: String? = nil,
+    leading: BezierMultiSelectOptionLeading<AnyView> = .none,
+    isSelected: Bool = false,
+    onToggle: (() -> Void)? = nil
+  ) {
+    self.init(
+      title: title,
+      description: description,
+      leading: leading,
+      isSelected: isSelected,
+      onToggle: onToggle,
+      centerSlot: { EmptyView() }
+    )
+  }
+}
+
+struct SUBezierMultiSelectOption_Previews: PreviewProvider {
+  static var previews: some View {
+    VStack(spacing: 0) {
+      SUBezierMultiSelectOption(title: "한국어", isSelected: true, onToggle: {})
+      SUBezierMultiSelectOption(title: "English", isSelected: true, onToggle: {})
+      SUBezierMultiSelectOption(title: "日本語", onToggle: {})
+      SUBezierMultiSelectOption(
+        title: "긴급",
+        leading: .icon(.tag),
+        isSelected: true,
+        onToggle: {}
+      )
+      SUBezierMultiSelectOption(
+        title: "VIP 고객",
+        description: "결제 이력이 상위 10%인 고객",
+        leading: .icon(.star),
+        onToggle: {}
+      )
+      SUBezierMultiSelectOption(title: "비활성 항목", leading: .icon(.lock), onToggle: {})
+        .disabled(true)
+    }
+    .padding()
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierSelect/BezierSelect.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierSelect/BezierSelect.swift
@@ -24,7 +24,7 @@ public final class BezierSelect: UIView, BezierComponentable {
     didSet { if oldValue != self.container { self.rebuildContainer() } }
   }
 
-  /// 목록 상단 라벨 텍스트. `nil`이면 라벨을 숨긴다 (기본값 `nil`).
+  /// 목록 상단 라벨 텍스트. `nil`이면 라벨을 숨긴다 (기본값 `nil`). `container`가 `.overlay`면 렌더되지 않는다 — 오버레이 안에서 라벨이 필요하면 `BezierSelectGroup`의 `labelText`를 쓴다.
   public var labelText: String? {
     didSet { if oldValue != self.labelText { self.refreshLabel() } }
   }
@@ -104,8 +104,9 @@ public final class BezierSelect: UIView, BezierComponentable {
   }
 
   private func refreshLabel() {
-    self.sectionLabel.text = self.labelText ?? ""
-    self.sectionLabel.isHidden = (self.labelText?.isEmpty ?? true)
+    let text = self.labelText ?? ""
+    self.sectionLabel.text = text
+    self.sectionLabel.isHidden = text.isEmpty || self.container != .page
   }
 
   private func rebuildContainer() {
@@ -135,5 +136,6 @@ public final class BezierSelect: UIView, BezierComponentable {
       ]
     }
     NSLayoutConstraint.activate(self.containerConstraints)
+    self.refreshLabel()
   }
 }

--- a/Sources/BezierSwift/MasterComponent/BezierSelect/SPEC.md
+++ b/Sources/BezierSwift/MasterComponent/BezierSelect/SPEC.md
@@ -232,6 +232,7 @@ Figma에 없는 구현 아키텍처 결정은 아래에 분리 표기한다. SSO
 11. **그룹 라벨 높이는 min-height 32 + HUG 하나로 통일**: §2대로 Figma는 `Internal/SelectGroup` 내부 라벨 인스턴스(`4648:130`)만 FIXED 32로 오버라이드하고 마스터·page 사용처는 min-height 32 + HUG다. 재사용하는 `BezierSectionLabel`/`SUBezierSectionLabel`은 맥락 구분 없이 min-height 32 + HUG만 제공하며, 라벨이 1줄 고정(ellipsis)이라 두 경우의 렌더 높이가 32pt로 같다. 구분을 코드에 재현하지 않는다.
 12. **description 행 높이는 line-height 16 기준 56pt**: Figma 인스턴스 실측 높이는 55pt지만 이는 description 텍스트 노드가 glyph box(15)로 잡힌 값이고, 노드에 바인딩된 `caption/line-height/medium`은 16이다. iOS는 `BTSemanticToken.captionMedium`의 line-height 16을 그대로 쓰므로 행 높이가 56pt가 된다(시뮬레이터 실측 UIKit·SwiftUI 모두 56.0/56.33pt). 형제 컴포넌트 `BezierDropdownMenu` SPEC도 line-height 16 기준(6+24+16+6=52)으로 기재돼 있다.
 13. **`leadingType=avatar`와 `custom`의 렌더 경로 공유**: Figma는 두 축을 분리하지만 레이아웃은 둘 다 24×24 슬롯으로 동일하다. 코드도 두 case를 모두 제공해 Figma 축을 보존하되 렌더는 같은 경로를 쓴다 — case 구분은 "무엇을 넣는가"(Avatar / 임의 뷰)의 문서적 구분이다.
+14. **`labelText`는 `container=.page`에서만 렌더**: §2대로 Figma `hasLabel`(`4870:1`)에 바인딩된 노드는 page variant의 루트 라벨(`1331:11`)뿐이고 overlay variant에는 라벨 노드 자체가 없다 — overlay 안에 보이는 라벨은 `Internal/SelectGroup`이 소유한 별개 축(`hasLabel#4665:1`)이다. 코드의 `labelText`는 두 container에 공통 프로퍼티로 두되(container를 런타임에 바꿀 수 있어야 하므로) 렌더는 `.page`에서만 한다. `.overlay`에서 라벨이 필요하면 Figma가 그 맥락에서 쓰는 경로 — `BezierSelectGroup`/`SUBezierSelectGroup`의 `labelText` — 를 쓴다. doc comment에 이 조건을 명시해 조용한 no-op이 되지 않게 했다 (`BezierMultiSelect` SPEC §9-13과 동일 결정).
 
 ## 10. Variant 매트릭스
 

--- a/Sources/BezierSwift/MasterComponent/BezierSelect/SUBezierSelect.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierSelect/SUBezierSelect.swift
@@ -11,7 +11,7 @@ public struct SUBezierSelect<Content: View>: View {
   private let labelText: String?
   private let content: Content
 
-  /// 표현 방식·라벨 텍스트·목록 빌더로 목록을 만든다. 라벨은 목록 전체의 맥락을 나타내며, 그룹별 라벨이 필요하면 `SUBezierSelectGroup`의 `labelText`를 쓴다.
+  /// 표현 방식·라벨 텍스트·목록 빌더로 목록을 만든다. 라벨은 목록 전체의 맥락을 나타내며 `container`가 `.page`일 때만 렌더된다 — `.overlay`에서 라벨이 필요하면 `SUBezierSelectGroup`의 `labelText`를 쓴다.
   public init(
     container: BezierSelectContainer = .page,
     labelText: String? = nil,
@@ -25,15 +25,15 @@ public struct SUBezierSelect<Content: View>: View {
   public var body: some View {
     switch self.container {
     case .page:
-      self.list
+      self.list(showsLabel: true)
     case .overlay:
-      SUBezierOverlay { self.list }
+      SUBezierOverlay { self.list(showsLabel: false) }
     }
   }
 
-  private var list: some View {
+  private func list(showsLabel: Bool) -> some View {
     VStack(alignment: .leading, spacing: 0) {
-      if let labelText = self.labelText, !labelText.isEmpty {
+      if showsLabel, let labelText = self.labelText, !labelText.isEmpty {
         SUBezierSectionLabel(labelText, color: .neutralLight)
       }
 


### PR DESCRIPTION
## MOB-6354

https://linear.app/channel/issue/MOB-6354

V3 MultiSelect 컴포넌트 패밀리(MultiSelect / MultiSelectGroup / MultiSelectOption)를 UIKit + SwiftUI로 구현합니다.

> **방금 머지된 `BezierSelect`(#168)와 같은 구조입니다.** Mobile MultiSelect도 Web과 달리 input 스타일 trigger를 갖지 않는 **inline 리스트**이고(Figma `MultiSelect` CS `4903:6133` 실측), 선택 표시는 checkbox가 아니라 **trailing check 아이콘**입니다(DL-011 — leading Checkbox 폐기). 그래서 Select와 동일한 컴포지션 idiom을 그대로 따랐습니다. 단일 선택과 달리 **여러 항목이 동시에 `isSelected`일 수 있습니다.**

### Select와 다른 점 (Figma 실측)

| 항목 | Select | **MultiSelect** |
|---|---|---|
| 상하 패딩 | 8 | **6** (= BaseItem `medium` 기본값과 동일) |
| description 행 높이 | 55pt 실측 / 56 구현 | **52pt** (= 6+24+16+6, Figma 실측과 구현 일치) |
| check 아이콘 | 24×24 | **20×20** |
| check 색 변수 바인딩 | 없음 (raw `#000000D9`) | **`color/icon/neutral/heavier` 바인딩 있음** |
| 그룹 divider | `showDivider` 프로퍼티 있음 | **없음** — description이 "구분선 미지원, 필요 시 외부에 Divider 배치"로 지시 |
| `container=bottomsheet` | 버튼 없음 (선택 즉시 반영) | Cancel/Save 2버튼 `buttonsArea` 내장 (DL-098) |
| 선택 개수 | 하나만 true (사용처 보장) | **복수 true 허용** |
| page 루트 라벨 폭 | x=10·폭 340 (§9-10에서 FILL로 정렬) | **처음부터 FILL** — 정렬 divergence 없음 |

## 구현 내용

### 컴포지션 구조 (재구현 없음 — 기존 V3 컴포넌트 조합)

```
BezierMultiSelect (container: page | overlay)
├── BezierSectionLabel                     ← 재사용 (color: .neutralLight — Figma MultiSelectGroupLabel과 동일 스펙)
└── [container=.overlay] BezierOverlay      ← 재사용 (240pt · padding 10 · radius 32 · mEv3)
    └── BezierMultiSelectGroup ×N
        ├── BezierSectionLabel              ← 재사용
        └── BezierMultiSelectOption ×N
            └── BezierBaseItem              ← composition 소유 (상속 금지, MOB-6354 핸드오프)
```

`BezierDivider`는 그룹 안에 넣지 않았습니다 — Figma `Internal/MultiSelectGroup`(`4648:12419`)에 divider 프로퍼티가 없고 component description이 "구분선 미지원 — 필요 시 외부에 Divider 인스턴스를 배치할 것"으로 명시하기 때문입니다. 형제 `BezierSelectGroup`이 `showsDivider`를 갖는 것은 그쪽 Figma 그룹(`4648:129`)에 `showDivider`가 있어서이며, 이식 근거가 아닙니다 (`SPEC.md` §9-10).

### MultiSelect — `BezierMultiSelect` / `SUBezierMultiSelect`

- `container` = Figma `container` VARIANT. `page`(인라인 배치) / `overlay`(`BezierOverlay` 240pt 카드)
- Figma의 `container=bottomsheet`는 **미제공** — BezierSwift에 대응 BottomSheet 쉘이 없고(`MasterComponent/` 전수 확인), 해당 variant의 콘텐츠는 `page`와 동일한 인라인 리스트라 bottom sheet 호스팅과 Cancel/Save `buttonsArea` 재현을 사용처 책임으로 뒀습니다 (§9-2, `BezierSelect` §9-2와 동일 결정)
- `labelText`(nil = 미표시) = Figma `hasLabel` + `Internal/MultiSelectGroupLabel`의 `label` TEXT
- 열림/닫힘·앵커 포지셔닝·외부 탭 닫힘, 그리고 **선택 집합의 보관·토글은 사용처 책임** — Figma는 옵션 단위 BOOLEAN만 정의합니다 (§9-5)

### MultiSelectGroup — `BezierMultiSelectGroup` / `SUBezierMultiSelectGroup`

- `labelText`(복수 그룹일 때만) + 선택지 목록. divider 프로퍼티 없음(위 참조)
- 라벨 = `BezierSectionLabel(color: .neutralLight)` 재사용 — Figma `Internal/MultiSelectGroupLabel`과 레이아웃(min-height 32 / 좌우 10 / radius 8)·타이포(`textMedium bold`)·색(`textNeutralLighter`) 일치 실측 확인

### MultiSelectOption — `BezierMultiSelectOption` / `SUBezierMultiSelectOption`

- `BezierBaseItem`/`SUBezierBaseItem`을 **composition(소유)** — pressed 배경(`fillNeutralLighter`)·press scale(0.97 + 오버슈트 복귀)·disabled(opacity 0.4)·min-height 48·슬롯 gap 10·labelRow gap 4·truncate 전부 BaseItem에 위임
- leading `none` / `icon(BezierIcon)` / `avatar(뷰)` / `custom(뷰)` — Figma `leadingType` 4축, 24×24. `avatar`와 `custom`은 렌더 경로를 공유하며 case 구분은 "무엇을 넣는가"의 문서적 구분입니다 (§9-11)
- `isSelected` = Figma BOOLEAN. state(default/pressed/disabled)와 **독립 축**이고 **여러 항목이 동시에 true일 수 있습니다.** true면 trailing에 20×20 check 아이콘(`BezierIcon.check`, `iconNeutralHeavier`)이 붙습니다
- `onToggle` — 단일 선택의 `onSelect`와 달리 탭이 곧 토글이라는 의미를 이름에 담았습니다. 사용처가 해당 항목의 `isSelected`를 뒤집어 다시 주입합니다
- description: Figma `hasDescription` 지원 (48 → 52pt, 들여쓰기 34/0)
- `centerSlot`: Figma FIXED 높이 24 컨테이너로 감싸고 클리핑 (§9-13)

### BaseItem internal 스타일 주입 (public API 불변, struct 변경 없음)

Figma MultiSelectOption은 BaseItem `medium` 기본값 대비 **좌우 패딩 10(↔6) · radius 16(↔8) · center 인셋 0(↔2)** 이 다릅니다. 상수 하드코딩 대신 기존 internal `BezierBaseItemStyle` 주입으로 해소했습니다.

**Select와 달리 `BezierBaseItemStyle`에 필드를 추가하지 않았습니다.** Select는 상하 패딩 8이 필요해 `verticalPadding: CGFloat?`를 신설했지만, MultiSelect의 상하 패딩 6은 `BezierBaseItemSize.medium.verticalPadding`과 같아 그 필드를 그대로 쓰면 됩니다. 다만 `nil` 폴백에 기대지 않고 **6을 명시 주입**했습니다 — 폴백에 의존하면 BaseItem 기본값이 바뀔 때 이 컴포넌트가 조용히 따라가므로, §2의 Figma 실측값을 코드에 박아 둡니다 (§9-4).

### SwiftUI 빈 슬롯 처리

leading 유무를 `SUBezierMultiSelectOption` body에서 분기 — `.none`이면 리터럴 `EmptyView`가 `SUBezierBaseItem`의 `Leading.self != EmptyView.self` 체크에 걸리도록 하여 빈 24×24 박스를 방지 (핸드오프 ⚠️ 항목). trailing check on/off는 클로저 내부 런타임 조건부로 처리했습니다.

## Spec 검증

figma-component-spec 3단계 사이클로 검증했습니다 (Figma = SSOT):

- **Phase 0**: `figma-desktop` MCP가 대상 노드에 빈 canvas를 반환하고 인스턴스 노드는 "not found"라 원격 `figma` MCP로 확정 (skill의 대조 절차 — Select와 동일 결과)
- **Phase 1**: Figma 실측 기반 `SPEC.md` 작성 — MultiSelect CS `4903:6133`(3v) / Internal/MultiSelectOption CS `1352:42`(12v) / Internal/MultiSelectGroup `4648:12419` / Internal/MultiSelectGroupLabel CS `4373:20`(2v)
- **Phase 2**: Properties / Layout / Color / Typography / Asset / Spec Noise / Implementation Reference 7종 병렬 검증
  - Properties·Color·Typography·Asset·Noise는 1회 통과
  - **Layout 지적 2건 반영**: ① `centerSlot` 행에 적은 `clip`이 실제로는 부모 `centerContent`의 속성이었음 → `centerContent | overflow clip` 행으로 분리하고 구현의 슬롯 클리핑은 §9-13 결정으로 이관 ② `label overflow`를 "1줄 `textTruncation=ENDING`"으로 적었으나 Figma codegen에 truncation 클래스가 전혀 없음(대조군 GroupLabel은 `whitespace-nowrap`+`text-ellipsis`를 가짐) → "truncation 설정 없음"으로 정정하고 구현의 1줄 truncate를 §9-12 divergence로 명시
  - Implementation Reference 지적 1건은 구현 파일이 생성되는 중에 SPEC 구버전을 읽어 발생한 것으로, 재검증에서 해소
- **Phase 3**: UIKit·SwiftUI Implementation Validator로 구현–SPEC 일치 확인
  - **지적 1건 반영**: `labelText`를 `container=.overlay`에서도 렌더하고 있었습니다. Figma를 다시 보면 `hasLabel`은 **page variant에만 노출된 프로퍼티**입니다 — `1332:3`의 property 타입은 `{ container, hasLabel, content }`인데 `5150:2921`(overlay)은 `{ container }`뿐이고 라벨 노드 자체가 없습니다. overlay·bottomsheet는 대신 `Internal/MultiSelectGroup`을 내장하고 그 그룹이 자기 `hasLabel`을 갖습니다. 양 패러다임 모두 `.page`에서만 렌더하도록 고치고(UIKit은 `container` 런타임 변경 시 재평가되도록 `rebuildContainer()`에서 `refreshLabel()` 호출), doc comment에 조건을 명시해 조용한 no-op이 되지 않게 했습니다 (§9-13). **같은 결함이 `BezierSelect`에도 있어 이 PR에서 함께 고쳤습니다 — 아래 전용 절 참조**
- Figma에 없는 구현 결정(BaseItem composition · internal 스타일 주입 · bottomsheet 미제공 · stale description 미반영 · label 1줄 truncate · centerSlot 클리핑 · divider API 미제공 · 프레젠테이션 스코프 제외 등 13건)은 `SPEC.md` §9에 협의 사항으로 분리 기록

**자산 검증**: Figma raw asset 2종(`icon/check` 20×20, leading 기본 `icon/plus` 24×24) 모두 `BezierIcon` enum + `Icons.xcassets`에 형태가 일치하는 자산이 실재함을 export SVG path 대조로 확인했습니다. SF Symbol fallback 없음.

**check 아이콘 색**: Select와 달리 MultiSelect의 check는 **Figma 변수에 실제로 바인딩되어 있습니다** — `get_variable_defs`가 실사용 인스턴스 양쪽에서 `color/icon/neutral/heavier`를 반환하고 export SVG의 `fill="black" fill-opacity="0.85"`가 `#000000D9`와 일치합니다. 추측 매핑 없이 `iconNeutralHeavier`로 직결했습니다.

### Figma 파일 자체의 정합성 이슈 2건 (구현에 반영하지 않음)

SSOT는 레이어 구조로 삼고, description·목업 콘텐츠의 드리프트는 따르지 않았습니다 (§9-3).

1. **stale description** — MultiSelect CS description은 "bottomsheet·overlay 사용 시 모두 Cancel/Save footer 내장", variant description은 "항목 탭 시 Checkbox 토글 / 항목 탭 즉시 반영 금지"라고 적혀 있지만, `container=overlay`(`5150:2921`)에는 footer 노드가 없고 12개 option variant 어디에도 Checkbox 노드가 없습니다(trailing `icon/check`뿐). design doc도 DL-011(Checkbox 폐기)·DL-103(overlay는 footer 없이 탭 즉시 토글)으로 같은 방향입니다.
2. **`container=page` 목업 콘텐츠의 타이포 드리프트** — `1332:3`의 예시 Option 인스턴스 3개(`1460:101`/`106`/`111`)만 `Typography/text/medium`(14/18)에 바인딩돼 있고, 마스터 CS·Group·overlay·실사용 인스턴스는 전부 `Typography/text/xlarge`(16/24)입니다. canonical 마스터 기준으로 `textXLarge`를 적용했습니다. 디자인팀 확인이 필요한 항목으로 공유합니다.

## 함께 포함: `BezierSelect`의 같은 결함 수정 (MOB-6353 / #168 후속)

> **스코프 확장 안내** — 이 PR은 MOB-6354(MultiSelect) 티켓이지만, 먼저 머지된 `BezierSelect`(#168)의 동일 결함 수정을 **사용자 지시로 함께 포함**했습니다 (커밋 `da40e7b`). 같은 축(`hasLabel`)의 같은 원인이고 두 컴포넌트가 같은 idiom을 공유해야 하므로, 별도 PR로 쪼개면 리뷰어가 같은 판단을 두 번 하게 되고 그 사이 두 컴포넌트의 동작이 갈립니다.

**발견 경위** — MultiSelect Phase 3 Implementation Validator가 `labelText`의 overlay 렌더를 지적했고(위 Phase 3 항목), 같은 구조를 공유하는 `BezierSelect`를 대조하니 동일한 코드였습니다. `BezierSelect` SPEC §1·§5는 이미 `hasLabel`을 "`container=page`에서만 렌더"로 **정확히** 적어 뒀고 **구현만 어긋난 상태**였습니다 — SPEC 오류가 아니라 구현 버그입니다.

### Figma 근거 (Select CS `4870:581`)

- `get_context_for_code_connect(4870:581)`에서 `hasLabel#4870:1`에 바인딩된 노드는 `"variants": ["container=page"]` — **page 전용**입니다
- 직접 자식 실측: page(`1331:3`)에만 루트 라벨 노드 `1331:11`(x=10, 340×32)이 있고 overlay(`5150:1162`)·bottomsheet(`4903:2464`)에는 **없습니다**
- overlay/bottomsheet 안에 보이는 라벨은 `Internal/SelectGroup`이 소유한 `hasLabel#4665:1` — **별개 축**(= `BezierSelectGroup.labelText`)입니다
- Select overlay variant는 `hasLabel` property를 노출하지만 그것을 참조하는 노드가 전혀 없는 **고아 토글**입니다

MultiSelect(`5150:2921`)는 overlay variant가 property 자체를 노출하지 않아 더 명확했고, Select는 property는 남아 있으나 바인딩된 노드가 없다는 점만 다릅니다. 결론은 동일합니다.

### 수정 내용 — MultiSelect와 완전히 같은 방식

| 파일 | 변경 |
|---|---|
| `SUBezierSelect.swift` | `private var list` → `private func list(showsLabel: Bool)`. `.page` → `list(showsLabel: true)` / `.overlay` → `SUBezierOverlay { list(showsLabel: false) }` |
| `BezierSelect.swift` | `refreshLabel()`의 `isHidden`에 `\|\| self.container != .page` 추가 + **`rebuildContainer()` 끝에서 `refreshLabel()` 호출** |
| 양쪽 doc comment | `labelText`가 `.page` 전용임과 대체 경로(`BezierSelectGroup`/`SUBezierSelectGroup`의 `labelText`)를 명시 — 조용한 no-op 방지 |
| `BezierSelect/SPEC.md` | §9-14로 협의 사항 기록. **§1·§5의 `hasLabel` 기술은 Figma와 일치하므로 수정하지 않았습니다** |

`rebuildContainer()`의 `refreshLabel()` 호출이 **필수**입니다 — `container` didSet이 라벨 가시성을 재평가하지 않으면, `SelectCatalog`처럼 `container`를 `labelText`보다 먼저 세팅하는 사용처에서 순서 의존 stale이 남습니다(overlay → page 전환 시 라벨이 계속 숨은 채로 유지). MultiSelect도 같은 이유로 같은 위치에서 호출합니다.

수정 후 두 컴포넌트의 라벨 게이팅 코드는 네이밍만 다른 **동일 구조**입니다 — `sed 's/MultiSelect/Select/'` 치환 후 diff에 남는 것은 클래스 doc comment 문구(단일/복수 선택)와 Preview 샘플 데이터뿐입니다.

### 영향 범위

- **public API 변경 없음** — `labelText`는 두 container 공통 프로퍼티로 유지되고 렌더 게이팅만 바뀝니다(런타임에 `container`를 바꿀 수 있어야 하므로 프로퍼티를 container별로 쪼개지 않았습니다)
- 동작이 바뀌는 조합은 `.overlay` + non-nil `labelText` **하나뿐**입니다 — 기존에 보이던 루트 라벨이 사라집니다. 오버레이 안에서 라벨이 필요했던 사용처는 `BezierSelectGroup`/`SUBezierSelectGroup`의 `labelText`로 옮기면 됩니다(Figma가 그 맥락에서 쓰는 경로)
- 저장소 내 사용처는 `SelectCatalog` 하나이고 단정문이 없습니다. Select 전용 테스트는 존재하지 않아 깨지는 테스트도 없습니다

## 시각 검증 (시뮬레이터)

iPhone 17 / iOS 26.4 시뮬레이터(402×874pt @3x)에 **이 브랜치 빌드**를 설치해 전 항목을 실측했습니다. 수치는 접근성 프레임과 스크린샷 픽셀 실측(@3x → pt 환산)을 함께 썼습니다. **결함 없음 — 이 검증으로 인한 코드 변경은 없습니다.**

### MultiSelect

| 항목 | 결과 | 실측 |
|---|---|---|
| **복수 선택** | ✅ | 3개 항목이 **동시에** 체크됨. 탭으로 켜고 다시 탭해 끄는 토글도 정상 — 단일 선택인 `Select`(항상 1개만 체크)와 대비 확인 |
| **UIKit ↔ SwiftUI 동기화** | ✅ | **양방향**. SwiftUI 행 탭 → UIKit 섹션 즉시 반영, UIKit 행 탭 → SwiftUI 섹션 즉시 반영 (`@Binding Set<Int>` 공유) |
| 행 높이 (description 없음) | ✅ | 48.0pt (양 패러다임) |
| **행 높이 (description)** | ✅ | **52.3pt**(SwiftUI) / **52.0pt**(UIKit 행 간격) — Figma 실측 52pt와 일치. 같은 조건의 `Select`는 56.3 / 56.0pt로, 표에 적은 52 ↔ 56 divergence가 실측으로 확인됨 |
| **check 아이콘 20×20** | ✅ | 글리프 잉크 47×32px(@3x) ↔ `Select` 56×40px → 비율 **0.83 = 20/24**. 이진화 임계값 4단계(100·140·180·210) 전부 같은 결론. 코드 상수(`checkIconLength` 20 ↔ 24)와도 일치 |
| `container=page` ↔ `overlay` | ✅ | overlay에서 행 폭 298 → **220pt**, 카드 **240pt**(=220+패딩 10×2) 중앙 정렬, radius 32 라운드 카드 + elevation 그림자 |
| leading `none` | ✅ | UIKit 제목 x 96 → **62pt** (−34 = leading 24 + gap 10). **빈 24pt 박스 없이** 그룹 라벨과 좌측 정렬이 맞음. SwiftUI 동일 |
| leading `icon` / `avatar` | ✅ | 24×24 슬롯, 제목 x=96pt. 아바타는 squircle로 렌더 |
| centerSlot 24pt 클리핑 | ✅ | 40pt 콘텐츠가 **정확히 24.00pt**로 잘림(6개 행 전부). 행 높이는 48pt 유지 — 초과 콘텐츠가 행을 밀지 않음 |
| pressed | ✅ | 길게 누름 시 radius 16 pressed 배경 + press scale. 손 뗀 뒤 잔상 없이 복귀(정지 스크린샷으로 확인) |
| disabled | ✅ | 옵션 행 흐림(섹션 라벨은 유지), **탭 무반응** — SwiftUI·UIKit 모두 탭 전후 픽셀 diff가 스크롤 인디케이터뿐이고 선택 상태 불변 |
| 다크모드 | ✅ | page·overlay 모두 제목/체크 흰색, 라벨 회색, leading 아이콘 재tint, overlay 카드 surface 어둡게. **UIKit도 SwiftUI와 동일** — 토큰 재주입 정상 |

### Select — `hasLabel` 게이팅 (`da40e7b`)

| 항목 | 결과 | 실측 |
|---|---|---|
| `container=overlay`에서 루트 라벨 미표시 | ✅ | 루트 라벨(`언어`) 접근성 노드 **0개** — SwiftUI·UIKit 모두. 카탈로그의 `select label` 토글이 ON인 상태에서도 미표시 |
| **`page` ↔ `overlay` 런타임 전환** | ✅ | **왕복 3회 전부 정확** — overlay 0개 ↔ page 2개(SwiftUI+UIKit). `rebuildContainer()`의 `refreshLabel()` 호출이 동작해 **overlay → page 복귀 시 라벨이 되살아남**(stale 없음) |
| `page` 루트 라벨 정상 표시 | ✅ | 회귀 없음 |
| overlay 안 그룹 라벨 | ✅ | `group label`(`최근 사용`)은 overlay에서 계속 표시 — 별개 축(`BezierSelectGroup.labelText`)이 살아 있음을 확인 |

추가 경계 케이스: overlay 상태에서 `select label`을 OFF → ON 토글해도 루트 라벨은 계속 숨어 있고, 그 뒤 `page`로 전환하면 정상 표시됩니다. 반대로 `page`에서 라벨을 OFF로 둔 채 overlay를 경유해 돌아오면 계속 숨어 있습니다 — `labelText` 유무와 `container` 두 축이 순서와 무관하게 올바르게 합성됩니다.

## Examples 카탈로그

`MultiSelectCatalog`를 `CatalogRegistry.v3Components`의 알파벳 제자리(`Modal` ↔ `Overlay` 사이)에 등록했습니다. `SelectCatalog`에서 시각 검증으로 발견된 함정 2건을 처음부터 반영했습니다.

- **폭 붕괴 방지** — `container`별로 제약 세트를 나눠 `updateUIView`에서 교체 (page FILL / overlay 240 고정). `centerXAnchor` + 부등호만 쓰면 hug으로 접힙니다
- **UIKit disabled 전달** — representable 루트가 plain `UIView` wrapper라 `.disabled()`가 중첩 `UIControl`까지 내려가지 않으므로 `option.isEnabled`를 직접 주입
- 선택 상태를 `@Binding Set<Int>`로 공유해 UIKit 프리뷰의 탭이 SwiftUI 섹션에도 반영됩니다. 복수 선택이라 단일 `Picker`로는 표현할 수 없어 항목별 토글 버튼을 나열했습니다

`SelectCatalog`는 위 Select 수정 후에도 코드 변경 없이 그대로 동작합니다. `updateUIView`가 `container`를 `labelText`보다 먼저 세팅하지만(L203-204) `rebuildContainer()`가 끝에서 `refreshLabel()`을 호출하므로 양방향 전환 모두 정확합니다. 두 카탈로그의 루트 라벨 토글(`select label` / `multiSelect label`)은 `container=overlay`에서 의도적으로 무반응이며 — 이것이 컴포넌트의 올바른 동작입니다 — 그룹 라벨 토글(`group label`)이 오버레이 안 라벨을 담당합니다.

## CodeRabbit 리뷰 대응 (`6705bf7`)

Actionable 2건 수용, nitpick 3건 거부했습니다. 거부 근거는 [conversation comment](https://github.com/channel-io/BezierSwift/pull/170#issuecomment-5128476928)에 정리했습니다.

### 🟠 Major — centerSlot 빈 슬롯이 `EmptyView`로 특수화되지 않음 → 수용

`SUBezierBaseItem`은 슬롯 제네릭이 `EmptyView`일 때만 슬롯을 제거하는데, `centerSlot: { self.centerSlotView }`처럼 `@ViewBuilder` 프로퍼티를 넘기면 `buildIf` 때문에 `Optional<…>`로 특수화되어 그 분기를 타지 못합니다. probe로 확인한 실제 타입입니다.

```
수정 전: CenterSlot = Optional<ModifiedContent<ModifiedContent<EmptyView, _FrameLayout>, _ClipEffect<Rectangle>>>
수정 후: CenterSlot = EmptyView   → BaseItem이 슬롯 제거
```

`leading`과 동일하게 호출부(`item(leading:)`)에서 분기해 빈 쪽에 리터럴 `EmptyView()`를 넘기고, `centerSlotView`의 중복 가드를 제거했습니다.

**다만 24pt 여백이라는 증상은 원래도 나타나지 않았습니다.** `.frame(height: 24)`가 가드 안쪽에 있어 빈 경우 frame 적용 전에 `nil`이 반환되고, SwiftUI가 nil-Optional 서브트리를 통째로 드롭하기 때문입니다. 시뮬레이터 실측(행 배경 경계 픽셀 스캔):

| 프로브 행 | 수정 전 | 수정 후 |
|---|---|---|
| A `<EmptyView>` (convenience init) | 48.00pt | 48.00pt |
| B Optional-nil (`centerSlot: { if false { … } }`) | 48.00pt | 48.00pt |
| C A + description | 52.33pt | 52.33pt |
| D B + description | 52.33pt | 52.33pt |

수정 전후 해당 블록 **픽셀 완전 일치**(diff bbox `None`)입니다. 즉 이번 수정은 **렌더 결과를 바꾸지 않는 잠재 취약성 제거**입니다 — 현재의 정상 동작이 "frame이 가드 안에 있다"는 우연에 기대고 있어, frame을 밖으로 빼는 리팩터 한 번이면 바로 빈 24pt 박스가 생깁니다.

> 동일 패턴이 이미 develop에 머지된 `SUBezierSelectOption`(1곳)·`SUBezierDropdownMenuItem`(3곳)에도 있습니다. 이 PR 스코프 밖이라 손대지 않았습니다.

### 🟡 Minor — SPEC의 Figma 사양 ↔ 코드 지원 범위 경계 → 수용 (값 변경 없음)

- **`bottomsheet`**: §1은 Figma 거울이라 variant 3종을 그대로 두고, "구현 매핑" 열에 `page`·`overlay`만 제공하며 `bottomsheet`는 코드 API에 없음을 명시했습니다(사유는 기존 §9-2). §1 표 아래에 "§1~§5는 Figma 거울, 지원 범위는 §9가 결정한다"는 규칙 문장을 추가했습니다.
- **overlay 폭 240 vs 160~280**: 충돌이 아니라 **서술 대상이 다른 것**이었습니다. §2(Layout Spec = 실측)는 `container=overlay`가 내장한 인스턴스(`5150:2921`)의 `240pt` FIXED, §7(디자이너 가이드라인 = Figma description 인용)은 쉘 컴포넌트 단독(`5078:2253`)의 일반 계약 `HUG · 160~280px`입니다. 구현 계약은 240pt(`BezierOverlayConstant.width`)이고 위 시각 검증 실측(카드 240pt)과도 일치합니다. §7에 대상 구분 주석을 달고 결정 근거를 §9-15로 분리 기록했습니다.

**§1~§5의 Figma 실측값은 하나도 바꾸지 않았습니다.**

## 빌드

CodeRabbit 대응(`6705bf7`)까지 포함해 clean build와 테스트를 다시 돌렸습니다.

- `xcodebuild -scheme BezierSwift` clean build — `BUILD SUCCEEDED`
- `xcodebuild -scheme BezierSwift test` — `TEST SUCCEEDED` (5 tests, 0 failures)
- `xcodebuild -scheme BezierExamples` clean build — `BUILD SUCCEEDED`
- 시뮬레이터: iPhone 17 / iOS 26.4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 페이지 및 오버레이 형태를 지원하는 다중 선택 컴포넌트를 추가했습니다.
  * 선택 상태, 비활성 상태, 제목·설명, 체크 아이콘, 아이콘·아바타·커스텀 콘텐츠를 지원합니다.
  * 옵션을 그룹과 라벨로 구성하고, 중앙 슬롯 콘텐츠도 표시할 수 있습니다.
  * UIKit과 SwiftUI 환경에서 사용할 수 있습니다.
  * 컴포넌트 카탈로그에 다중 선택 예제와 다양한 설정 미리보기를 추가했습니다.

* **문서**
  * 레이아웃, 상태, 스타일 및 사용 가능한 구성 옵션을 문서화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


