### PR TITLE
Examples 카탈로그를 #172 state 토큰 변경에 맞춘다

### DIFF
--- a/Examples/BezierExamples/BezierExamples/Foundation/ColorTokenCatalog.swift
+++ b/Examples/BezierExamples/BezierExamples/Foundation/ColorTokenCatalog.swift
@@ -108,12 +108,10 @@ private struct ColorTokenGroup: Identifiable {
       ColorTokenSpec(.dimAbsoluteWhiteHeavy, "dim-absolute-white-heavy"),
     ]),
     ColorTokenGroup(title: "State", tokens: [
-      ColorTokenSpec(.stateAction,       "state-action"),
-      ColorTokenSpec(.stateActionLight,  "state-action-light"),
-      ColorTokenSpec(.stateActive,       "state-active"),
-      ColorTokenSpec(.stateDefault,      "state-default"),
-      ColorTokenSpec(.stateWarning,      "state-warning"),
-      ColorTokenSpec(.stateWarningLight, "state-warning-light"),
+      ColorTokenSpec(.stateActive,  "state-active"),
+      ColorTokenSpec(.stateDefault, "state-default"),
+      ColorTokenSpec(.stateFocus,   "state-focus"),
+      ColorTokenSpec(.stateWarning, "state-warning"),
     ]),
     ColorTokenGroup(title: "Chart", tokens: [
       ColorTokenSpec(.chartThemeDefault01, "chart-theme-default-01"),


### PR DESCRIPTION
## 문제

#172 토큰 sync가 `BCSemanticToken`의 state 토큰을 바꿨는데 Examples 카탈로그가 따라가지 않아 **Examples 앱 컴파일이 깨져 있다.**

```
error: type 'BCSemanticToken' has no member 'stateAction'
error: type 'BCSemanticToken' has no member 'stateActionLight'
error: type 'BCSemanticToken' has no member 'stateWarningLight'
```

| enum | 삭제 | 추가 |
|---|---|---|
| `BCSemanticToken` | `stateAction`, `stateActionLight`, `stateWarningLight`, `gradientAccentGreen`, `gradientAccentGreenLight` | `stateFocus` |
| `BCGlobalToken` | `black80` | — |

카탈로그가 참조하던 것은 state 3개뿐이다. `gradient*` 2개와 `black80`은 저장소 어디에서도 참조하지 않아 대응할 것이 없다.

## 변경

`ColorTokenCatalog`의 State 그룹에서 사라진 3개를 지우고 `stateFocus`를 추가했다. 그룹 안의 알파벳 순서를 유지했다.

## 검증

```
xcodebuild -project BezierExamples clean build   → ** BUILD SUCCEEDED **
```

시뮬레이터에서 Color Token 화면 확인 — State 그룹이 `state-active` · `state-default` · `state-focus` · `state-warning` 4개로 표시된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)