### PR TITLE
[MOB-6471] BezierPressFeedback을 public으로 승격하고 BaseItem을 마이그레이션한다

### DIFF
--- a/Sources/BezierSwift/MasterComponent/BezierBaseItem/BezierBaseItem.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBaseItem/BezierBaseItem.swift
@@ -328,47 +328,19 @@ public final class BezierBaseItem: UIControl, BezierComponentable {
     }
   }
 
-  private static let pressReleaseAnimationKey = "bezierBaseItemPressRelease"
-
   private func refreshInteraction() {
     self.isUserInteractionEnabled = self.onTap != nil
     if self.onTap == nil {
-      self.rootStackView.layer.removeAnimation(forKey: Self.pressReleaseAnimationKey)
-      self.rootStackView.transform = .identity
+      BezierPressFeedback.reset(self.rootStackView)
     }
   }
 
-  // 콘텐츠(rootStackView)만 press scale — 배경(self)은 full-size 유지.
-  // ch-desk-ios ListItemPressFeedback와 동일: press-in 축소 → release 시 오버슈트 복귀.
   private func refreshPressScale() {
-    guard self.onTap != nil, !UIAccessibility.isReduceMotionEnabled else {
-      self.rootStackView.layer.removeAnimation(forKey: Self.pressReleaseAnimationKey)
-      self.rootStackView.transform = .identity
+    guard self.onTap != nil else {
+      BezierPressFeedback.reset(self.rootStackView)
       return
     }
-
-    if self.isHighlighted {
-      self.rootStackView.layer.removeAnimation(forKey: Self.pressReleaseAnimationKey)
-      UIView.animate(
-        withDuration: BezierBaseItemConstant.pressInDuration,
-        delay: 0,
-        options: [.curveEaseInOut, .beginFromCurrentState]
-      ) {
-        self.rootStackView.transform = CGAffineTransform(
-          scaleX: BezierBaseItemConstant.pressScale,
-          y: BezierBaseItemConstant.pressScale
-        )
-      }
-    } else {
-      self.rootStackView.transform = .identity
-      let keyframe = CAKeyframeAnimation(keyPath: "transform.scale")
-      keyframe.values = BezierBaseItemConstant.releaseScaleValues
-      keyframe.keyTimes = BezierBaseItemConstant.releaseScaleKeyTimes
-      keyframe.duration = BezierBaseItemConstant.releaseDuration
-      keyframe.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
-      keyframe.isRemovedOnCompletion = true
-      self.rootStackView.layer.add(keyframe, forKey: Self.pressReleaseAnimationKey)
-    }
+    BezierPressFeedback.apply(isPressed: self.isHighlighted, to: self.rootStackView)
   }
 
   private func refreshEnabled() {

--- a/Sources/BezierSwift/MasterComponent/BezierBaseItem/BezierBaseItemSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBaseItem/BezierBaseItemSpec.swift
@@ -69,12 +69,4 @@ public enum BezierBaseItemConstant {
   static let titleColor: BCSemanticToken = .textNeutral
   static let descriptionColor: BCSemanticToken = .textNeutralLighter
   static let pressedBackgroundColor: BCSemanticToken = .fillNeutralLighter
-
-  // Press scale 피드백 (Figma 외 · 협의 — ch-desk-ios ListItemPressFeedback 참조)
-  // 콘텐츠가 눌림 시 0.97로 축소되고, 뗄 때 살짝 오버슈트하며 복귀한다.
-  static let pressScale: CGFloat = 0.97
-  static let pressInDuration: TimeInterval = 0.10
-  static let releaseDuration: TimeInterval = 0.40
-  static let releaseScaleValues: [NSNumber] = [0.97, 1.004, 1.0]
-  static let releaseScaleKeyTimes: [NSNumber] = [0, 0.55, 1.0]
 }

--- a/Sources/BezierSwift/MasterComponent/BezierBaseItem/SUBezierBaseItem.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBaseItem/SUBezierBaseItem.swift
@@ -170,20 +170,15 @@ extension SUBezierBaseItem where CenterSlot == EmptyView {
 
 private struct SUBezierBaseItemContainer: ViewModifier, Themeable {
   @Environment(\.colorScheme) var colorScheme
-  @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
   let size: BezierBaseItemSize
   let style: BezierBaseItemStyle
   let isPressed: Bool
 
-  private var contentScale: CGFloat {
-    (self.isPressed && !self.reduceMotion) ? BezierBaseItemConstant.pressScale : 1
-  }
-
   func body(content: Content) -> some View {
     content
-      // 콘텐츠만 축소 — 배경은 full-size 유지 (press scale 피드백)
-      .scaleEffect(self.contentScale)
+      // 콘텐츠만 축소 — pressed 배경은 full-size 유지
+      .bezierPressScale(isPressed: self.isPressed)
       .padding(.horizontal, self.style.horizontalPadding)
       .padding(.vertical, self.style.verticalPadding ?? self.size.verticalPadding)
       .frame(minHeight: self.size.minHeight)
@@ -195,7 +190,13 @@ private struct SUBezierBaseItemContainer: ViewModifier, Themeable {
       )
       .clipShape(RoundedRectangle(cornerRadius: self.style.cornerRadius))
       .contentShape(Rectangle())
-      .animation(.spring(response: 0.34, dampingFraction: 0.62), value: self.isPressed)
+      .animation(
+        .spring(
+          response: BezierPressFeedback.springResponse,
+          dampingFraction: BezierPressFeedback.springDampingFraction
+        ),
+        value: self.isPressed
+      )
   }
 }
 

--- a/Sources/BezierSwift/MasterComponent/BezierBaseItem/SUBezierBaseItem.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBaseItem/SUBezierBaseItem.swift
@@ -177,7 +177,6 @@ private struct SUBezierBaseItemContainer: ViewModifier, Themeable {
 
   func body(content: Content) -> some View {
     content
-      // 콘텐츠만 축소 — pressed 배경은 full-size 유지
       .bezierPressScale(isPressed: self.isPressed)
       .padding(.horizontal, self.style.horizontalPadding)
       .padding(.vertical, self.style.verticalPadding ?? self.size.verticalPadding)

--- a/Sources/BezierSwift/MasterComponent/BezierSectionItem/SPEC.md
+++ b/Sources/BezierSwift/MasterComponent/BezierSectionItem/SPEC.md
@@ -175,7 +175,7 @@ Figma에 없는 구현 결정은 아래에 분리 표기한다. SSOT 값이 아�
 4. **toggle 표시자**: Switch 컴포넌트(`1095:19`)가 BezierSwift에 아직 없어, accessory 내부에 Switch의 Figma 실측값(50×28·radius 14·track off `fillNeutralHeavy`/on `fillNeutralHeaviest`·thumb 24 흰색, top 2, left 2/24)으로 비인터랙티브 시각을 직접 그린다. thumb 그림자 실측: offset (0, 2), blur 4, black 25% (thumb 벡터의 drop-shadow 필터). BezierSwitch 컴포넌트가 생기면 교체 대상.
 5. **description 인덴트 적용 규칙**: 구현은 de-nest 인덴트를 "leading 표시 시 34 / 없음(none) 0"으로 적용한다 (§2 표와 동일 — icon·avatar 공통 34).
 6. **BezierBaseItem 미재사용**: 좌우 패딩(6↔10)·radius(8↔0)·상하 패딩 축·description 배치 구조(de-nest/nested)가 BaseItem과 달라 코드 재사용 대신 동일 컨벤션의 독립 구현으로 간다.
-7. **press scale 적용**: Figma pressed state는 배경 fill 변화만 정의하나, BaseItem과 동일한 press scale 피드백(콘텐츠 0.97 축소 → release 오버슈트 복귀, reduce motion 시 비활성)을 협의로 적용한다 (2026-07-24). 구현은 internal 유틸 `BezierPressFeedback`(`Util/BezierPressFeedback.swift`) — public 승격·BaseItem 마이그레이션은 MOB-6471.
+7. **press scale 적용**: Figma pressed state는 배경 fill 변화만 정의하나, BaseItem과 동일한 press scale 피드백(콘텐츠 0.97 축소 → release 오버슈트 복귀, reduce motion 시 비활성)을 협의로 적용한다 (2026-07-24). 구현은 public 유틸 `BezierPressFeedback`(`Util/BezierPressFeedback.swift`) — BaseItem도 같은 유틸을 쓴다 (MOB-6471).
 8. **state 코드 매핑**: pressed → UIKit `isHighlighted` / SwiftUI ButtonStyle `isPressed`, disabled → `isEnabled`/`.disabled()`. `onTap == nil`이면 비인터랙티브(pressed 없음).
 9. **leading 아이콘 색 heavy 고정**: §3의 실측 편차(기본 variant만 heavy, 8개 variant는 neutral)에 대해 구현은 `iconNeutralHeavy`를 전 state·size에 고정 적용한다 — 근거: defaultVariant가 heavy이고, §5의 state 정의(배경/opacity만 변경)와 team-design Section-spec.md §13의 토큰 기재가 heavy를 지지.
 

--- a/Sources/BezierSwift/MasterComponent/BezierSectionItem/SUBezierSectionItem.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierSectionItem/SUBezierSectionItem.swift
@@ -205,7 +205,6 @@ private struct SUBezierSectionItemContainer: ViewModifier, Themeable {
 
   func body(content: Content) -> some View {
     content
-      // 콘텐츠만 축소 — pressed 배경은 full-size 유지
       .bezierPressScale(isPressed: self.isPressed)
       .padding(.horizontal, BezierSectionItemConstant.horizontalPadding)
       .padding(.vertical, self.size.verticalPadding)

--- a/Sources/BezierSwift/Util/BezierPressFeedback.swift
+++ b/Sources/BezierSwift/Util/BezierPressFeedback.swift
@@ -13,9 +13,14 @@ import UIKit
 /// Reduce Motion이 켜져 있으면 축소 없이 원래 크기를 유지한다.
 ///
 /// UIKit `UIControl`에서는 `isHighlighted` 변화에 맞춰 호출하고, 탭을 받지 않는 상태에서는 `reset(_:)`으로 되돌린다.
+/// `didSet`은 값이 그대로여도 대입마다 발동하므로, 같은 값 재대입에 release 애니메이션이 다시 걸리지 않도록 `oldValue`로 걸러야 한다.
 /// ```swift
 /// public override var isHighlighted: Bool {
-///   didSet { self.refreshPressScale() }
+///   didSet {
+///     if oldValue != self.isHighlighted {
+///       self.refreshPressScale()
+///     }
+///   }
 /// }
 ///
 /// private func refreshPressScale() {
@@ -44,6 +49,8 @@ public enum BezierPressFeedback {
   // MARK: - UIKit
 
   /// `contentView`에 press 피드백을 적용한다. `isPressed`가 `true`면 축소하고, `false`면 오버슈트하며 원래 크기로 복귀한다.
+  ///
+  /// Reduce Motion이 켜져 있으면 어느 쪽이든 애니메이션 없이 원래 크기를 유지한다 — `isPressed`와 무관하게 `reset(_:)`과 같은 결과가 된다.
   ///
   /// - Parameters:
   ///   - isPressed: 눌린 상태 여부. `UIControl`이면 `isHighlighted`를 그대로 넘긴다.
@@ -112,6 +119,8 @@ struct BezierPressScaleModifier: ViewModifier {
 extension View {
   /// 눌린 동안 콘텐츠를 `0.97`로 축소하는 press 피드백을 건다. 계약과 근거는 `BezierPressFeedback` 참조.
   ///
+  /// 축소 애니메이션은 내장돼 있어 별도로 걸 필요가 없다. Reduce Motion이 켜져 있으면 축소하지 않는다.
+  ///
   /// **`.padding`·`.background`보다 앞(콘텐츠 쪽)에 붙여야 한다.** 뒤에 붙이면 pressed 배경까지 함께 축소된다.
   /// ```swift
   /// func makeBody(configuration: Configuration) -> some View {
@@ -121,6 +130,8 @@ extension View {
   ///     .background(configuration.isPressed ? pressedColor : .clear)   // 배경은 full-size 유지
   /// }
   /// ```
+  ///
+  /// 내장 애니메이션은 scale에만 걸린다 — 위 예시의 pressed 배경은 즉시 전환된다.
   ///
   /// - Parameter isPressed: 눌린 상태 여부. `ButtonStyle`이면 `configuration.isPressed`를 그대로 넘긴다.
   public func bezierPressScale(isPressed: Bool) -> some View {

--- a/Sources/BezierSwift/Util/BezierPressFeedback.swift
+++ b/Sources/BezierSwift/Util/BezierPressFeedback.swift
@@ -6,11 +6,31 @@
 import SwiftUI
 import UIKit
 
-// 아이템형 컴포넌트 공통 press 피드백 (Figma 외 · 협의 — ch-desk-ios ListItemPressFeedback 참조)
-// 콘텐츠가 눌림 시 0.97로 축소되고, 뗄 때 살짝 오버슈트하며 복귀한다.
-// 대상은 콘텐츠 뷰만 — pressed 배경은 컴포넌트가 full-size로 유지한다.
-// public 승격 + BezierBaseItem 마이그레이션은 MOB-6471에서 다룬다.
-enum BezierPressFeedback {
+/// 아이템형 컴포넌트가 공유하는 탭 press 피드백. 눌린 동안 콘텐츠가 `0.97`로 축소되고, 뗄 때 살짝 오버슈트하며 원래 크기로 돌아온다.
+///
+/// **적용 대상은 콘텐츠 뷰만이다.** 배경(pressed 하이라이트)은 축소하지 않고 full-size로 유지해야 한다 — 배경까지 함께 줄면 눌릴 때마다 행의 시각적 경계가 안쪽으로 수축해 리스트가 출렁인다. 그래서 UIKit은 배경을 그리는 컴포넌트 루트(`self`)가 아니라 그 안의 콘텐츠 스택뷰를, SwiftUI는 `.background(...)`를 붙이기 **전**의 콘텐츠를 대상으로 삼는다.
+///
+/// Reduce Motion이 켜져 있으면 축소 없이 원래 크기를 유지한다.
+///
+/// UIKit `UIControl`에서는 `isHighlighted` 변화에 맞춰 호출하고, 탭을 받지 않는 상태에서는 `reset(_:)`으로 되돌린다.
+/// ```swift
+/// public override var isHighlighted: Bool {
+///   didSet { self.refreshPressScale() }
+/// }
+///
+/// private func refreshPressScale() {
+///   guard self.onTap != nil else {
+///     BezierPressFeedback.reset(self.rootStackView)
+///     return
+///   }
+///   BezierPressFeedback.apply(isPressed: self.isHighlighted, to: self.rootStackView)
+/// }
+/// ```
+///
+/// SwiftUI에서는 `View.bezierPressScale(isPressed:)`를 사용한다.
+///
+/// Figma에 대응 정의가 없는 코드 전용 동작이다 (협의 적용 · 원 패턴은 ch-desk-ios `ListItemPressFeedback`).
+public enum BezierPressFeedback {
   static let pressScale: CGFloat = 0.97
   static let pressInDuration: TimeInterval = 0.10
   static let releaseDuration: TimeInterval = 0.40
@@ -23,8 +43,13 @@ enum BezierPressFeedback {
 
   // MARK: - UIKit
 
+  /// `contentView`에 press 피드백을 적용한다. `isPressed`가 `true`면 축소하고, `false`면 오버슈트하며 원래 크기로 복귀한다.
+  ///
+  /// - Parameters:
+  ///   - isPressed: 눌린 상태 여부. `UIControl`이면 `isHighlighted`를 그대로 넘긴다.
+  ///   - contentView: 축소할 **콘텐츠** 뷰. 배경을 그리는 컴포넌트 루트가 아니라 그 안의 콘텐츠 컨테이너를 넘긴다.
   @MainActor
-  static func apply(isPressed: Bool, to contentView: UIView) {
+  public static func apply(isPressed: Bool, to contentView: UIView) {
     guard !UIAccessibility.isReduceMotionEnabled else {
       self.reset(contentView)
       return
@@ -54,8 +79,9 @@ enum BezierPressFeedback {
     }
   }
 
+  /// 진행 중인 press 애니메이션을 제거하고 `contentView`를 원래 크기로 되돌린다. 탭을 받지 않는(비인터랙티브) 상태로 바뀔 때 호출한다.
   @MainActor
-  static func reset(_ contentView: UIView) {
+  public static func reset(_ contentView: UIView) {
     contentView.layer.removeAnimation(forKey: self.releaseAnimationKey)
     contentView.transform = .identity
   }
@@ -84,7 +110,20 @@ struct BezierPressScaleModifier: ViewModifier {
 }
 
 extension View {
-  func bezierPressScale(isPressed: Bool) -> some View {
+  /// 눌린 동안 콘텐츠를 `0.97`로 축소하는 press 피드백을 건다. 계약과 근거는 `BezierPressFeedback` 참조.
+  ///
+  /// **`.padding`·`.background`보다 앞(콘텐츠 쪽)에 붙여야 한다.** 뒤에 붙이면 pressed 배경까지 함께 축소된다.
+  /// ```swift
+  /// func makeBody(configuration: Configuration) -> some View {
+  ///   configuration.label
+  ///     .bezierPressScale(isPressed: configuration.isPressed)          // 콘텐츠만 축소
+  ///     .padding(.horizontal, 6)
+  ///     .background(configuration.isPressed ? pressedColor : .clear)   // 배경은 full-size 유지
+  /// }
+  /// ```
+  ///
+  /// - Parameter isPressed: 눌린 상태 여부. `ButtonStyle`이면 `configuration.isPressed`를 그대로 넘긴다.
+  public func bezierPressScale(isPressed: Bool) -> some View {
     self.modifier(BezierPressScaleModifier(isPressed: isPressed))
   }
 }

--- a/Sources/BezierSwift/Util/BezierPressFeedback.swift
+++ b/Sources/BezierSwift/Util/BezierPressFeedback.swift
@@ -90,7 +90,15 @@ public enum BezierPressFeedback {
   @MainActor
   public static func reset(_ contentView: UIView) {
     contentView.layer.removeAnimation(forKey: self.releaseAnimationKey)
-    contentView.transform = .identity
+    // press-in은 UIView.animate가 붙인 암묵 애니메이션이라 키로 제거할 수 없다. transform 대입만으로는
+    // 모델 값만 바뀌고 진행 중인 애니메이션이 완주해버리므로, duration 0 애니메이션으로 대체해 확정시킨다.
+    UIView.animate(
+      withDuration: 0,
+      delay: 0,
+      options: [.beginFromCurrentState, .overrideInheritedDuration]
+    ) {
+      contentView.transform = .identity
+    }
   }
 }
 

--- a/docs/agent/uikit-pitfalls.md
+++ b/docs/agent/uikit-pitfalls.md
@@ -54,15 +54,21 @@ border 위로 올라와야 하는 자식(badge·status indicator·overlay)이 �
 
 ## press 피드백은 `BezierPressFeedback`을 재사용한다
 
-`Sources/BezierSwift/Util/BezierPressFeedback.swift` (internal)에 UIKit·SwiftUI 양쪽 헬퍼가 있다.
+`Sources/BezierSwift/Util/BezierPressFeedback.swift` (public)에 UIKit·SwiftUI 양쪽 헬퍼가 있다.
 새로 만들지 말 것.
 
 ```swift
-BezierPressFeedback.apply(isPressed: true, to: self)   // UIKit
-BezierPressFeedback.reset(self)
+BezierPressFeedback.apply(isPressed: self.isHighlighted, to: self.rootStackView)   // UIKit
+BezierPressFeedback.reset(self.rootStackView)
+
+content.bezierPressScale(isPressed: configuration.isPressed)                       // SwiftUI
 ```
 
-사용 예시는 `BezierSectionItem.swift`. public 승격과 `BezierBaseItem` 마이그레이션은 MOB-6471에서 다룬다.
+**대상은 콘텐츠 뷰만이다.** 배경을 그리는 컴포넌트 루트(`self`)를 넘기면 pressed 배경까지 같이
+축소돼 행 경계가 수축한다. SwiftUI도 같은 이유로 `.padding`·`.background`보다 **앞**에 붙인다.
+계약과 사용 예시는 `BezierPressFeedback`의 doc comment에 있다.
+
+사용 예시는 `BezierBaseItem.swift`·`BezierSectionItem.swift`·`BezierCollapsibleSectionLabel.swift`.
 
 ## `UITextView`는 TextKit 1로 만들어야 line height 토큰이 먹는다
 


### PR DESCRIPTION
## 배경

MOB-6455에서 아이템형 컴포넌트 공통 press 피드백을 internal 유틸로 추출해 SectionItem·CollapsibleSectionLabel에 적용했으나, BaseItem은 자체 구현을 그대로 두어 같은 로직이 두 곳에 남아 있었다. 유틸이 internal이라 앱 코드에서 재사용도 불가능했다.

## 변경

### 1. `BezierPressFeedback` public 승격

공개 표면은 티켓이 명시한 3개로 최소화했다.

- `BezierPressFeedback.apply(isPressed:to:)`
- `BezierPressFeedback.reset(_:)`
- `View.bezierPressScale(isPressed:)`

타이밍 상수(`pressScale`·`pressInDuration`·`releaseScaleValues` 등)와 `BezierPressScaleModifier`는 internal로 남긴다. 상수를 열면 소비자가 애니메이션을 직접 재조립하게 되어 유틸의 존재 이유가 사라지고, 모디파이어는 `bezierPressScale`이 `some View`로 감싸므로 공개할 필요가 없다. 유틸 본문은 접근 제어자 4개 외에 변경이 없어 기존 사용처는 영향을 받지 않는다.

### 2. BaseItem 마이그레이션 — 시각 동작 무변경

기존 `refreshPressScale()`과 유틸의 애니메이션 파라미터를 전수 대조한 결과 press-in `0.10s`/`curveEaseInOut`, release `0.40s`/`[0.97, 1.004, 1.0]`/`[0, 0.55, 1.0]`/`easeInEaseOut`, scale `0.97`, reduce motion 가드가 모두 동일했다. 차이는 CALayer 애니메이션 키 문자열뿐이라 그대로 치환했다.

`onTap == nil`일 때 피드백을 끄는 가드는 컴포넌트 고유 관심사라 호출부에 남겨 SectionItem과 같은 형태로 맞췄다.

SwiftUI 컨테이너 말미의 `.animation(...)`은 유지한다. 이 모디파이어는 scale뿐 아니라 pressed 배경색 전환도 함께 태우고 있어, 제거하면 배경이 spring 없이 즉시 바뀌는 회귀가 된다. 매직 넘버 `0.34`/`0.62`만 유틸 상수 참조로 바꿔 중복을 없앴다. (SectionItem·CollapsibleSection에는 이 말미 `.animation`이 없어 배경이 즉시 전환된다 — 기존부터 있던 컴포넌트 간 편차이며 이번 범위 밖이라 그대로 둔다.)

### 3. doc comment를 실제 동작에 맞춤

승격하며 새로 쓴 doc comment를 코드와 전수 대조해 어긋난 곳을 고쳤다.

- **`isHighlighted` 예시에 `oldValue` 가드 복원** — `didSet`은 값이 그대로여도 대입마다 발동하는데 `apply()`에는 내부 dedupe가 없어, 같은 값이 재대입되면 release 분기가 transform을 identity로 되돌린 뒤 `0.40s` 키프레임을 다시 건다. 저장소의 실제 호출부 3곳이 예외 없이 이 가드를 두고 있는데 예시만 빠져 있었다.
- **`apply()` doc에 Reduce Motion 분기 명시** — 함수의 첫 분기가 reduce motion 가드인데 doc은 "true면 축소, false면 오버슈트 복귀"만 서술했다. 이 사실은 타입 본문 doc에만 있었고 Xcode Quick Help는 심볼 단위라 `apply()`에 커서를 올린 소비자에겐 보이지 않았다.
- **`bezierPressScale(isPressed:)` doc에 애니메이션 소유권 기재** — 모디파이어가 `scaleEffect`와 함께 애니메이션을 내장하고 있는데 doc은 "축소한다"까지만 말해, 소비자가 애니메이션을 또 걸어야 하는지 알 수 없었다. 그 애니메이션이 scale에만 걸려 예시의 pressed 배경은 즉시 전환된다는 점도 함께 적었다. 파라미터 수치는 적지 않았다 — UIKit 기본 애니메이션의 duration이 doc에 없듯 구현 세부이고, 상수가 internal인 이상 소비자가 참조할 수단도 없다.

### 4. 주석 정리

SwiftUI 컨테이너의 `// 콘텐츠만 축소 — pressed 배경은 full-size 유지` 주석을 BaseItem·SectionItem 두 곳에서 지웠다. 정상 코드의 동작 설명이라 저장소 주석 정책에 어긋나고, 바로 아래 호출하는 `bezierPressScale`의 doc comment가 같은 계약을 이미 설명한다. CollapsibleSection에는 원래 없어 이제 세 컴포넌트가 같은 형태다.

사용 가이드도 별도 md 없이 doc comment에 실었다. 해소된 MOB-6471 예고 문구(`uikit-pitfalls.md`·SectionItem `SPEC.md`)만 현재 상태로 갱신했다.

## 검증

- BezierSwift clean build · BezierExamples clean build 통과
- 테스트 100개(Swift Testing 95 + XCTest 5) 전부 통과
- doc comment 커밋은 코드 라인 변경이 0이라 빌드 대신 `git diff`로 확인 (추가·변경분이 전부 `///`, 삭제 2줄이 모두 `//`)
- press 애니메이션 자체의 시뮬레이터 육안 검증은 하지 않았다

## 범위 밖으로 둔 것

- **`BezierCollapsibleSectionLabel`이 `onTap == nil`에서 `reset()`을 호출하지 않는다** — `onTap`이 optional인데 `refreshPressed()`는 조건 없이 `apply`만 호출해, 탭을 받지 않는 상태에서도 press 피드백이 걸린다. 저장소 3곳 중 이 1곳만 doc의 지침을 따르지 않는다. 동작 변경이라 별도 판단이 필요하다.
- **spring·`pressScale` 상수가 internal이라 외부 소비자는 pressed 배경 전환을 같은 커브로 맞출 수 없다** — 공개 표면을 티켓 범위로 유지하는 대신 감수한 트레이드오프다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 눌림 피드백 기능을 공개 API로 제공해 UIKit과 SwiftUI에서 직접 사용할 수 있습니다.
  * 접근성의 동작 줄이기 설정을 고려한 일관된 눌림 애니메이션을 지원합니다.

* **개선 사항**
  * 기본 항목의 탭 가능 여부에 따라 눌림 효과가 적용되거나 초기화됩니다.
  * UIKit 및 SwiftUI에서 눌림 피드백을 올바르게 적용하는 방법을 문서화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->