### PR TITLE
Toast 표면을 dark 고정에서 테마 반전으로 정정

### DIFF
--- a/Sources/BezierSwift/MasterComponent/BezierToast/BezierToast.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierToast/BezierToast.swift
@@ -9,9 +9,9 @@ import UIKit
 public final class BezierToast: UIView, BezierComponentable {
   // MARK: - BezierComponentable
 
-  // Toast는 항상 dark 표면. colorTheme을 .dark 상수로 고정하여 token.palette(self)가 dark 값을 해석하게 한다.
-  public var colorTheme: BezierColorTheme { .dark }
-  public var componentTheme: BezierComponentTheme = .normal {
+  public var colorTheme: BezierColorTheme { .systemBezierColorTheme() }
+  // Toast 표면은 앱 테마의 반전이다(웹 InvertedThemeProvider 대응). 다른 컴포넌트와 달리 기본값이 .inverted다.
+  public var componentTheme: BezierComponentTheme = .inverted {
     didSet { self.refreshAppearance() }
   }
 
@@ -86,7 +86,6 @@ public final class BezierToast: UIView, BezierComponentable {
   private func setUp() {
     self.translatesAutoresizingMaskIntoConstraints = false
     self.layer.masksToBounds = true
-    self.overrideUserInterfaceStyle = .dark
 
     self.contentStackView.addArrangedSubview(self.iconImageView)
     self.contentStackView.addArrangedSubview(self.titleLabel)

--- a/Sources/BezierSwift/MasterComponent/BezierToast/SPEC.md
+++ b/Sources/BezierSwift/MasterComponent/BezierToast/SPEC.md
@@ -6,7 +6,7 @@
 화면 상단에 일시적으로 표시되는 비방해적 알림 (iOS 네이티브 관례).
 
 - **모양**: pill (완전 캡슐, radius = height / 2)
-- **표면 모드**: 항상 dark (라이트/다크 무관, 항상 어두운 표면)
+- **표면 모드**: 반전 (앱 테마의 반대 — 라이트에서 dark 표면, 다크에서 light 표면)
 - **위치**: 상단 고정 (`top`)
 - **동시 표시**: 1개 (새 Toast가 오면 기존 Toast 즉시 교체)
 
@@ -52,22 +52,26 @@ Toast는 size 축이 없다. preset(아이콘 유무)에 따라 수평 padding�
 
 ### Background / Text (공통)
 
-| Part | Token | Figma Variable | Raw (dark) |
-|---|---|---|---|
-| 배경 | `fillGreyHeavier` | `color/fill/grey/heavier` | `#313135` |
-| 텍스트 | `textNeutral` | `color/text/neutral` | `#ffffffcc` |
+토큰은 공통이고, 표면이 반전이므로 **앱 테마의 반대쪽 값**이 적용된다.
+
+| Part | Token | Figma Variable | 앱 light → 적용값 | 앱 dark → 적용값 |
+|---|---|---|---|---|
+| 배경 | `fillGreyHeavier` | `color/fill/grey/heavier` | `#313135` (grey750) | `#efeff0` (grey200) |
+| 텍스트 | `textNeutral` | `color/text/neutral` | `#ffffffcc` (white80) | `#000000d9` (black85) |
 
 > 배경 fill은 `color/fill/grey/heavier`(불투명). Figma에는 `Backdrop/small`(BACKGROUND_BLUR radius 6) 이펙트와 description "배경 blur(glass)"도 함께 존재하나, 바인딩된 배경 fill은 불투명이다.
 >
-> Toast는 항상 dark 표면이므로 Figma가 노출한 dark 값을 적용한다.
+> **반전 근거** — Figma의 preset 컴포넌트(`2089:2` / `2089:17` / `2089:25`)는 `2. semantic/color` 컬렉션을 `dark-theme` 모드로 `explicitVariableModes` pin하고 있고, 부모 COMPONENT_SET(`2090:17`)과 페이지는 pin 없이 컬렉션 기본값인 `light-theme`을 상속한다. 즉 Figma는 "light 컨텍스트에 놓인 Toast는 dark 표면"이라는 **반전 결과 1개 상태**를 목업으로 고정한 것이다. 대조군인 Banner 컴포넌트는 `semantic/typography`만 Mobile로 pin하고 `semantic/color`는 pin하지 않는다 — color pin은 Toast 고유다.
+>
+> Figma는 모드가 2개뿐이라 반전 자체를 표현할 수 없으므로, "항상 dark"가 아니라 "반전"으로 읽어야 한다. 코드는 `componentTheme = .inverted`(UIKit) / `palette(_:isInverted: true)`(SwiftUI)로 구현한다.
 
 ### Icon (preset별)
 
-| preset | 아이콘 | Token | Raw |
-|---|---|---|---|
-| `success` | `check-circle-filled` | `iconNeutralHeavy` | `#ffffff99` |
-| `error` | `error-diamond-filled` | `iconNeutralHeavy` | `#ffffff99` |
-| `info` | — *(없음)* | — | — |
+| preset | 아이콘 | Token | 앱 light → 적용값 | 앱 dark → 적용값 |
+|---|---|---|---|---|
+| `success` | `check-circle-filled` | `iconNeutralHeavy` | `#ffffff99` (white60) | `#00000099` (black60) |
+| `error` | `error-diamond-filled` | `iconNeutralHeavy` | `#ffffff99` (white60) | `#00000099` (black60) |
+| `info` | — *(없음)* | — | — | — |
 
 > 아이콘 색은 Figma **export SVG** 기준으로 확정한다 (`shape` path의 `fill="white" fill-opacity="0.6"` = `#ffffff99` = `iconNeutralHeavy`). success·error 동일. `get_variable_defs`가 반환하는 다중 변수는 아이콘 라이브러리 컴포넌트가 참조하는 변수 목록일 뿐, 이 인스턴스의 실제 렌더 색이 아니다.
 

--- a/Sources/BezierSwift/MasterComponent/BezierToast/SUBezierToast.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierToast/SUBezierToast.swift
@@ -9,8 +9,11 @@ public struct SUBezierToast: View, Themeable {
   private let preset: BezierToastPreset
   private let title: String
 
-  // Toast는 항상 dark 표면. colorScheme을 .dark 상수로 고정하여 palette()가 dark 값(배경·아이콘)을 해석하게 한다.
-  public var colorScheme: ColorScheme { .dark }
+  @Environment(\.colorScheme) public var colorScheme
+
+  private var invertedColorScheme: ColorScheme {
+    self.colorScheme == .dark ? .light : .dark
+  }
 
   public init(preset: BezierToastPreset = .info, title: String) {
     self.preset = preset
@@ -25,7 +28,7 @@ public struct SUBezierToast: View, Themeable {
           .resizable()
           .scaledToFit()
           .frame(width: BezierToastSpec.iconLength, height: BezierToastSpec.iconLength)
-          .foregroundColor(self.palette(self.preset.iconColor))
+          .foregroundColor(self.palette(self.preset.iconColor, isInverted: true))
       }
 
       Text(self.title)
@@ -39,24 +42,27 @@ public struct SUBezierToast: View, Themeable {
       self.preset.icon == nil ? BezierToastSpec.horizontalPaddingTextOnly : BezierToastSpec.horizontalPaddingWithIcon
     )
     .frame(minHeight: BezierToastSpec.minHeight)
-    .background(Capsule().fill(self.palette(BezierToastSpec.backgroundToken)))
+    .background(Capsule().fill(self.palette(BezierToastSpec.backgroundToken, isInverted: true)))
     .clipShape(Capsule())
     .frame(maxWidth: BezierToastSpec.maxWidth)
-    // applyBezierFontStyle 내부 modifier가 자체 @Environment(\.colorScheme)로 텍스트 색을 해석하므로,
-    // 텍스트도 dark로 고정하려면 environment도 함께 pin해야 한다.
-    .environment(\.colorScheme, .dark)
+    // applyBezierFontStyle 내부 modifier가 자체 @Environment(\.colorScheme)로 텍스트 색을 해석해
+    // isInverted를 받지 못하므로, 텍스트를 함께 반전시키려면 environment를 뒤집어 주입해야 한다.
+    .environment(\.colorScheme, self.invertedColorScheme)
   }
 }
 
 struct SUBezierToast_Previews: PreviewProvider {
   static var previews: some View {
-    VStack(spacing: 16) {
-      ForEach(BezierToastPreset.allCases, id: \.self) { preset in
-        SUBezierToast(preset: preset, title: "Message")
+    ForEach([ColorScheme.light, ColorScheme.dark], id: \.self) { scheme in
+      VStack(spacing: 16) {
+        ForEach(BezierToastPreset.allCases, id: \.self) { preset in
+          SUBezierToast(preset: preset, title: "Message")
+        }
       }
+      .padding()
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
+      .background(Color.gray)
+      .preferredColorScheme(scheme)
     }
-    .padding()
-    .frame(maxWidth: .infinity, maxHeight: .infinity)
-    .background(Color.gray)
   }
 }


### PR DESCRIPTION
## 문제

`BezierToast` / `SUBezierToast`가 표면을 **dark로 고정**하고 있다. 그런데 Toast는 dark 고정이 아니라 **앱 테마의 반전**이 맞다. 다크 모드에서 표면이 배경과 같은 어둠으로 묻혀 SSOT와 어긋난다.

```swift
// as-is
public var colorTheme: BezierColorTheme { .dark }          // UIKit
public var colorScheme: ColorScheme { .dark }              // SwiftUI
self.overrideUserInterfaceStyle = .dark
```

### "항상 dark"는 Figma를 오독한 결과다

Figma의 Toast는 라이트 캔버스 위에 어두운 pill로 그려져 있어 얼핏 "항상 dark"로 보인다. 하지만 mode 구조를 보면 반대다.

| 노드 | `2. semantic/color` 모드 |
|---|---|
| PAGE `2088:2` | pin 없음 → **light-theme**(컬렉션 기본값) 상속 |
| COMPONENT_SET `2090:17` | pin 없음 → **light-theme** 상속 |
| COMPONENT `2089:2` / `2089:17` / `2089:25` | **`dark-theme` explicit pin** |

페이지는 light-theme인데 preset 컴포넌트만 dark-theme으로 pin돼 있다. 이 컬렉션에는 모드가 light/dark 둘뿐이라 Figma는 "반전"이라는 **관계** 자체를 표현할 수단이 없다. 그래서 *light 컨텍스트에 놓였을 때의 결과 한 장*을 목업으로 고정한 것이고, 이를 상태값으로 읽어 dark 고정으로 구현한 것이 원인이다.

대조군으로 Banner 컴포넌트(9개)를 확인하면 `semantic/typography`만 Mobile로 pin하고 `semantic/color`는 pin하지 않는다. **color pin은 Toast 고유**이며, 이는 "반전 컴포넌트라서 특별 취급"이라는 해석과 일치한다.

웹 대응 구현 이름도 `InvertedThemeProvider`로 이름 그대로 반전이다.

> `team-design`의 `Toast-spec.md` §7에는 "항상 다크 배경"으로 적혀 있는데, 이 서술이 잘못됐다. 해당 문서 수정은 별도로 진행될 예정이다.

## 변경

이미 있던 `componentTheme: .inverted` 인프라가 정확히 `InvertedThemeProvider` 대응이라 그대로 활용했다.

| | as-is | to-be |
|---|---|---|
| UIKit `colorTheme` | `.dark` 상수 | `.systemBezierColorTheme()` |
| UIKit `componentTheme` | `.normal` | **`.inverted`** (기본값만 변경, setter 유지) |
| UIKit `overrideUserInterfaceStyle` | `.dark` | **제거** |
| SwiftUI `colorScheme` | `.dark` 상수 | `@Environment(\.colorScheme)` |
| SwiftUI `palette(...)` | 기본 | `isInverted: true` |
| SwiftUI 텍스트용 `.environment` | `.dark` 고정 | 반전값 주입 |

**`overrideUserInterfaceStyle` 제거가 필수다.** `palette(_ component:)`의 `UIColor` resolve 클로저는 `UITraitCollection.current`를 통해 뷰의 trait을 읽는다. trait까지 dark로 고정한 채 `.inverted`를 걸면 `(.inverted, .dark) → light` 가 되어 두 반전이 서로 상쇄된다.

SwiftUI에서 `.environment(\.colorScheme,)` 주입이 여전히 필요한 이유도 그대로다. `applyBezierFontStyle`이 감싸는 `BezierTypographyStyle`은 자체 `@Environment(\.colorScheme)`으로 텍스트 색을 해석하고 `isInverted`를 받지 않는다. 배경·아이콘만 `isInverted: true`로 뒤집으면 텍스트만 반전에서 빠진다. 다만 주입값이 `.dark` 고정에서 반전값으로 바뀌었다.

`componentTheme`은 저장 프로퍼티와 setter를 그대로 두고 기본값만 `.inverted`로 바꿨다. public API 표면은 변하지 않고, 소비자가 반전을 끄고 싶으면 `.normal`을 넣으면 된다.

`SPEC.md`는 표면 모드 정의와 컬러 토큰 표를 반전 기준(앱 light → 적용값 / 앱 dark → 적용값)으로 갱신하고, 위 Figma 근거와 Banner 대조 결과를 각주로 남겼다. 같은 의문이 다시 반복되지 않게 하기 위함이다.

## 검증

```
xcodebuild -scheme BezierSwift    clean build  → ** BUILD SUCCEEDED **
xcodebuild -project BezierExamples clean build → ** BUILD SUCCEEDED **
```

시뮬레이터(iPhone 16 Pro) Toast 카탈로그에서 테마를 전환하며 실측했다.

| 앱 테마 | 표면 | 텍스트 | 아이콘 |
|---|---|---|---|
| light | 어두운 pill `#313135` (grey750) | 흰색 `#ffffffcc` | `#ffffff99` |
| dark | 밝은 pill `#efeff0` (grey200) | 검정 `#000000d9` | `#00000099` |

SwiftUI·UIKit 두 구현이 동일하게 반전되는 것도 같은 화면에서 확인했다. UIKit 쪽은 `traitCollectionDidChange → refreshAppearance` 경로로 테마 전환에 즉시 반응한다.

SwiftUI Preview도 light/dark 두 scheme을 나란히 보도록 바꿔, 앞으로 반전 회귀를 Preview에서 바로 잡을 수 있게 했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * BezierToast가 시스템의 라이트·다크 모드를 자동으로 따르도록 개선되었습니다.
  * 앱 테마에 맞춰 배경, 텍스트, 아이콘 색상이 반전된 스타일로 표시됩니다.
  * SwiftUI 미리보기에서 라이트·다크 모드와 모든 프리셋을 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->