### PR TITLE
[MOB-6642] ConfirmModal title/description 태그 서식 지원

### DIFF
--- a/Examples/BezierExamples/BezierExamples/Components/ConfirmModalCatalog.swift
+++ b/Examples/BezierExamples/BezierExamples/Components/ConfirmModalCatalog.swift
@@ -81,6 +81,13 @@ struct ConfirmModalCatalog: View {
           )
       }
 
+      SUBezierConfirmModal(
+        title: "이메일을 확인해 주세요",
+        description: "<b>finn@channel.io</b>로 인증 메일을 보냈어요.<br />메일함을 확인해 주세요.",
+        confirmAction: BezierConfirmModalAction(title: "확인"),
+        cancelAction: BezierConfirmModalAction(title: "취소")
+      )
+
       HStack(spacing: 12) {
         SUBezierButton(
           size: .medium,
@@ -169,37 +176,24 @@ struct ConfirmModalCatalog: View {
       .fixedSize()
 
       UIKitWrap {
-        let modal = BezierConfirmModal(
+        BezierConfirmModal(
           title: "이메일을 확인해 주세요",
+          description: "<b>finn@channel.io</b>로 인증 메일을 보냈어요.<br />메일함을 확인해 주세요.",
           confirmAction: BezierConfirmModalAction(title: "확인"),
           cancelAction: BezierConfirmModalAction(title: "취소")
         )
-        modal.attributedDescription = BezierConfirmModalSpec.descriptionTypography.attributedString(
-          modal,
-          text: "<b>finn@channel.io</b>로 인증 메일을 보냈어요.<br />메일함을 확인해 주세요.",
-          semanticColorToken: BezierConfirmModalSpec.textColorToken,
-          alignment: .center,
-          hasTagProperty: true
-        )
-        return modal
       }
       .fixedSize()
 
       UIKitWrap {
         let button = BezierButton(size: .medium, variant: .filled, semantic: .primary)
-        button.title = "Present (rich text)"
+        button.title = "Present (태그 서식)"
         button.addAction(
           UIAction { [weak button] _ in
-            guard let button, let presenter = button.topPresentingViewController else { return }
+            guard let presenter = button?.topPresentingViewController else { return }
             let modalController = BezierModalViewController.confirm(
               title: "섹션을 삭제할까요?",
-              attributedDescription: BezierConfirmModalSpec.descriptionTypography.attributedString(
-                button,
-                text: "<b>일반</b> 섹션의 팀 채팅이 모두 사라져요.<br />되돌릴 수 없어요.",
-                semanticColorToken: BezierConfirmModalSpec.textColorToken,
-                alignment: .center,
-                hasTagProperty: true
-              ),
+              description: "<b>일반</b> 섹션의 팀 채팅이 모두 사라져요.<br />되돌릴 수 없어요.",
               type: .destructive,
               buttonLayout: .vertical(altAction: nil),
               confirmAction: BezierConfirmModalAction(title: "삭제"),

--- a/Examples/BezierExamples/BezierExamples/Components/ConfirmModalCatalog.swift
+++ b/Examples/BezierExamples/BezierExamples/Components/ConfirmModalCatalog.swift
@@ -169,6 +169,51 @@ struct ConfirmModalCatalog: View {
       .fixedSize()
 
       UIKitWrap {
+        let modal = BezierConfirmModal(
+          title: "이메일을 확인해 주세요",
+          confirmAction: BezierConfirmModalAction(title: "확인"),
+          cancelAction: BezierConfirmModalAction(title: "취소")
+        )
+        modal.attributedDescription = BezierConfirmModalSpec.descriptionTypography.attributedString(
+          modal,
+          text: "<b>finn@channel.io</b>로 인증 메일을 보냈어요.<br />메일함을 확인해 주세요.",
+          semanticColorToken: BezierConfirmModalSpec.textColorToken,
+          alignment: .center,
+          hasTagProperty: true
+        )
+        return modal
+      }
+      .fixedSize()
+
+      UIKitWrap {
+        let button = BezierButton(size: .medium, variant: .filled, semantic: .primary)
+        button.title = "Present (rich text)"
+        button.addAction(
+          UIAction { [weak button] _ in
+            guard let button, let presenter = button.topPresentingViewController else { return }
+            let modalController = BezierModalViewController.confirm(
+              title: "섹션을 삭제할까요?",
+              attributedDescription: BezierConfirmModalSpec.descriptionTypography.attributedString(
+                button,
+                text: "<b>일반</b> 섹션의 팀 채팅이 모두 사라져요.<br />되돌릴 수 없어요.",
+                semanticColorToken: BezierConfirmModalSpec.textColorToken,
+                alignment: .center,
+                hasTagProperty: true
+              ),
+              type: .destructive,
+              buttonLayout: .vertical(altAction: nil),
+              confirmAction: BezierConfirmModalAction(title: "삭제"),
+              cancelAction: BezierConfirmModalAction(title: "취소")
+            )
+            presenter.present(modalController, animated: true)
+          },
+          for: .touchUpInside
+        )
+        return button
+      }
+      .fixedSize()
+
+      UIKitWrap {
         let button = BezierButton(size: .medium, variant: .filled, semantic: .primary)
         button.title = "Present (UIKit)"
         button.addAction(

--- a/Sources/BezierSwift/Extension/String+TagRuns.swift
+++ b/Sources/BezierSwift/Extension/String+TagRuns.swift
@@ -1,0 +1,49 @@
+//
+//  String+TagRuns.swift
+//  BezierSwift
+//
+
+import Foundation
+
+/// 태그 서식이 적용된 텍스트 조각.
+struct BezierTagRun: Equatable {
+  let text: String
+  let isBold: Bool
+  let isUnderlined: Bool
+}
+
+private extension NSAttributedString.Key {
+  static let bezierTagBold = NSAttributedString.Key("bezierTagBold")
+  static let bezierTagUnderline = NSAttributedString.Key("bezierTagUnderline")
+}
+
+extension String {
+  /// `<b>`·`<u>`·`<br />` 태그를 파싱해 서식 조각으로 쪼갠다.
+  ///
+  /// SwiftUI `Text`는 `NSAttributedString`을 그대로 받으면 `paragraphStyle`을 무시해 UIKit과 행높이가 어긋난다. 그래서 서식을 조각 단위로 옮겨 `Text`를 잇는데, 파싱만은 UIKit 경로와 같은 파서를 타게 해 두 구현의 태그 해석이 갈라지지 않게 한다.
+  func bezierTagRuns() -> [BezierTagRun] {
+    let parsed = self.attributes(
+      [:],
+      tagAttributes: [
+        .bold: [.bezierTagBold: true],
+        .underline: [.bezierTagUnderline: true],
+      ]
+    )
+
+    let text = parsed.string as NSString
+    var runs: [BezierTagRun] = []
+    parsed.enumerateAttributes(
+      in: NSRange(location: 0, length: parsed.length),
+      options: []
+    ) { attributes, range, _ in
+      runs.append(
+        BezierTagRun(
+          text: text.substring(with: range),
+          isBold: attributes[.bezierTagBold] != nil,
+          isUnderlined: attributes[.bezierTagUnderline] != nil
+        )
+      )
+    }
+    return runs
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierConfirmModal/BezierConfirmModal+Presentation.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierConfirmModal/BezierConfirmModal+Presentation.swift
@@ -16,6 +16,51 @@ extension BezierModalViewController {
     confirmAction: BezierConfirmModalAction,
     cancelAction: BezierConfirmModalAction?
   ) -> BezierModalViewController {
+    self.makeConfirm(
+      title: title,
+      customContent: customContent,
+      type: type,
+      buttonLayout: buttonLayout,
+      confirmAction: confirmAction,
+      cancelAction: cancelAction
+    ) { modalView in
+      modalView.descriptionText = description
+    }
+  }
+
+  /// 설명에 리치 텍스트를 넣는 `confirm(...)` 오버로드. `<b>` 강조나 `<br />` 줄바꿈이 섞인 문구에 쓴다.
+  ///
+  /// `attributedDescription`의 전경색은 모달이 표시 시점에 다시 칠하므로, 리치 텍스트를 만들 때 넘기는 `BezierComponentable`이 무엇이든(그리고 그 사이 해제되더라도) 색 결과는 달라지지 않는다. 자세한 계약은 `BezierConfirmModal.attributedDescription`에 있다.
+  public static func confirm(
+    title: String,
+    attributedDescription: NSAttributedString,
+    customContent: UIView? = nil,
+    type: BezierConfirmModalType = .default,
+    buttonLayout: BezierConfirmModalButtonLayout = .horizontal,
+    confirmAction: BezierConfirmModalAction,
+    cancelAction: BezierConfirmModalAction?
+  ) -> BezierModalViewController {
+    self.makeConfirm(
+      title: title,
+      customContent: customContent,
+      type: type,
+      buttonLayout: buttonLayout,
+      confirmAction: confirmAction,
+      cancelAction: cancelAction
+    ) { modalView in
+      modalView.attributedDescription = attributedDescription
+    }
+  }
+
+  private static func makeConfirm(
+    title: String,
+    customContent: UIView?,
+    type: BezierConfirmModalType,
+    buttonLayout: BezierConfirmModalButtonLayout,
+    confirmAction: BezierConfirmModalAction,
+    cancelAction: BezierConfirmModalAction?,
+    applyDescription: (BezierConfirmModal) -> Void
+  ) -> BezierModalViewController {
     weak var weakController: BezierModalViewController?
 
     func dismissingAction(_ action: BezierConfirmModalAction) -> BezierConfirmModalAction {
@@ -36,13 +81,13 @@ extension BezierModalViewController {
 
     let modalView = BezierConfirmModal(
       title: title,
-      description: description,
       customContent: customContent,
       type: type,
       buttonLayout: wrappedLayout,
       confirmAction: dismissingAction(confirmAction),
       cancelAction: cancelAction.map(dismissingAction)
     )
+    applyDescription(modalView)
 
     let controller = BezierModalViewController(modalView: modalView)
     weakController = controller

--- a/Sources/BezierSwift/MasterComponent/BezierConfirmModal/BezierConfirmModal+Presentation.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierConfirmModal/BezierConfirmModal+Presentation.swift
@@ -7,6 +7,8 @@ import UIKit
 
 extension BezierModalViewController {
   /// 확인 모달을 카드로 감싸 dim 배경과 함께 띄울 수 있는 컨트롤러를 만든다. 각 버튼 액션은 탭 시 모달을 먼저 닫은 뒤 핸들러를 실행한다.
+  ///
+  /// `title`·`description`에는 `<b>`·`<u>`·`<br />` 태그를 섞어 쓸 수 있다. 자세한 내용은 `BezierConfirmModal.title`에 있다.
   public static func confirm(
     title: String,
     description: String? = nil,
@@ -15,51 +17,6 @@ extension BezierModalViewController {
     buttonLayout: BezierConfirmModalButtonLayout = .horizontal,
     confirmAction: BezierConfirmModalAction,
     cancelAction: BezierConfirmModalAction?
-  ) -> BezierModalViewController {
-    self.makeConfirm(
-      title: title,
-      customContent: customContent,
-      type: type,
-      buttonLayout: buttonLayout,
-      confirmAction: confirmAction,
-      cancelAction: cancelAction
-    ) { modalView in
-      modalView.descriptionText = description
-    }
-  }
-
-  /// 설명에 리치 텍스트를 넣는 `confirm(...)` 오버로드. `<b>` 강조나 `<br />` 줄바꿈이 섞인 문구에 쓴다.
-  ///
-  /// `attributedDescription`의 전경색은 모달이 표시 시점에 다시 칠하므로, 리치 텍스트를 만들 때 넘기는 `BezierComponentable`이 무엇이든(그리고 그 사이 해제되더라도) 색 결과는 달라지지 않는다. 자세한 계약은 `BezierConfirmModal.attributedDescription`에 있다.
-  public static func confirm(
-    title: String,
-    attributedDescription: NSAttributedString,
-    customContent: UIView? = nil,
-    type: BezierConfirmModalType = .default,
-    buttonLayout: BezierConfirmModalButtonLayout = .horizontal,
-    confirmAction: BezierConfirmModalAction,
-    cancelAction: BezierConfirmModalAction?
-  ) -> BezierModalViewController {
-    self.makeConfirm(
-      title: title,
-      customContent: customContent,
-      type: type,
-      buttonLayout: buttonLayout,
-      confirmAction: confirmAction,
-      cancelAction: cancelAction
-    ) { modalView in
-      modalView.attributedDescription = attributedDescription
-    }
-  }
-
-  private static func makeConfirm(
-    title: String,
-    customContent: UIView?,
-    type: BezierConfirmModalType,
-    buttonLayout: BezierConfirmModalButtonLayout,
-    confirmAction: BezierConfirmModalAction,
-    cancelAction: BezierConfirmModalAction?,
-    applyDescription: (BezierConfirmModal) -> Void
   ) -> BezierModalViewController {
     weak var weakController: BezierModalViewController?
 
@@ -81,13 +38,13 @@ extension BezierModalViewController {
 
     let modalView = BezierConfirmModal(
       title: title,
+      description: description,
       customContent: customContent,
       type: type,
       buttonLayout: wrappedLayout,
       confirmAction: dismissingAction(confirmAction),
       cancelAction: cancelAction.map(dismissingAction)
     )
-    applyDescription(modalView)
 
     let controller = BezierModalViewController(modalView: modalView)
     weakController = controller

--- a/Sources/BezierSwift/MasterComponent/BezierConfirmModal/BezierConfirmModal.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierConfirmModal/BezierConfirmModal.swift
@@ -20,17 +20,81 @@ public final class BezierConfirmModal: UIView, BezierComponentable {
     }
   }
 
-  // MARK: - Public Properties
+  // MARK: - Text Storage
 
-  /// 모달 상단에 표시하는 제목.
-  public var title: String {
+  // 평문과 리치 텍스트를 슬롯 하나에 담아, 나중에 설정한 쪽만 남고 다른 쪽 잔재가 남지 않게 한다
+  private enum TextContent {
+    case plain(String)
+    case attributed(NSAttributedString)
+
+    var string: String {
+      switch self {
+      case .plain(let text): return text
+      case .attributed(let text): return text.string
+      }
+    }
+
+    var attributed: NSAttributedString? {
+      switch self {
+      case .plain: return nil
+      case .attributed(let text): return text
+      }
+    }
+  }
+
+  private var titleContent: TextContent {
     didSet { self.refreshAppearance() }
   }
 
-  // UIView.description(NSObject)과의 충돌을 피하기 위한 명명
-  /// 제목 아래 표시하는 설명 텍스트. `nil`이면 숨겨진다.
-  public var descriptionText: String? {
+  private var descriptionContent: TextContent? {
     didSet { self.refreshAppearance() }
+  }
+
+  // MARK: - Public Properties
+
+  /// 모달 상단에 표시하는 제목. `attributedTitle`이 설정돼 있으면 그 평문(`NSAttributedString.string`)을 돌려주고, 이 프로퍼티에 값을 넣으면 `attributedTitle`은 `nil`이 된다.
+  public var title: String {
+    get { self.titleContent.string }
+    set { self.titleContent = .plain(newValue) }
+  }
+
+  // UIView.description(NSObject)과의 충돌을 피하기 위한 명명
+  /// 제목 아래 표시하는 설명 텍스트. `nil`이면 설명이 숨겨진다. `attributedDescription`이 설정돼 있으면 그 평문을 돌려주고, 이 프로퍼티에 값을 넣으면 `attributedDescription`은 `nil`이 된다.
+  public var descriptionText: String? {
+    get { self.descriptionContent?.string }
+    set { self.descriptionContent = newValue.map { .plain($0) } }
+  }
+
+  /// 제목에 넣을 리치 텍스트. `<b>` 강조처럼 문자열 하나에 서로 다른 서식이 섞여야 할 때 쓴다.
+  ///
+  /// 값을 넣으면 `title`은 이 문자열의 평문으로 대체되고, 반대로 `title`에 값을 넣으면 이 프로퍼티는 `nil`이 된다 — 둘 중 나중에 설정한 쪽만 남는다. `nil`을 넣으면 서식만 버리고 같은 평문의 `title`로 돌아간다(제목은 필수라 비워지지 않는다).
+  ///
+  /// 전경색은 모달이 표시 시점에 `BezierConfirmModalSpec.textColorToken`으로 다시 칠하므로 여기서 지정한 색은 무시된다. 색을 모달이 소유해야 다크모드·`componentTheme` 전환이 평문 경로와 똑같이 따라온다. 글꼴·문단 서식·줄바꿈은 넘긴 그대로 쓰이므로, SPEC의 가운데 정렬과 typography를 지키려면 `BezierConfirmModalSpec.titleTypography`로 `alignment: .center`를 지정해 만든다.
+  public var attributedTitle: NSAttributedString? {
+    get { self.titleContent.attributed }
+    set {
+      if let newValue {
+        self.titleContent = .attributed(newValue)
+      } else {
+        self.titleContent = .plain(self.titleContent.string)
+      }
+    }
+  }
+
+  /// 설명에 넣을 리치 텍스트. `<b>` 강조나 `<br />` 줄바꿈이 섞인 문구에 쓴다.
+  ///
+  /// 값을 넣으면 `descriptionText`는 이 문자열의 평문으로 대체되고, 반대로 `descriptionText`에 값을 넣으면 이 프로퍼티는 `nil`이 된다 — 둘 중 나중에 설정한 쪽만 남는다. `nil`을 넣으면 서식만 버리고 같은 평문의 `descriptionText`로 돌아가며, 설명을 숨기려면 `descriptionText`에 `nil`을 넣는다.
+  ///
+  /// 전경색은 모달이 표시 시점에 `BezierConfirmModalSpec.textColorToken`으로 다시 칠하므로 여기서 지정한 색은 무시된다. 색을 모달이 소유해야 다크모드·`componentTheme` 전환이 평문 경로와 똑같이 따라온다. 글꼴·문단 서식·줄바꿈은 넘긴 그대로 쓰이므로, SPEC의 가운데 정렬과 typography를 지키려면 `BezierConfirmModalSpec.descriptionTypography`로 `alignment: .center`를 지정해 만든다.
+  public var attributedDescription: NSAttributedString? {
+    get { self.descriptionContent?.attributed }
+    set {
+      if let newValue {
+        self.descriptionContent = .attributed(newValue)
+      } else {
+        self.descriptionContent = self.descriptionContent.map { .plain($0.string) }
+      }
+    }
   }
 
   /// 주 액션(확인) 버튼. `type`에 따라 강조 색이 결정된다.
@@ -61,8 +125,8 @@ public final class BezierConfirmModal: UIView, BezierComponentable {
     confirmAction: BezierConfirmModalAction,
     cancelAction: BezierConfirmModalAction?
   ) {
-    self.title = title
-    self.descriptionText = description
+    self.titleContent = .plain(title)
+    self.descriptionContent = description.map { .plain($0) }
     self.confirmButton = BezierButton(
       size: BezierConfirmModalSpec.buttonSize,
       variant: BezierConfirmModalSpec.buttonVariant,
@@ -229,24 +293,44 @@ public final class BezierConfirmModal: UIView, BezierComponentable {
   // MARK: - Refresh
 
   private func refreshAppearance() {
-    self.titleLabel.attributedText = BezierConfirmModalSpec.titleTypography.attributedString(
-      self,
-      text: self.title,
-      semanticColorToken: BezierConfirmModalSpec.textColorToken,
-      alignment: .center
+    self.titleLabel.attributedText = self.render(
+      self.titleContent,
+      typography: BezierConfirmModalSpec.titleTypography
     )
 
-    if let descriptionText = self.descriptionText {
+    if let descriptionContent = self.descriptionContent {
       self.descriptionLabel.isHidden = false
-      self.descriptionLabel.attributedText = BezierConfirmModalSpec.descriptionTypography.attributedString(
-        self,
-        text: descriptionText,
-        semanticColorToken: BezierConfirmModalSpec.textColorToken,
-        alignment: .center
+      self.descriptionLabel.attributedText = self.render(
+        descriptionContent,
+        typography: BezierConfirmModalSpec.descriptionTypography
       )
     } else {
       self.descriptionLabel.isHidden = true
       self.descriptionLabel.attributedText = nil
+    }
+  }
+
+  private func render(_ content: TextContent, typography: BTSemanticToken) -> NSAttributedString {
+    switch content {
+    case .plain(let text):
+      return typography.attributedString(
+        self,
+        text: text,
+        semanticColorToken: BezierConfirmModalSpec.textColorToken,
+        alignment: .center
+      )
+
+    case .attributed(let text):
+      // 호출부가 리치 텍스트를 만드는 시점엔 이 모달이 아직 없어, 넘어온 전경색은 곧 사라질
+      // 임시 컴포넌트(→ TempBezierComponent 폴백)에 묶여 componentTheme을 잃는다.
+      // 살아 있는 self로 다시 칠해야 테마 전환이 평문 경로와 같은 보장을 갖는다.
+      let rendered = NSMutableAttributedString(attributedString: text)
+      rendered.addAttribute(
+        .foregroundColor,
+        value: BezierConfirmModalSpec.textColorToken.palette(self),
+        range: NSRange(location: 0, length: rendered.length)
+      )
+      return rendered
     }
   }
 }

--- a/Sources/BezierSwift/MasterComponent/BezierConfirmModal/BezierConfirmModal.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierConfirmModal/BezierConfirmModal.swift
@@ -20,81 +20,21 @@ public final class BezierConfirmModal: UIView, BezierComponentable {
     }
   }
 
-  // MARK: - Text Storage
-
-  // 평문과 리치 텍스트를 슬롯 하나에 담아, 나중에 설정한 쪽만 남고 다른 쪽 잔재가 남지 않게 한다
-  private enum TextContent {
-    case plain(String)
-    case attributed(NSAttributedString)
-
-    var string: String {
-      switch self {
-      case .plain(let text): return text
-      case .attributed(let text): return text.string
-      }
-    }
-
-    var attributed: NSAttributedString? {
-      switch self {
-      case .plain: return nil
-      case .attributed(let text): return text
-      }
-    }
-  }
-
-  private var titleContent: TextContent {
-    didSet { self.refreshAppearance() }
-  }
-
-  private var descriptionContent: TextContent? {
-    didSet { self.refreshAppearance() }
-  }
-
   // MARK: - Public Properties
 
-  /// 모달 상단에 표시하는 제목. `attributedTitle`이 설정돼 있으면 그 평문(`NSAttributedString.string`)을 돌려주고, 이 프로퍼티에 값을 넣으면 `attributedTitle`은 `nil`이 된다.
+  /// 모달 상단에 표시하는 제목.
+  ///
+  /// `<b>`(강조)·`<u>`(밑줄)·`<br />`(줄바꿈) 태그를 문자열에 그대로 섞어 쓸 수 있다. 다만 제목 typography는 이미 굵은 계열이라 `<b>`로 굵기가 더 달라지지는 않는다. 태그를 글자 그대로 보여주는 방법은 없다.
   public var title: String {
-    get { self.titleContent.string }
-    set { self.titleContent = .plain(newValue) }
+    didSet { self.refreshAppearance() }
   }
 
   // UIView.description(NSObject)과의 충돌을 피하기 위한 명명
-  /// 제목 아래 표시하는 설명 텍스트. `nil`이면 설명이 숨겨진다. `attributedDescription`이 설정돼 있으면 그 평문을 돌려주고, 이 프로퍼티에 값을 넣으면 `attributedDescription`은 `nil`이 된다.
+  /// 제목 아래 표시하는 설명 텍스트. `nil`이면 숨겨진다.
+  ///
+  /// `<b>`(강조)·`<u>`(밑줄)·`<br />`(줄바꿈) 태그를 문자열에 그대로 섞어 쓸 수 있다. 강조 구간에는 설명 typography의 bold 짝이 적용된다. 태그를 글자 그대로 보여주는 방법은 없다.
   public var descriptionText: String? {
-    get { self.descriptionContent?.string }
-    set { self.descriptionContent = newValue.map { .plain($0) } }
-  }
-
-  /// 제목에 넣을 리치 텍스트. `<b>` 강조처럼 문자열 하나에 서로 다른 서식이 섞여야 할 때 쓴다.
-  ///
-  /// 값을 넣으면 `title`은 이 문자열의 평문으로 대체되고, 반대로 `title`에 값을 넣으면 이 프로퍼티는 `nil`이 된다 — 둘 중 나중에 설정한 쪽만 남는다. `nil`을 넣으면 서식만 버리고 같은 평문의 `title`로 돌아간다(제목은 필수라 비워지지 않는다).
-  ///
-  /// 전경색은 모달이 표시 시점에 `BezierConfirmModalSpec.textColorToken`으로 다시 칠하므로 여기서 지정한 색은 무시된다. 색을 모달이 소유해야 다크모드·`componentTheme` 전환이 평문 경로와 똑같이 따라온다. 글꼴·문단 서식·줄바꿈은 넘긴 그대로 쓰이므로, SPEC의 가운데 정렬과 typography를 지키려면 `BezierConfirmModalSpec.titleTypography`로 `alignment: .center`를 지정해 만든다.
-  public var attributedTitle: NSAttributedString? {
-    get { self.titleContent.attributed }
-    set {
-      if let newValue {
-        self.titleContent = .attributed(newValue)
-      } else {
-        self.titleContent = .plain(self.titleContent.string)
-      }
-    }
-  }
-
-  /// 설명에 넣을 리치 텍스트. `<b>` 강조나 `<br />` 줄바꿈이 섞인 문구에 쓴다.
-  ///
-  /// 값을 넣으면 `descriptionText`는 이 문자열의 평문으로 대체되고, 반대로 `descriptionText`에 값을 넣으면 이 프로퍼티는 `nil`이 된다 — 둘 중 나중에 설정한 쪽만 남는다. `nil`을 넣으면 서식만 버리고 같은 평문의 `descriptionText`로 돌아가며, 설명을 숨기려면 `descriptionText`에 `nil`을 넣는다.
-  ///
-  /// 전경색은 모달이 표시 시점에 `BezierConfirmModalSpec.textColorToken`으로 다시 칠하므로 여기서 지정한 색은 무시된다. 색을 모달이 소유해야 다크모드·`componentTheme` 전환이 평문 경로와 똑같이 따라온다. 글꼴·문단 서식·줄바꿈은 넘긴 그대로 쓰이므로, SPEC의 가운데 정렬과 typography를 지키려면 `BezierConfirmModalSpec.descriptionTypography`로 `alignment: .center`를 지정해 만든다.
-  public var attributedDescription: NSAttributedString? {
-    get { self.descriptionContent?.attributed }
-    set {
-      if let newValue {
-        self.descriptionContent = .attributed(newValue)
-      } else {
-        self.descriptionContent = self.descriptionContent.map { .plain($0.string) }
-      }
-    }
+    didSet { self.refreshAppearance() }
   }
 
   /// 주 액션(확인) 버튼. `type`에 따라 강조 색이 결정된다.
@@ -116,6 +56,8 @@ public final class BezierConfirmModal: UIView, BezierComponentable {
   // MARK: - Init
 
   /// 제목·설명·버튼 구성으로 확인 모달을 생성한다. `type`으로 확인 버튼의 강조를, `buttonLayout`으로 버튼 배치를 정하며, `cancelAction`이 `nil`이면 확인 단일 버튼이 된다.
+  ///
+  /// `title`·`description`에는 `<b>`(강조)·`<u>`(밑줄)·`<br />`(줄바꿈) 태그를 섞어 쓸 수 있다. 자세한 내용은 `title` 프로퍼티에 있다.
   public init(
     title: String,
     description: String? = nil,
@@ -125,8 +67,8 @@ public final class BezierConfirmModal: UIView, BezierComponentable {
     confirmAction: BezierConfirmModalAction,
     cancelAction: BezierConfirmModalAction?
   ) {
-    self.titleContent = .plain(title)
-    self.descriptionContent = description.map { .plain($0) }
+    self.title = title
+    self.descriptionText = description
     self.confirmButton = BezierButton(
       size: BezierConfirmModalSpec.buttonSize,
       variant: BezierConfirmModalSpec.buttonVariant,
@@ -293,44 +235,26 @@ public final class BezierConfirmModal: UIView, BezierComponentable {
   // MARK: - Refresh
 
   private func refreshAppearance() {
-    self.titleLabel.attributedText = self.render(
-      self.titleContent,
-      typography: BezierConfirmModalSpec.titleTypography
+    self.titleLabel.attributedText = BezierConfirmModalSpec.titleTypography.attributedString(
+      self,
+      text: self.title,
+      semanticColorToken: BezierConfirmModalSpec.textColorToken,
+      alignment: .center,
+      hasTagProperty: true
     )
 
-    if let descriptionContent = self.descriptionContent {
+    if let descriptionText = self.descriptionText {
       self.descriptionLabel.isHidden = false
-      self.descriptionLabel.attributedText = self.render(
-        descriptionContent,
-        typography: BezierConfirmModalSpec.descriptionTypography
+      self.descriptionLabel.attributedText = BezierConfirmModalSpec.descriptionTypography.attributedString(
+        self,
+        text: descriptionText,
+        semanticColorToken: BezierConfirmModalSpec.textColorToken,
+        alignment: .center,
+        hasTagProperty: true
       )
     } else {
       self.descriptionLabel.isHidden = true
       self.descriptionLabel.attributedText = nil
-    }
-  }
-
-  private func render(_ content: TextContent, typography: BTSemanticToken) -> NSAttributedString {
-    switch content {
-    case .plain(let text):
-      return typography.attributedString(
-        self,
-        text: text,
-        semanticColorToken: BezierConfirmModalSpec.textColorToken,
-        alignment: .center
-      )
-
-    case .attributed(let text):
-      // 호출부가 리치 텍스트를 만드는 시점엔 이 모달이 아직 없어, 넘어온 전경색은 곧 사라질
-      // 임시 컴포넌트(→ TempBezierComponent 폴백)에 묶여 componentTheme을 잃는다.
-      // 살아 있는 self로 다시 칠해야 테마 전환이 평문 경로와 같은 보장을 갖는다.
-      let rendered = NSMutableAttributedString(attributedString: text)
-      rendered.addAttribute(
-        .foregroundColor,
-        value: BezierConfirmModalSpec.textColorToken.palette(self),
-        range: NSRange(location: 0, length: rendered.length)
-      )
-      return rendered
     }
   }
 }

--- a/Sources/BezierSwift/MasterComponent/BezierConfirmModal/SUBezierConfirmModal.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierConfirmModal/SUBezierConfirmModal.swift
@@ -16,6 +16,8 @@ public struct SUBezierConfirmModal<CustomContent: View>: View {
   private let customContent: CustomContent?
 
   /// 제목·설명·버튼 구성과 함께 추가 커스텀 콘텐츠를 `@ViewBuilder`로 받아 확인 모달을 생성한다.
+  ///
+  /// `title`·`description`에는 `<b>`(강조)·`<u>`(밑줄)·`<br />`(줄바꿈) 태그를 섞어 쓸 수 있다. 강조 구간에는 해당 typography의 bold 짝이 적용된다 — 제목은 이미 굵은 계열이라 변화가 없다. 태그를 글자 그대로 보여주는 방법은 없다.
   public init(
     title: String,
     description: String? = nil,
@@ -66,22 +68,10 @@ public struct SUBezierConfirmModal<CustomContent: View>: View {
     SUBezierModal {
       VStack(spacing: 0) {
         VStack(spacing: BezierConfirmModalSpec.contentSpacing) {
-          Text(self.title)
-            .applyBezierFontStyle(
-              BezierConfirmModalSpec.titleTypography,
-              semanticColorToken: BezierConfirmModalSpec.textColorToken
-            )
-            .multilineTextAlignment(.center)
-            .frame(maxWidth: .infinity)
+          self.styledText(self.title, typography: BezierConfirmModalSpec.titleTypography)
 
           if let description = self.description {
-            Text(description)
-              .applyBezierFontStyle(
-                BezierConfirmModalSpec.descriptionTypography,
-                semanticColorToken: BezierConfirmModalSpec.textColorToken
-              )
-              .multilineTextAlignment(.center)
-              .frame(maxWidth: .infinity)
+            self.styledText(description, typography: BezierConfirmModalSpec.descriptionTypography)
           }
         }
         .padding(.bottom, BezierConfirmModalSpec.contentBottomPadding)
@@ -134,10 +124,29 @@ public struct SUBezierConfirmModal<CustomContent: View>: View {
       action: action.handler
     )
   }
+
+  private func styledText(_ raw: String, typography: BTSemanticToken) -> some View {
+    raw.bezierTagRuns()
+      .reduce(Text("")) { accumulated, run in
+        var text = Text(run.text)
+        if run.isBold {
+          text = text.font(typography.boldPair.font)
+        }
+        if run.isUnderlined {
+          text = text.underline()
+        }
+        return accumulated + text
+      }
+      .applyBezierFontStyle(typography, semanticColorToken: BezierConfirmModalSpec.textColorToken)
+      .multilineTextAlignment(.center)
+      .frame(maxWidth: .infinity)
+  }
 }
 
 extension SUBezierConfirmModal where CustomContent == EmptyView {
   /// 커스텀 콘텐츠 없이 제목·설명·버튼만으로 확인 모달을 생성하는 편의 이니셜라이저.
+  ///
+  /// `title`·`description`에는 `<b>`(강조)·`<u>`(밑줄)·`<br />`(줄바꿈) 태그를 섞어 쓸 수 있다. 강조 구간에는 해당 typography의 bold 짝이 적용된다 — 제목은 이미 굵은 계열이라 변화가 없다. 태그를 글자 그대로 보여주는 방법은 없다.
   public init(
     title: String,
     description: String? = nil,

--- a/Tests/BezierSwiftTests/BezierConfirmModalTextTests.swift
+++ b/Tests/BezierSwiftTests/BezierConfirmModalTextTests.swift
@@ -2,163 +2,120 @@ import Testing
 import UIKit
 @testable import BezierSwift
 
-// 리치 텍스트를 만드는 시점엔 모달이 없어 호출부는 아무 컴포넌트나 넘기게 된다.
-// 테마를 전혀 따라가지 않는 컴포넌트를 일부러 넘겨, 모달이 색을 되찾는지 검증한다.
-private final class FrozenLightComponent: BezierComponentable {
-  var colorTheme: BezierColorTheme { .light }
-  var componentTheme: BezierComponentTheme = .normal
-}
-
-@Suite("BezierConfirmModal 텍스트 갱신 계약", .serialized)
+@Suite("BezierConfirmModal 태그 서식", .serialized)
 @MainActor
-struct BezierConfirmModalTextContractTests {
-  @Test("attributedTitle을 설정하면 title은 그 평문이 된다")
-  func attributedTitleReplacesPlainTitle() {
-    let modal = makeModal(title: "Plain")
-    #expect(modal.attributedTitle == nil)
+struct BezierConfirmModalTagStyleTests {
+  @Test("설명의 <b> 구간에만 bold 짝 폰트가 적용된다")
+  func boldTagAppliesBoldPairFont() throws {
+    let modal = makeModal(description: "일반 <b>강조</b> 끝")
+    let rendered = try #require(attributedText(matching: "일반 강조 끝", in: modal))
 
-    modal.attributedTitle = NSAttributedString(string: "Rich")
-
-    #expect(modal.title == "Rich")
-    #expect(modal.attributedTitle?.string == "Rich")
+    let typography = BezierConfirmModalSpec.descriptionTypography
+    #expect(typography.uiFont != typography.boldPair.uiFont)
+    #expect(rendered.attribute(.font, at: 0, effectiveRange: nil) as? UIFont == typography.uiFont)
+    #expect(rendered.attribute(.font, at: 3, effectiveRange: nil) as? UIFont == typography.boldPair.uiFont)
   }
 
-  @Test("title을 설정하면 attributedTitle 잔재가 남지 않는다")
-  func plainTitleClearsAttributedTitle() {
-    let modal = makeModal(title: "Plain")
-    modal.attributedTitle = NSAttributedString(string: "Rich")
+  @Test("설명의 <u> 구간에만 밑줄이 적용된다")
+  func underlineTagAppliesUnderline() throws {
+    let modal = makeModal(description: "보통 <u>밑줄</u>")
+    let rendered = try #require(attributedText(matching: "보통 밑줄", in: modal))
 
-    modal.title = "Plain again"
-
-    #expect(modal.attributedTitle == nil)
-    #expect(modal.title == "Plain again")
-    #expect(label(withText: "Rich", in: modal) == nil)
+    #expect(rendered.attribute(.underlineStyle, at: 0, effectiveRange: nil) == nil)
+    #expect(rendered.attribute(.underlineStyle, at: 3, effectiveRange: nil) != nil)
   }
 
-  @Test("attributedTitle에 nil을 넣으면 서식만 버리고 평문이 남는다")
-  func clearingAttributedTitleKeepsPlainText() {
-    let modal = makeModal(title: "Plain")
-    modal.attributedTitle = NSAttributedString(string: "Rich")
+  @Test("<br />는 줄바꿈이 된다")
+  func lineBreakTagBecomesNewline() {
+    let modal = makeModal(description: "첫 줄<br />둘째 줄")
 
-    modal.attributedTitle = nil
-
-    #expect(modal.attributedTitle == nil)
-    #expect(modal.title == "Rich")
+    #expect(attributedText(matching: "첫 줄\n둘째 줄", in: modal) != nil)
   }
 
-  @Test("attributedDescription을 설정하면 descriptionText는 그 평문이 된다")
-  func attributedDescriptionReplacesPlainDescription() {
-    let modal = makeModal(description: "Plain")
+  @Test("태그는 화면에 글자로 남지 않는다")
+  func tagsAreStrippedFromRenderedText() {
+    let modal = makeModal(title: "<b>제목</b>", description: "<u>설명</u>")
 
-    modal.attributedDescription = NSAttributedString(string: "Rich")
-
-    #expect(modal.descriptionText == "Rich")
-    #expect(modal.attributedDescription?.string == "Rich")
+    #expect(attributedText(matching: "제목", in: modal) != nil)
+    #expect(attributedText(matching: "설명", in: modal) != nil)
   }
 
-  @Test("descriptionText를 설정하면 attributedDescription 잔재가 남지 않는다")
-  func plainDescriptionClearsAttributedDescription() {
-    let modal = makeModal(description: "Plain")
-    modal.attributedDescription = NSAttributedString(string: "Rich")
+  @Test("태그가 없는 설명은 전 구간이 한 서식으로 렌더된다")
+  func plainDescriptionRendersUniformly() throws {
+    let modal = makeModal(description: "태그 없는 설명")
+    let rendered = try #require(attributedText(matching: "태그 없는 설명", in: modal))
 
-    modal.descriptionText = "Plain again"
+    var effectiveRange = NSRange()
+    let font = rendered.attribute(.font, at: 0, effectiveRange: &effectiveRange) as? UIFont
 
-    #expect(modal.attributedDescription == nil)
-    #expect(modal.descriptionText == "Plain again")
-    #expect(label(withText: "Rich", in: modal) == nil)
+    #expect(font == BezierConfirmModalSpec.descriptionTypography.uiFont)
+    #expect(effectiveRange.length == rendered.length)
   }
 
-  @Test("설명 없이 만든 모달에 attributedDescription을 넣으면 나타난다")
-  func attributedDescriptionAppearsOnModalCreatedWithoutDescription() throws {
-    let modal = makeModal(description: nil)
-    #expect(modal.descriptionText == nil)
+  @Test("태그를 써도 가운데 정렬과 행높이는 SPEC 값을 유지한다")
+  func paragraphStyleFollowsSpec() throws {
+    let modal = makeModal(description: "설명 <b>강조</b>")
+    let rendered = try #require(attributedText(matching: "설명 강조", in: modal))
+    let style = try #require(rendered.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle)
 
-    modal.attributedDescription = NSAttributedString(string: "Rich")
-
-    let descriptionLabel = try #require(label(withText: "Rich", in: modal))
-    #expect(descriptionLabel.isHidden == false)
+    #expect(style.alignment == .center)
+    #expect(style.minimumLineHeight == BezierConfirmModalSpec.descriptionTypography.lineHeight)
   }
 
-  @Test("descriptionText에 nil을 넣으면 attributed 여부와 무관하게 숨겨진다")
-  func nilDescriptionHidesRegardlessOfKind() {
-    let modal = makeModal(description: "Plain")
-    modal.attributedDescription = NSAttributedString(string: "Rich")
+  @Test("설명을 nil로 바꾸면 사라진다")
+  func settingNilDescriptionHidesIt() {
+    let modal = makeModal(description: "설명")
+    #expect(attributedText(matching: "설명", in: modal) != nil)
 
     modal.descriptionText = nil
 
-    #expect(modal.descriptionText == nil)
-    #expect(modal.attributedDescription == nil)
-    #expect(label(withText: "Rich", in: modal) == nil)
+    #expect(attributedText(matching: "설명", in: modal) == nil)
+  }
+
+  @Test("제목을 바꾸면 태그가 다시 해석된다")
+  func updatingTitleReparsesTags() {
+    let modal = makeModal(title: "처음")
+
+    modal.title = "<b>나중</b>"
+
+    #expect(attributedText(matching: "나중", in: modal) != nil)
+    #expect(attributedText(matching: "처음", in: modal) == nil)
   }
 }
 
-@Suite("BezierConfirmModal 리치 텍스트 색 소유", .serialized)
+@Suite("BezierConfirmModal 태그 텍스트 테마 추종", .serialized)
 @MainActor
-struct BezierConfirmModalAttributedColorTests {
-  @Test("주입한 전경색은 모달의 시맨틱 색으로 덮어써진다")
-  func injectedForegroundColorIsOverwritten() throws {
-    let modal = makeModal()
-    let injected = NSMutableAttributedString(string: "Rich")
-    injected.addAttribute(
-      .foregroundColor,
-      value: UIColor.red,
-      range: NSRange(location: 0, length: injected.length)
-    )
-    modal.attributedDescription = injected
+struct BezierConfirmModalTagThemeTests {
+  @Test("다크모드에서 태그 텍스트 색이 달라진다")
+  func tagTextFollowsDarkMode() throws {
+    let modal = makeModal(description: "일반 <b>강조</b>")
+    let color = try #require(foregroundColor(matching: "일반 강조", in: modal))
 
-    let rendered = try #require(foregroundColor(ofTextMatching: "Rich", in: modal))
-    let expected = BezierConfirmModalSpec.textColorToken.palette(modal)
-
-    for style in [UIUserInterfaceStyle.light, .dark] {
-      #expect(resolved(rendered, style: style) == resolved(expected, style: style))
-      #expect(resolved(rendered, style: style) != resolved(.red, style: style))
-    }
+    #expect(resolved(color, style: .light) != resolved(color, style: .dark))
   }
 
-  @Test("테마를 따라가지 않는 컴포넌트로 만든 리치 텍스트도 라이트·다크가 갈린다")
-  func attributedTextTracksInterfaceStyleEvenWhenBuiltWithFrozenComponent() throws {
-    let frozen = FrozenLightComponent()
-    let modal = makeModal()
-    modal.attributedDescription = BezierConfirmModalSpec.descriptionTypography.attributedString(
-      frozen,
-      text: "Rich",
-      semanticColorToken: BezierConfirmModalSpec.textColorToken,
-      alignment: .center
-    )
-
-    try withExtendedLifetime(frozen) {
-      let rendered = try #require(foregroundColor(ofTextMatching: "Rich", in: modal))
-      #expect(resolved(rendered, style: .light) != resolved(rendered, style: .dark))
-    }
-  }
-
-  @Test("componentTheme을 뒤집으면 리치 텍스트 색도 평문 경로처럼 반전된다")
-  func attributedTextFollowsComponentThemeInversion() throws {
-    let modal = makeModal()
-    modal.attributedDescription = NSAttributedString(string: "Rich")
-
-    let normal = try #require(foregroundColor(ofTextMatching: "Rich", in: modal))
+  @Test("componentTheme을 뒤집으면 태그 텍스트 색도 반전된다")
+  func tagTextFollowsComponentThemeInversion() throws {
+    let modal = makeModal(description: "일반 <b>강조</b>")
+    let normal = try #require(foregroundColor(matching: "일반 강조", in: modal))
     let normalDark = resolved(normal, style: .dark)
 
     modal.componentTheme = .inverted
-    let inverted = try #require(foregroundColor(ofTextMatching: "Rich", in: modal))
+    let inverted = try #require(foregroundColor(matching: "일반 강조", in: modal))
 
     #expect(resolved(inverted, style: .light) == normalDark)
   }
 
-  @Test("색만 덮어쓰고 글꼴은 넘긴 그대로 유지된다")
-  func fontRunsArePreserved() throws {
-    let modal = makeModal()
-    let bold = UIFont.boldSystemFont(ofSize: 20)
-    let injected = NSMutableAttributedString(string: "AB")
-    injected.addAttribute(.font, value: bold, range: NSRange(location: 1, length: 1))
-    modal.attributedDescription = injected
+  @Test("강조 구간도 나머지와 같은 색을 쓴다")
+  func boldRunSharesColorWithRest() throws {
+    let modal = makeModal(description: "일반 <b>강조</b>")
+    let rendered = try #require(attributedText(matching: "일반 강조", in: modal))
 
-    let descriptionLabel = try #require(label(withText: "AB", in: modal))
-    let rendered = try #require(descriptionLabel.attributedText)
+    let normal = try #require(rendered.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? UIColor)
+    let bold = try #require(rendered.attribute(.foregroundColor, at: 3, effectiveRange: nil) as? UIColor)
 
-    #expect(rendered.attribute(.font, at: 1, effectiveRange: nil) as? UIFont == bold)
-    #expect(rendered.attribute(.font, at: 0, effectiveRange: nil) as? UIFont == nil)
+    #expect(resolved(normal, style: .light) == resolved(bold, style: .light))
+    #expect(resolved(normal, style: .dark) == resolved(bold, style: .dark))
   }
 }
 
@@ -188,14 +145,16 @@ private func label(withText text: String, in view: UIView) -> UILabel? {
 }
 
 @MainActor
-private func foregroundColor(ofTextMatching text: String, in view: UIView) -> UIColor? {
-  label(withText: text, in: view)?
-    .attributedText?
+private func attributedText(matching text: String, in view: UIView) -> NSAttributedString? {
+  label(withText: text, in: view)?.attributedText
+}
+
+@MainActor
+private func foregroundColor(matching text: String, in view: UIView) -> UIColor? {
+  attributedText(matching: text, in: view)?
     .attribute(.foregroundColor, at: 0, effectiveRange: nil) as? UIColor
 }
 
-// palette(_:)의 dynamic provider는 인자 대신 UITraitCollection.current를 읽으므로
-// performAsCurrent 없이 resolvedColor(with:)만 부르면 주변 스타일이 그대로 나온다
 private func resolved(_ color: UIColor, style: UIUserInterfaceStyle) -> UIColor {
   let traits = UITraitCollection(userInterfaceStyle: style)
   var result = color

--- a/Tests/BezierSwiftTests/BezierConfirmModalTextTests.swift
+++ b/Tests/BezierSwiftTests/BezierConfirmModalTextTests.swift
@@ -1,0 +1,204 @@
+import Testing
+import UIKit
+@testable import BezierSwift
+
+// 리치 텍스트를 만드는 시점엔 모달이 없어 호출부는 아무 컴포넌트나 넘기게 된다.
+// 테마를 전혀 따라가지 않는 컴포넌트를 일부러 넘겨, 모달이 색을 되찾는지 검증한다.
+private final class FrozenLightComponent: BezierComponentable {
+  var colorTheme: BezierColorTheme { .light }
+  var componentTheme: BezierComponentTheme = .normal
+}
+
+@Suite("BezierConfirmModal 텍스트 갱신 계약", .serialized)
+@MainActor
+struct BezierConfirmModalTextContractTests {
+  @Test("attributedTitle을 설정하면 title은 그 평문이 된다")
+  func attributedTitleReplacesPlainTitle() {
+    let modal = makeModal(title: "Plain")
+    #expect(modal.attributedTitle == nil)
+
+    modal.attributedTitle = NSAttributedString(string: "Rich")
+
+    #expect(modal.title == "Rich")
+    #expect(modal.attributedTitle?.string == "Rich")
+  }
+
+  @Test("title을 설정하면 attributedTitle 잔재가 남지 않는다")
+  func plainTitleClearsAttributedTitle() {
+    let modal = makeModal(title: "Plain")
+    modal.attributedTitle = NSAttributedString(string: "Rich")
+
+    modal.title = "Plain again"
+
+    #expect(modal.attributedTitle == nil)
+    #expect(modal.title == "Plain again")
+    #expect(label(withText: "Rich", in: modal) == nil)
+  }
+
+  @Test("attributedTitle에 nil을 넣으면 서식만 버리고 평문이 남는다")
+  func clearingAttributedTitleKeepsPlainText() {
+    let modal = makeModal(title: "Plain")
+    modal.attributedTitle = NSAttributedString(string: "Rich")
+
+    modal.attributedTitle = nil
+
+    #expect(modal.attributedTitle == nil)
+    #expect(modal.title == "Rich")
+  }
+
+  @Test("attributedDescription을 설정하면 descriptionText는 그 평문이 된다")
+  func attributedDescriptionReplacesPlainDescription() {
+    let modal = makeModal(description: "Plain")
+
+    modal.attributedDescription = NSAttributedString(string: "Rich")
+
+    #expect(modal.descriptionText == "Rich")
+    #expect(modal.attributedDescription?.string == "Rich")
+  }
+
+  @Test("descriptionText를 설정하면 attributedDescription 잔재가 남지 않는다")
+  func plainDescriptionClearsAttributedDescription() {
+    let modal = makeModal(description: "Plain")
+    modal.attributedDescription = NSAttributedString(string: "Rich")
+
+    modal.descriptionText = "Plain again"
+
+    #expect(modal.attributedDescription == nil)
+    #expect(modal.descriptionText == "Plain again")
+    #expect(label(withText: "Rich", in: modal) == nil)
+  }
+
+  @Test("설명 없이 만든 모달에 attributedDescription을 넣으면 나타난다")
+  func attributedDescriptionAppearsOnModalCreatedWithoutDescription() throws {
+    let modal = makeModal(description: nil)
+    #expect(modal.descriptionText == nil)
+
+    modal.attributedDescription = NSAttributedString(string: "Rich")
+
+    let descriptionLabel = try #require(label(withText: "Rich", in: modal))
+    #expect(descriptionLabel.isHidden == false)
+  }
+
+  @Test("descriptionText에 nil을 넣으면 attributed 여부와 무관하게 숨겨진다")
+  func nilDescriptionHidesRegardlessOfKind() {
+    let modal = makeModal(description: "Plain")
+    modal.attributedDescription = NSAttributedString(string: "Rich")
+
+    modal.descriptionText = nil
+
+    #expect(modal.descriptionText == nil)
+    #expect(modal.attributedDescription == nil)
+    #expect(label(withText: "Rich", in: modal) == nil)
+  }
+}
+
+@Suite("BezierConfirmModal 리치 텍스트 색 소유", .serialized)
+@MainActor
+struct BezierConfirmModalAttributedColorTests {
+  @Test("주입한 전경색은 모달의 시맨틱 색으로 덮어써진다")
+  func injectedForegroundColorIsOverwritten() throws {
+    let modal = makeModal()
+    let injected = NSMutableAttributedString(string: "Rich")
+    injected.addAttribute(
+      .foregroundColor,
+      value: UIColor.red,
+      range: NSRange(location: 0, length: injected.length)
+    )
+    modal.attributedDescription = injected
+
+    let rendered = try #require(foregroundColor(ofTextMatching: "Rich", in: modal))
+    let expected = BezierConfirmModalSpec.textColorToken.palette(modal)
+
+    for style in [UIUserInterfaceStyle.light, .dark] {
+      #expect(resolved(rendered, style: style) == resolved(expected, style: style))
+      #expect(resolved(rendered, style: style) != resolved(.red, style: style))
+    }
+  }
+
+  @Test("테마를 따라가지 않는 컴포넌트로 만든 리치 텍스트도 라이트·다크가 갈린다")
+  func attributedTextTracksInterfaceStyleEvenWhenBuiltWithFrozenComponent() throws {
+    let frozen = FrozenLightComponent()
+    let modal = makeModal()
+    modal.attributedDescription = BezierConfirmModalSpec.descriptionTypography.attributedString(
+      frozen,
+      text: "Rich",
+      semanticColorToken: BezierConfirmModalSpec.textColorToken,
+      alignment: .center
+    )
+
+    try withExtendedLifetime(frozen) {
+      let rendered = try #require(foregroundColor(ofTextMatching: "Rich", in: modal))
+      #expect(resolved(rendered, style: .light) != resolved(rendered, style: .dark))
+    }
+  }
+
+  @Test("componentTheme을 뒤집으면 리치 텍스트 색도 평문 경로처럼 반전된다")
+  func attributedTextFollowsComponentThemeInversion() throws {
+    let modal = makeModal()
+    modal.attributedDescription = NSAttributedString(string: "Rich")
+
+    let normal = try #require(foregroundColor(ofTextMatching: "Rich", in: modal))
+    let normalDark = resolved(normal, style: .dark)
+
+    modal.componentTheme = .inverted
+    let inverted = try #require(foregroundColor(ofTextMatching: "Rich", in: modal))
+
+    #expect(resolved(inverted, style: .light) == normalDark)
+  }
+
+  @Test("색만 덮어쓰고 글꼴은 넘긴 그대로 유지된다")
+  func fontRunsArePreserved() throws {
+    let modal = makeModal()
+    let bold = UIFont.boldSystemFont(ofSize: 20)
+    let injected = NSMutableAttributedString(string: "AB")
+    injected.addAttribute(.font, value: bold, range: NSRange(location: 1, length: 1))
+    modal.attributedDescription = injected
+
+    let descriptionLabel = try #require(label(withText: "AB", in: modal))
+    let rendered = try #require(descriptionLabel.attributedText)
+
+    #expect(rendered.attribute(.font, at: 1, effectiveRange: nil) as? UIFont == bold)
+    #expect(rendered.attribute(.font, at: 0, effectiveRange: nil) as? UIFont == nil)
+  }
+}
+
+// MARK: - Helpers
+
+@MainActor
+private func makeModal(title: String = "Title", description: String? = nil) -> BezierConfirmModal {
+  BezierConfirmModal(
+    title: title,
+    description: description,
+    confirmAction: BezierConfirmModalAction(title: "Confirm"),
+    cancelAction: BezierConfirmModalAction(title: "Cancel")
+  )
+}
+
+@MainActor
+private func label(withText text: String, in view: UIView) -> UILabel? {
+  if let label = view as? UILabel, label.attributedText?.string == text, !label.isHidden {
+    return label
+  }
+  for subview in view.subviews {
+    if let found = label(withText: text, in: subview) {
+      return found
+    }
+  }
+  return nil
+}
+
+@MainActor
+private func foregroundColor(ofTextMatching text: String, in view: UIView) -> UIColor? {
+  label(withText: text, in: view)?
+    .attributedText?
+    .attribute(.foregroundColor, at: 0, effectiveRange: nil) as? UIColor
+}
+
+// palette(_:)의 dynamic provider는 인자 대신 UITraitCollection.current를 읽으므로
+// performAsCurrent 없이 resolvedColor(with:)만 부르면 주변 스타일이 그대로 나온다
+private func resolved(_ color: UIColor, style: UIUserInterfaceStyle) -> UIColor {
+  let traits = UITraitCollection(userInterfaceStyle: style)
+  var result = color
+  traits.performAsCurrent { result = color.resolvedColor(with: traits) }
+  return result
+}

--- a/Tests/BezierSwiftTests/StringTagRunsTests.swift
+++ b/Tests/BezierSwiftTests/StringTagRunsTests.swift
@@ -1,0 +1,66 @@
+import Testing
+@testable import BezierSwift
+
+@Suite("태그 문자열 run 분해")
+struct StringTagRunsTests {
+  @Test("태그가 없으면 조각 하나로 남는다")
+  func plainTextYieldsSingleRun() {
+    #expect("그냥 텍스트".bezierTagRuns() == [
+      BezierTagRun(text: "그냥 텍스트", isBold: false, isUnderlined: false),
+    ])
+  }
+
+  @Test("<b>는 앞뒤와 분리된 강조 조각이 된다")
+  func boldTagSplitsRuns() {
+    #expect("앞 <b>강조</b> 뒤".bezierTagRuns() == [
+      BezierTagRun(text: "앞 ", isBold: false, isUnderlined: false),
+      BezierTagRun(text: "강조", isBold: true, isUnderlined: false),
+      BezierTagRun(text: " 뒤", isBold: false, isUnderlined: false),
+    ])
+  }
+
+  @Test("<u>는 밑줄 조각이 된다")
+  func underlineTagSplitsRuns() {
+    #expect("<u>밑줄</u>만".bezierTagRuns() == [
+      BezierTagRun(text: "밑줄", isBold: false, isUnderlined: true),
+      BezierTagRun(text: "만", isBold: false, isUnderlined: false),
+    ])
+  }
+
+  @Test("강조가 여러 번 나오면 각각 분리된다")
+  func multipleBoldTagsSplitIndependently() {
+    #expect("<b>가</b>와 <b>나</b>".bezierTagRuns() == [
+      BezierTagRun(text: "가", isBold: true, isUnderlined: false),
+      BezierTagRun(text: "와 ", isBold: false, isUnderlined: false),
+      BezierTagRun(text: "나", isBold: true, isUnderlined: false),
+    ])
+  }
+
+  @Test("강조와 밑줄이 함께 있어도 각각 제 구간에만 적용된다")
+  func boldAndUnderlineCoexist() {
+    #expect("<b>강조</b>와 <u>밑줄</u>".bezierTagRuns() == [
+      BezierTagRun(text: "강조", isBold: true, isUnderlined: false),
+      BezierTagRun(text: "와 ", isBold: false, isUnderlined: false),
+      BezierTagRun(text: "밑줄", isBold: false, isUnderlined: true),
+    ])
+  }
+
+  @Test("<br />는 조각을 나누지 않고 개행 문자가 된다")
+  func lineBreakStaysInsideRun() {
+    #expect("첫 줄<br />둘째 줄".bezierTagRuns() == [
+      BezierTagRun(text: "첫 줄\n둘째 줄", isBold: false, isUnderlined: false),
+    ])
+  }
+
+  @Test("닫히지 않은 태그는 글자 그대로 남는다")
+  func unclosedTagIsLeftAsIs() {
+    #expect("<b>닫히지 않음".bezierTagRuns() == [
+      BezierTagRun(text: "<b>닫히지 않음", isBold: false, isUnderlined: false),
+    ])
+  }
+
+  @Test("빈 문자열은 조각이 없다")
+  func emptyStringYieldsNoRuns() {
+    #expect("".bezierTagRuns().isEmpty)
+  }
+}


### PR DESCRIPTION
## 배경

ConfirmModal 문구에 **강조와 줄바꿈**이 필요했습니다. 처음에는 `NSAttributedString`을 직접 받는 `attributedTitle`/`attributedDescription`을 열었는데, 리뷰에서 나온 지적 대부분이 그 결정 하나에서 파생됐습니다 — 방어 복사 누락, typography 인자를 버리는 렌더 분기, 도달할 수 없는 리치 제목, `nil` 의미 비대칭, SwiftUI 미대응.

게다가 호출부가 컴포넌트 내부를 알아야 했습니다. 정작 그 색은 모달이 다시 덮어쓰는데도요.

```swift
// Before — 호출부가 Spec 토큰을 직접 조립
modal.attributedDescription = BezierConfirmModalSpec.descriptionTypography.attributedString(
  modal,
  text: "<b>일반</b> 섹션이 사라져요.<br />되돌릴 수 없어요.",
  semanticColorToken: BezierConfirmModalSpec.textColorToken,
  alignment: .center,
  hasTagProperty: true
)
```

필요했던 건 임의 서식 입력이 아니었습니다. 그래서 입력을 문자열로 되돌리고, 모달이 태그를 해석하게 했습니다.

```swift
// After — 파라미터 추가 없음
BezierConfirmModal(
  title: "섹션을 삭제할까요?",
  description: "<b>일반</b> 섹션이 사라져요.<br />되돌릴 수 없어요.",
  confirmAction: ..., cancelAction: ...
)
```

## 변경 사항

- `attributedTitle`/`attributedDescription`, `confirm(title:attributedDescription:)` 오버로드, `TextContent` enum, `render(_:typography:)` **제거**
- `refreshAppearance()`에서 `hasTagProperty: true`로 태그 파싱 **상시 적용**
- `SUBezierConfirmModal`도 같은 태그를 해석하도록 **Text 연결 렌더 추가** (`String.bezierTagRuns()`)

**추가 259줄 / 삭제 301줄로 순감소**이며, public 표면은 이 브랜치의 첫 커밋 이전과 같습니다.

## 설계 결정

**태그를 옵션 없이 항상 수용합니다.** `hasTagProperty:` 스위치를 컴포넌트 표면으로 올리지 않았습니다.

- 저장소에서 `hasTagProperty: true`를 쓰는 컴포넌트가 없어 깨뜨릴 관례가 없습니다
- 태그가 없는 문자열이면 결과가 사실상 동일합니다 — `applyBezierTagFont`의 `normalAttributes`는 `applyBezierFont`와 키·값 구성이 같고 `makeParagraphStyle`도 같은 헬퍼를 씁니다. 차이는 `<br />` 치환뿐입니다
- 플래그 방식의 최악 실패(켜는 걸 깜빡해 사용자에게 `<b>일반</b>`이 그대로 노출)가 구조적으로 불가능해집니다

**SwiftUI는 `NSAttributedString`을 경유하지 않습니다.** `Text`가 `paragraphStyle`을 무시해 UIKit과 행높이가 어긋나기 때문입니다. 태그를 run으로 쪼개 `Text`를 잇고 기존 modifier 체인은 그대로 두어, 평문 경로와 행간·정렬이 동일합니다. 파싱만은 기존 파서를 태워 두 구현의 태그 해석이 갈라지지 않게 했습니다.

## 검증

- `BezierSwift` clean build — **BUILD SUCCEEDED**
- 테스트 **114개 전부 통과** (태그 서식 8 · 테마 추종 3 · run 분해 8 신규)
- Examples clean build — **BUILD SUCCEEDED**
- 시뮬레이터 육안 확인 — 두 구현을 한 화면에 나란히 놓고 비교

같은 문자열을 넣었을 때 `<b>` 강조 · `<br />` 줄바꿈 · 행간 · 정렬이 일치하고, 다크모드에서 함께 반전됩니다.

| Light | Dark |
|:---:|:---:|
| <img width="320" src="https://github.com/user-attachments/assets/0d7eb070-9ddb-4270-8234-0af00a569d70"> | <img width="320" src="https://github.com/user-attachments/assets/9e53b217-686f-4908-a7ee-619d60ee820d"> |

## 짚어둘 점

**제목의 `<b>`는 굵기를 바꾸지 않습니다.** `headingXSmall`은 `boldPair`가 자기 자신이라 이미 굵은 계열입니다. doc comment에 명시했습니다. 설명(`textLarge(weight: .regular)`)은 정상적으로 bold 짝이 적용됩니다.

**태그를 글자 그대로 보여주는 수단은 없습니다.** 필요해지면 opt-out 플래그를 더하는 건 non-breaking이라 나중에 열 수 있습니다.

**SPEC.md는 갱신하지 않았습니다.** Figma의 title/description은 순수 `text` property이고 §4 Case B가 "없음"입니다. 태그 서식은 Figma에 없는 코드 측 확장이라 SPEC에 넣으면 SSOT가 오염됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 확인 모달의 제목과 설명에서 `<b>`, `<u>`, `<br />` 태그를 지원합니다.
  - 굵게, 밑줄, 줄바꿈 서식을 텍스트 일부에 적용할 수 있습니다.
  - SwiftUI와 UIKit 예시에 이메일 인증 및 삭제 확인 모달 사용 사례를 추가했습니다.

- **테스트**
  - 태그 해석, 줄바꿈, 색상, 테마 및 다양한 텍스트 상태에 대한 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->