### PR TITLE
BCGlobalToken·BCSemanticToken 확장을 별도 파일로 분리

### DIFF
--- a/Sources/BezierSwift/Foundation/Color/V3/BCGlobalToken+Color.swift
+++ b/Sources/BezierSwift/Foundation/Color/V3/BCGlobalToken+Color.swift
@@ -1,0 +1,19 @@
+//
+//  BCGlobalToken+Color.swift
+//  BezierSwift
+//
+//  Created by 구본욱 on 7/30/26.
+//
+
+import SwiftUI
+import UIKit
+
+extension BCGlobalToken {
+  public var color: Color {
+    self.value.color
+  }
+
+  public var uiColor: UIColor {
+    self.value.uiColor
+  }
+}

--- a/Sources/BezierSwift/Foundation/Color/V3/BCGlobalToken.swift
+++ b/Sources/BezierSwift/Foundation/Color/V3/BCGlobalToken.swift
@@ -719,12 +719,4 @@ public enum BCGlobalToken {
       return ColorComponentsWithAlpha(red: 0x9E, green: 0x75, blue: 0x04, alpha: 1)
     }
   }
-
-  public var color: Color {
-    self.value.color
-  }
-
-  public var uiColor: UIColor {
-    self.value.uiColor
-  }
 }

--- a/Sources/BezierSwift/Foundation/Color/V3/BCSemanticToken+PressedColor.swift
+++ b/Sources/BezierSwift/Foundation/Color/V3/BCSemanticToken+PressedColor.swift
@@ -1,0 +1,17 @@
+//
+//  BCSemanticToken+PressedColor.swift
+//  BezierSwift
+//
+//  Created by 구본욱 on 7/30/26.
+//
+
+import Foundation
+
+extension BCSemanticToken {
+  public var pressedColor: BCSemanticToken {
+    return .custom(
+      light: ColorUtils.getPressedColor(originalColor: self.light, colorTheme: .light),
+      dark: ColorUtils.getPressedColor(originalColor: self.dark, colorTheme: .dark)
+    )
+  }
+}

--- a/Sources/BezierSwift/Foundation/Color/V3/BCSemanticToken+SemanticColorProtocol.swift
+++ b/Sources/BezierSwift/Foundation/Color/V3/BCSemanticToken+SemanticColorProtocol.swift
@@ -1,0 +1,13 @@
+//
+//  BCSemanticToken+SemanticColorProtocol.swift
+//  BezierSwift
+//
+//  Created by 구본욱 on 7/30/26.
+//
+
+import Foundation
+
+extension BCSemanticToken: SemanticColorProtocol {
+  public var light: ColorComponentsWithAlpha { self.paletteSet.light }
+  public var dark: ColorComponentsWithAlpha { self.paletteSet.dark }
+}

--- a/Sources/BezierSwift/Foundation/Color/V3/BCSemanticToken.swift
+++ b/Sources/BezierSwift/Foundation/Color/V3/BCSemanticToken.swift
@@ -231,28 +231,11 @@ public enum BCSemanticToken: Equatable {
   case custom(light: ColorComponentsWithAlpha, dark: ColorComponentsWithAlpha)
 }
 
-// MARK: - SemanticColorProtocol
-extension BCSemanticToken: SemanticColorProtocol {
-  public var light: ColorComponentsWithAlpha { self.paletteSet.light }
-  public var dark: ColorComponentsWithAlpha { self.paletteSet.dark }
-  
-}
-
-// MARK: - Pressed Color Method
-extension BCSemanticToken {
-  public var pressedColor: BCSemanticToken {
-    return .custom(
-      light: ColorUtils.getPressedColor(originalColor: self.light, colorTheme: .light),
-      dark: ColorUtils.getPressedColor(originalColor: self.dark, colorTheme: .dark)
-    )
-  }
-}
-
-// MARK: - Private Methods
+// MARK: - Palette Set
 extension BCSemanticToken {
   typealias PaletteSet = (light: ColorComponentsWithAlpha, dark: ColorComponentsWithAlpha)
 
-  private var paletteSet: PaletteSet {
+  var paletteSet: PaletteSet {
     switch self {
     // MARK: - Border
     case .borderAbsoluteWhite:


### PR DESCRIPTION
## 배경

`BCGlobalToken.swift`와 `BCSemanticToken.swift`는 헤더에 `Generated from ...js`가 붙은 생성 파일인데, 생성 대상이 아닌 수기 확장이 파일 하단에 섞여 있었습니다. 이 확장들을 `{Type}+{Topic}.swift`로 분리합니다.

파일명은 같은 Foundation 계층의 기존 관례(`BTSemanticToken+Style.swift`, `BTSemanticToken+Typography.swift`)를 따랐습니다.

## 변경 사항

| 신규 파일 | 옮긴 대상 |
|---|---|
| `BCGlobalToken+Color.swift` | `public var color` / `public var uiColor` |
| `BCSemanticToken+SemanticColorProtocol.swift` | `SemanticColorProtocol` 준수 (`light` / `dark`) |
| `BCSemanticToken+PressedColor.swift` | `public var pressedColor` |

동작 변경은 없습니다. 코드 이동과 아래 접근 수준 완화가 전부입니다.

## `paletteSet`의 `private` 제거

Swift의 `private`은 **같은 파일 내** 다른 extension에서만 접근 가능합니다. `light`/`dark`가 `self.paletteSet`을 참조하므로, 이를 다른 파일로 옮기면 `private`인 채로는 컴파일되지 않습니다. 따라서 `private var paletteSet` → `var paletteSet`(internal)로 완화했습니다.

함께 선언된 `typealias PaletteSet`이 이미 internal이라 접근 수준은 일관됩니다. `public` 표면은 그대로이므로 소비자(`ch-desk-ios`)에 영향이 없습니다.

이에 맞춰 더 이상 사실이 아닌 `// MARK: - Private Methods`를 `// MARK: - Palette Set`으로 갱신했습니다.

## 남겨둔 것

두 원본 파일의 import(`BCGlobalToken.swift`의 `SwiftUI`/`UIKit`, `BCSemanticToken.swift`의 `UIKit`)는 분리 후 실제로 쓰이지 않게 됐지만 그대로 뒀습니다. 생성 파일의 preamble을 손대면 재생성 시 diff가 어긋날 수 있다고 판단했습니다. Swift는 미사용 import 경고를 내지 않아 빌드 노이즈는 없습니다.

> 이 분리의 의도가 "생성 파일에서 수기 코드를 걷어내는 것"이라면, 제너레이터 템플릿도 함께 맞춰야 다음 재생성 때 되돌아가지 않습니다.

## 검증

```
xcodebuild -scheme BezierSwift -destination "platform=iOS Simulator,id=<booted>" clean build
** BUILD SUCCEEDED **
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 전역 색상 토큰에서 SwiftUI `Color`와 UIKit `UIColor`에 쉽게 접근할 수 있습니다.
  * 시맨틱 색상 토큰의 라이트·다크 색상 정보를 표준 방식으로 제공합니다.
  * 색상 토큰의 눌림 상태(`pressed`) 색상을 지원합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->