### PR TITLE
[MOB-6797] Button을 갱신된 Figma 스펙에 맞춘다

### DIFF
--- a/Examples/BezierExamples/BezierExamples/Components/ButtonCatalog.swift
+++ b/Examples/BezierExamples/BezierExamples/Components/ButtonCatalog.swift
@@ -70,8 +70,8 @@ struct ButtonCatalog: View {
         variant: self.variant,
         semantic: self.semantic,
         title: self.title.isEmpty ? nil : self.title,
-        leadingIcon: self.hasLeadingIcon ? Image(systemName: "star.fill") : nil,
-        trailingIcon: self.hasTrailingIcon ? Image(systemName: "arrow.right") : nil,
+        leadingIcon: self.hasLeadingIcon ? BezierIcon.plus.image : nil,
+        trailingIcon: self.hasTrailingIcon ? BezierIcon.arrowRight.image : nil,
         isLoading: self.isLoading,
         action: {}
       )
@@ -93,8 +93,8 @@ struct ButtonCatalog: View {
           button.variant = self.variant
           button.semantic = self.semantic
           button.title = self.title.isEmpty ? nil : self.title
-          button.leadingIcon = self.hasLeadingIcon ? UIImage(systemName: "star.fill") : nil
-          button.trailingIcon = self.hasTrailingIcon ? UIImage(systemName: "arrow.right") : nil
+          button.leadingIcon = self.hasLeadingIcon ? BezierIcon.plus.uiImage : nil
+          button.trailingIcon = self.hasTrailingIcon ? BezierIcon.arrowRight.uiImage : nil
           button.isLoading = self.isLoading
           button.isEnabled = self.isEnabled
         }

--- a/Sources/BezierSwift/MasterComponent/BezierButton/BezierButton.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierButton/BezierButton.swift
@@ -62,8 +62,6 @@ public final class BezierButton: UIControl, BezierComponentable {
 
   // MARK: - Subviews
 
-  // 배경은 root backgroundColor 가 아니라 전담 뷰로 칠한다 — loading 시 배경만
-  // opacity/disabled 로 흐려지고 Spinner 는 full opacity 를 유지해야 하기 때문 (SPEC §6).
   private let backgroundView: UIView = {
     let view = UIView()
     view.isUserInteractionEnabled = false

--- a/Sources/BezierSwift/MasterComponent/BezierButton/BezierButton.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierButton/BezierButton.swift
@@ -62,6 +62,15 @@ public final class BezierButton: UIControl, BezierComponentable {
 
   // MARK: - Subviews
 
+  // 배경은 root backgroundColor 가 아니라 전담 뷰로 칠한다 — loading 시 배경만
+  // opacity/disabled 로 흐려지고 Spinner 는 full opacity 를 유지해야 하기 때문 (SPEC §6).
+  private let backgroundView: UIView = {
+    let view = UIView()
+    view.isUserInteractionEnabled = false
+    view.translatesAutoresizingMaskIntoConstraints = false
+    return view
+  }()
+
   private let contentStackView: UIStackView = {
     let stackView = UIStackView()
     stackView.axis = .horizontal
@@ -143,6 +152,7 @@ public final class BezierButton: UIControl, BezierComponentable {
     self.contentStackView.addArrangedSubview(self.titleLabel)
     self.contentStackView.addArrangedSubview(self.trailingImageView)
 
+    self.addSubview(self.backgroundView)
     self.addSubview(self.contentStackView)
     self.addSubview(self.spinner)
 
@@ -173,6 +183,10 @@ public final class BezierButton: UIControl, BezierComponentable {
       ).withIdentifier("contentTrailing"),
       self.spinner.centerXAnchor.constraint(equalTo: self.centerXAnchor),
       self.spinner.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+      self.backgroundView.topAnchor.constraint(equalTo: self.topAnchor),
+      self.backgroundView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+      self.backgroundView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+      self.backgroundView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
     ])
 
     self.heightConstraint = heightConstraint
@@ -251,10 +265,7 @@ public final class BezierButton: UIControl, BezierComponentable {
     if let title = self.title, !title.isEmpty {
       self.titleLabel.attributedText = title.applyBezierFont(
         height: self.size.lineHeight,
-        font: BTGlobalToken.FontFamily.system.uiFont(
-          size: self.size.fontSize,
-          weight: self.size.fontWeight
-        ),
+        font: self.size.uiFont,
         color: foregroundColor,
         letterSpacing: 0,
         alignment: .center
@@ -267,11 +278,7 @@ public final class BezierButton: UIControl, BezierComponentable {
   }
 
   private func refreshAppearance() {
-    if let backgroundToken = self.variant.backgroundToken(self.semantic) {
-      self.backgroundColor = backgroundToken.palette(self)
-    } else {
-      self.backgroundColor = .clear
-    }
+    self.refreshBackground()
 
     if let borderToken = self.variant.borderToken(self.semantic) {
       self.layer.borderWidth = BezierButtonConstant.borderWidth
@@ -289,10 +296,23 @@ public final class BezierButton: UIControl, BezierComponentable {
     self.refreshContent()
   }
 
+  private func refreshBackground() {
+    if self.isHighlighted, self.isEnabled, !self.isLoading {
+      self.backgroundView.backgroundColor = self.variant.pressedBackgroundToken(self.semantic).palette(self)
+    } else if let backgroundToken = self.variant.backgroundToken(self.semantic) {
+      self.backgroundView.backgroundColor = backgroundToken.palette(self)
+    } else {
+      self.backgroundView.backgroundColor = .clear
+    }
+
+    self.backgroundView.alpha = self.isLoading ? BezierButtonConstant.disabledOpacity : 1
+  }
+
   private func refreshLoading() {
     self.isUserInteractionEnabled = !self.isLoading
     self.contentStackView.isHidden = self.isLoading
     self.spinner.isHidden = !self.isLoading
+    self.refreshBackground()
   }
 
   private func refreshEnabled() {
@@ -301,9 +321,7 @@ public final class BezierButton: UIControl, BezierComponentable {
 
   private func refreshHighlight() {
     UIView.animate(withDuration: 0.1) {
-      self.alpha = self.isHighlighted
-        ? BezierButtonConstant.pressedOpacity
-        : (self.isEnabled ? 1 : BezierButtonConstant.disabledOpacity)
+      self.refreshBackground()
     }
   }
 

--- a/Sources/BezierSwift/MasterComponent/BezierButton/BezierButtonSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierButton/BezierButtonSpec.swift
@@ -75,29 +75,42 @@ public enum BezierButtonSize: String, CaseIterable {
   }
 
   // MARK: - Typography
-  //
-  // Figma 변수 바인딩: xsmall·small·medium 은 `label/*` semantic, large·xlarge 는
-  // `font-size/16` + `line-height/24` global. BezierSwift 에는 16/24 조합의 label/text
-  // semantic 토큰이 없으므로 (내부 참조 가능한) BTGlobalToken raw 값을 직접 사용한다.
+
+  // Figma 바인딩: xsmall·small·medium 은 `Typography/label/*` 스타일(= BTSemanticToken.label*),
+  // large·xlarge 는 raw 조합(`font-size/16` + `line-height/24` + `label/weight` 500)으로
+  // 대응 semantic 토큰이 없다 (SPEC §4). nil 이면 아래 프로퍼티들이 raw 값으로 fallback 한다.
+  var typographyToken: BTSemanticToken? {
+    switch self {
+    case .xsmall: return .labelSmall
+    case .small:  return .labelMedium
+    case .medium: return .labelLarge
+    case .large, .xlarge: return nil
+    }
+  }
+
+  /// 라벨 폰트 크기. Figma `label/size/*`(xsmall~medium) 또는 `font-size/16`(large·xlarge).
   public var fontSize: CGFloat {
-    switch self {
-    case .xsmall: return BTGlobalToken.FontSize.size13
-    case .small:  return BTGlobalToken.FontSize.size14
-    case .medium: return BTGlobalToken.FontSize.size15
-    case .large, .xlarge: return BTGlobalToken.FontSize.size16
-    }
+    self.typographyToken?.fontSize ?? BTGlobalToken.FontSize.size16
   }
 
+  /// 라벨 행높이. Figma `label/line-height/*`(xsmall~medium) 또는 `line-height/24`(large·xlarge).
   public var lineHeight: CGFloat {
+    self.typographyToken?.lineHeight ?? BTGlobalToken.LineHeight.height24
+  }
+
+  /// 라벨 폰트 weight. Figma `label/weight/bold`(700 → `.bold`, xsmall~medium) 또는
+  /// `label/weight`(500 → `.medium`, large·xlarge).
+  public var fontWeight: UIFont.Weight {
     switch self {
-    case .xsmall: return BTGlobalToken.LineHeight.height18
-    case .small, .medium: return BTGlobalToken.LineHeight.height20
-    case .large, .xlarge: return BTGlobalToken.LineHeight.height24
+    case .xsmall, .small, .medium: return .bold
+    case .large, .xlarge: return .medium
     }
   }
 
-  // Figma SemiBold(600) → iOS BTFontWeight binary system(`bold`) 매핑 (디자인 시스템 합의)
-  public var fontWeight: BTFontWeight { .bold }
+  /// 라벨 UIFont. SwiftUI에서는 `Font(uiFont)`로 사용한다.
+  public var uiFont: UIFont {
+    self.typographyToken?.uiFont ?? .systemFont(ofSize: self.fontSize, weight: self.fontWeight)
+  }
 }
 
 /// 버튼의 시각적 강조도. Figma `Button` 컴포넌트의 `variant` 프로퍼티에 대응 (case 이름 = Figma 값).
@@ -123,7 +136,6 @@ public enum BezierButtonSemantic: String, CaseIterable {
 enum BezierButtonConstant {
   static let borderWidth: CGFloat = 1
   static let disabledOpacity: CGFloat = BOGlobalToken.disabled
-  static let pressedOpacity: CGFloat = 0.7
 }
 
 extension BezierButtonVariant {
@@ -136,6 +148,12 @@ extension BezierButtonVariant {
          (.ghost, _):
       return nil
     }
+  }
+
+  // Figma pressed 배경(`*-hovered` 변수)은 iOS에 sync된 토큰이 없어 pressedColor(HSL 계산)로 재현한다 (SPEC §8).
+  // outlined/ghost 는 투명 배경(fillNeutralTransparent) 위에 pressed fill 이 추가되는 모델.
+  func pressedBackgroundToken(_ semantic: BezierButtonSemantic) -> BCSemanticToken {
+    (self.backgroundToken(semantic) ?? .fillNeutralTransparent).pressedColor
   }
 
   func borderToken(_ semantic: BezierButtonSemantic) -> BCSemanticToken? {
@@ -153,7 +171,8 @@ extension BezierButtonVariant {
     switch (self, semantic) {
     case (.filled, .primary):     return .textInverse
     case (.filled, .secondary):   return .textNeutral
-    case (.filled, .destructive): return .textInverse
+    // 붉은 배경 위 라벨은 테마 무관 항상 흰색 — textInverse(다크에서 검정)가 아니라 absolute white (SPEC §5)
+    case (.filled, .destructive): return .textAbsoluteWhite
 
     case (.outlined, .primary):     return .textNeutralHeaviest
     case (.outlined, .secondary):   return .textNeutralLight

--- a/Sources/BezierSwift/MasterComponent/BezierButton/BezierButtonSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierButton/BezierButtonSpec.swift
@@ -76,9 +76,6 @@ public enum BezierButtonSize: String, CaseIterable {
 
   // MARK: - Typography
 
-  // Figma 바인딩: xsmall·small·medium 은 `Typography/label/*` 스타일(= BTSemanticToken.label*),
-  // large·xlarge 는 raw 조합(`font-size/16` + `line-height/24` + `label/weight` 500)으로
-  // 대응 semantic 토큰이 없다 (SPEC §4). nil 이면 아래 프로퍼티들이 raw 값으로 fallback 한다.
   var typographyToken: BTSemanticToken? {
     switch self {
     case .xsmall: return .labelSmall
@@ -88,18 +85,17 @@ public enum BezierButtonSize: String, CaseIterable {
     }
   }
 
-  /// 라벨 폰트 크기. Figma `label/size/*`(xsmall~medium) 또는 `font-size/16`(large·xlarge).
+  /// 라벨 폰트 크기.
   public var fontSize: CGFloat {
     self.typographyToken?.fontSize ?? BTGlobalToken.FontSize.size16
   }
 
-  /// 라벨 행높이. Figma `label/line-height/*`(xsmall~medium) 또는 `line-height/24`(large·xlarge).
+  /// 라벨 행높이.
   public var lineHeight: CGFloat {
     self.typographyToken?.lineHeight ?? BTGlobalToken.LineHeight.height24
   }
 
-  /// 라벨 폰트 weight. Figma `label/weight/bold`(700 → `.bold`, xsmall~medium) 또는
-  /// `label/weight`(500 → `.medium`, large·xlarge).
+  /// 라벨 폰트 weight.
   public var fontWeight: UIFont.Weight {
     switch self {
     case .xsmall, .small, .medium: return .bold
@@ -150,8 +146,6 @@ extension BezierButtonVariant {
     }
   }
 
-  // Figma pressed 배경(`*-hovered` 변수)은 iOS에 sync된 토큰이 없어 pressedColor(HSL 계산)로 재현한다 (SPEC §8).
-  // outlined/ghost 는 투명 배경(fillNeutralTransparent) 위에 pressed fill 이 추가되는 모델.
   func pressedBackgroundToken(_ semantic: BezierButtonSemantic) -> BCSemanticToken {
     (self.backgroundToken(semantic) ?? .fillNeutralTransparent).pressedColor
   }
@@ -171,7 +165,6 @@ extension BezierButtonVariant {
     switch (self, semantic) {
     case (.filled, .primary):     return .textInverse
     case (.filled, .secondary):   return .textNeutral
-    // 붉은 배경 위 라벨은 테마 무관 항상 흰색 — textInverse(다크에서 검정)가 아니라 absolute white (SPEC §5)
     case (.filled, .destructive): return .textAbsoluteWhite
 
     case (.outlined, .primary):     return .textNeutralHeaviest

--- a/Sources/BezierSwift/MasterComponent/BezierButton/SPEC.md
+++ b/Sources/BezierSwift/MasterComponent/BezierButton/SPEC.md
@@ -12,23 +12,36 @@
   - `semantic = primary` 버튼은 한 화면에 1개만 둔다.
   - 아이콘 전용 버튼은 IconButton(별도 컴포넌트)을 사용한다.
 
-## 2. Component Properties (Figma variant 축)
+## 2. Component Properties
+
+Figma Button 컴포넌트가 정의하는 property는 다음 9개가 전부다.
+
+### Variant 축 (4)
 
 | 축 | 값 | 비고 |
 |---|---|---|
 | `size` | `xsmall`, `small`, `medium`, `large`, `xlarge` | 5 옵션 |
 | `variant` | `filled`, `outlined`, `ghost` | 3 옵션 |
 | `semantic` | `primary`, `secondary`, `destructive` | 3 옵션 |
-| `state` | `default`, `pressed`, `active`, `disabled`, `loading` | **Figma 설계용 축** — 시각 검토 목적, 런타임 API로 노출하지 않는다. |
+| `state` | `default`, `pressed`, `active`, `disabled`, `loading` | 런타임 API로 노출하지 않는다 (§2-1) |
 
 Figma 매트릭스 총량: 5 × 3 × 3 × 5 = **225 symbols** (전부 실재).
 
+### 콘텐츠 property (5)
+
+| property | 타입 | 기본값 | 비고 |
+|---|---|---|---|
+| `text` | TEXT | `"Label"` | 라벨 문자열 |
+| `leadingContent` | BOOLEAN | `false` | 라벨 왼쪽 슬롯 표시 여부 |
+| `trailingContent` | BOOLEAN | `false` | 라벨 오른쪽 슬롯 표시 여부 |
+| `leadingContentSource` | INSTANCE_SWAP | `icon/plus` | 왼쪽 슬롯에 주입할 인스턴스 |
+| `trailingContentSource` | INSTANCE_SWAP | `icon/plus` | 오른쪽 슬롯에 주입할 인스턴스 |
+
+- 슬롯은 Icon 사용 권장. 액션 이해에 특별히 유리하면 다른 UI를 swap instance로 적용 가능 (컴포넌트 description).
+
 ### 2-1. State 축의 해석
 
-Figma 컴포넌트 설명에 명시:
-> "state 축: Figma 설계용 — disabled/loading/pressed 상태별 시각 확인에 사용"
-
-따라서 코드는 다음 런타임 상태만 노출한다:
+코드는 다음 런타임 상태만 노출한다:
 
 | 코드 상태 | Figma state 매핑 |
 |---|---|
@@ -36,7 +49,7 @@ Figma 컴포넌트 설명에 명시:
 | `isHighlighted = true` (터치 중) | `pressed` |
 | `isEnabled = false` | `disabled` |
 | `isLoading = true` | `loading` |
-| (없음) | `active` — 토글/선택 상태를 위한 설계용. Button 컴포넌트는 sticky-toggled 상태를 노출하지 않는다. |
+| (없음) | `active` — Figma에 variant로 실재하나 코드 런타임 상태로 노출하지 않는다. |
 
 ## 3. Layout (size별)
 
@@ -51,41 +64,40 @@ Figma 컴포넌트 설명에 명시:
 | xlarge | 54 | 54 | 20 | 4 | 2 | 16 |
 
 - **border-radius**: 모든 size에서 height의 절반 (완전 capsule).
-- **icon**: leadingIcon / trailingIcon은 텍스트 좌우에 배치, 16×16 고정.
+- **icon**: leadingContent / trailingContent 슬롯은 텍스트 좌우에 배치, 16×16 고정. 아이콘 색은 텍스트와 동일 색 (export SVG raw 색이 §5 text 색과 일치).
 
-## 4. Typography (size별, Custom)
+## 4. Typography (size별)
 
-> **Typography 적용 방식: Custom (Token 미적용)**.
-> Figma Button 텍스트 노드는 Foundation의 typography token(`Typography/heading/*` text style 또는 `heading/size/*` / `heading/line-height/*` variable)에 연결되어 있지 않다. 5개 size 모두 `get_variable_defs` 결과가 `label/font-family` (= `"Inter"`) + `label/letter-spacing` (= `0`)만 노출하며, font-size 와 line-height 는 raw 값으로 직접 적용되어 있다.
->
-> **Custom 사유**: Figma Mobile Components Button(`1734:146`)이 typography token 매핑을 보유하고 있지 않은 상태. (디자이너 의도 — 디자인 시스템 typography token 매핑은 별도 진행 예정으로 추정되며, 현 시점 Button 의 SSOT 는 raw 값 자체.)
+> **xsmall·small·medium**은 Foundation `Typography/label/*` 텍스트 스타일 토큰에 바인딩되어 있고,
+> **large·xlarge**는 대응 label 스타일 미등록으로 raw 변수 조합(`font-size/16` + `line-height/24` + `label/weight`)이 직접 적용되어 있다.
 
 공통값 (5 size 동일):
 - `font-family`: `Inter` (variable: `label/font-family`)
-- `font-weight`: `SemiBold` (600)
 - `letter-spacing`: `0` (variable: `label/letter-spacing`)
 
-size 별 raw 값:
+size 별 값:
 
-| size | fontSize | lineHeight |
-|---|---|---|
-| xsmall | 13 | 18 |
-| small | 14 | 18 |
-| medium | 15 | 20 |
-| large | 16 | 20 |
-| xlarge | 16 | 20 |
+| size | Figma 바인딩 | fontSize | lineHeight | fontWeight |
+|---|---|---|---|---|
+| xsmall | `Typography/label/small` | 13 (`label/size/small`) | 18 (`label/line-height/small`) | 700 (`label/weight/bold`) |
+| small | `Typography/label/medium` | 14 (`label/size/medium`) | 20 (`label/line-height/medium`) | 700 (`label/weight/bold`) |
+| medium | `Typography/label/large` | 15 (`label/size/large`) | 20 (`label/line-height/large`) | 700 (`label/weight/bold`) |
+| large | raw 변수 조합 | 16 (`font-size/16`) | 24 (`line-height/24`) | 500 (`label/weight`) |
+| xlarge | raw 변수 조합 | 16 (`font-size/16`) | 24 (`line-height/24`) | 500 (`label/weight`) |
 
-> ⚠️ iOS BezierSwift V3 Typography는 regular/bold 이진 weight 시스템(`BTFontWeight`)을 사용한다. Figma SemiBold(600)는 iOS에서 `bold`로 매핑된다 (디자인 시스템 합의 사항).
+> weight는 size에 따라 갈린다 — xsmall·small·medium은 `label/weight/bold`(700), large·xlarge는 `label/weight`(500).
+>
+> iOS 매핑 (디자인 시스템 합의): `Typography/label/{small,medium,large}` ↔ `BTSemanticToken.label{Small,Medium,Large}` (13/18·14/20·15/20, weight bold 고정 — 값 완전 일치). large·xlarge의 16/24/500 조합은 대응 semantic 토큰이 없어 raw 값(`UIFont.Weight.medium`)으로 직접 구성한다.
 
-## 5. Color (variant × semantic × variant 별, default state)
+## 5. Color (variant × semantic 별, default state)
 
-> 키는 Figma variable 경로. 괄호 안은 raw 값.
+> 키는 Figma variable 경로. 괄호 안은 raw 값. text 색은 아이콘·스피너에도 동일 적용된다 (§3, §7).
 
 | variant × semantic | background | text/icon | border |
 |---|---|---|---|
 | `filled` × `primary` | `color/fill/neutral/heaviest` (`#000000d9`) | `color/text/inverse` (`#ffffff`) | — |
 | `filled` × `secondary` | `color/fill/neutral` (`#00000014`) | `color/text/neutral` (`#000000d9`) | — |
-| `filled` × `destructive` | `color/fill/accent/red/heavier` (`#e1535d`) | `color/text/inverse` (`#ffffff`) | — |
+| `filled` × `destructive` | `color/fill/accent/red/heavier` (`#e1535d`) | `color/text/absolute/white` (`#ffffff`) | — |
 | `outlined` × `primary` | — | `color/text/neutral/heaviest` (`#000000`) | `color/border/neutral` (`#00000014`) |
 | `outlined` × `secondary` | — | `color/text/neutral/light` (`#00000099`) | `color/border/neutral` (`#00000014`) |
 | `outlined` × `destructive` | — | `color/text/accent/red` (`#e1535d`) | `color/border/neutral` (`#00000014`) |
@@ -94,24 +106,32 @@ size 별 raw 값:
 | `ghost` × `destructive` | — | `color/text/accent/red` (`#e1535d`) | — |
 
 - **border-width**: outlined 1px (모든 size 공통).
-- **outlined / ghost** variant는 background fill 없음 (clear).
+- **outlined / ghost** variant는 default state에서 background fill 없음.
+- `filled × destructive`의 텍스트는 `color/text/inverse`가 아니라 `color/text/absolute/white`다 — 붉은 배경 위 라벨은 테마와 무관하게 항상 흰색.
 
 ## 6. State 별 시각 동작
-
-> `pressed` / `active` 시각은 Figma SSOT에 별도 컬러 토큰이 없고 opacity 기반으로 표현된다.
 
 | state | 시각 처리 |
 |---|---|
 | `default` | 위 §5 색상 그대로 |
-| `pressed` | 본체 opacity를 낮춤 (터치 중에만 일시적) |
-| `active` | 코드 미노출 (Button은 토글 상태를 가지지 않음) |
-| `disabled` | 본체 전체 `opacity: 0.4` (Figma `opacity-40` 일치) |
-| `loading` | 라벨/아이콘 숨김 + 가운데 Spinner 컴포넌트 인스턴스 표시. 사용자 입력 무시 |
+| `pressed` | 배경색이 `*-hovered` 변수로 전환 (아래 표). 텍스트·아이콘·보더 색은 default와 동일 |
+| `active` | pressed와 동일 배경 변수 (Figma active variant 실측값). 코드 미노출 (§2-1) |
+| `disabled` | 본체 노드 전체 `opacity: opacity/disabled` (`40%`) |
+| `loading` | 라벨·아이콘 숨김 + 가운데 Spinner 인스턴스 표시, 사용자 입력 무시. **filled는 배경이 별도 `background` 레이어로 분리되어 레이어 opacity가 `opacity/disabled`(`40%`)로 낮아지고, Spinner는 full opacity를 유지한다.** outlined/ghost는 background 레이어 없음 (outlined 보더는 그대로) |
+
+### pressed 배경 (variant × semantic)
+
+| variant × semantic | pressed background |
+|---|---|
+| `filled` × `primary` | `color/fill/neutral/heaviest-hovered` (`#1c1c1cd9`) |
+| `filled` × `secondary` | `color/fill/neutral-hovered` (`#1c1c1c1e`) |
+| `filled` × `destructive` | `color/fill/accent/red-heavier-hovered` (`#da444f`) |
+| `outlined` × 전체 | `color/fill/neutral/transparent-hovered` (`#0000000d`) — 투명 배경 위에 fill 추가, 보더 유지 |
+| `ghost` × 전체 | `color/fill/neutral/transparent-hovered` (`#0000000d`) — 투명 배경 위에 fill 추가 |
 
 ## 7. Loading Spinner (size별)
 
 > Figma loading variant는 Spinner 컴포넌트(`3380:1591`) 인스턴스를 내장한다.
-> 색상·크기는 MOB-5322에서 디자인팀이 확정한 정책(design-team `Button-spec.md §6` / `Spinner-spec.md`)을 반영한다.
 
 ### Spinner 크기 (size별)
 
@@ -125,22 +145,19 @@ size 별 raw 값:
 
 ### Spinner 색 (variant × semantic)
 
+> **원칙: Spinner 색 = 해당 조합의 label(text) 색** (§5 `text/icon` 컬럼과 동일 토큰 — 9개 조합 모두 loading variant의 Spinner export SVG raw 색이 §5 text 색과 일치).
+
 | variant × semantic | Spinner fill | Token | Figma Variable |
 |---|---|---|---|
 | `filled` × `primary` | label 색 | `textInverse` | `color/text/inverse` |
 | `filled` × `secondary` | label 색 | `textNeutral` | `color/text/neutral` |
-| `filled` × `destructive` | label 색 | `textInverse` | `color/text/inverse` |
+| `filled` × `destructive` | label 색 | `textAbsoluteWhite` | `color/text/absolute/white` |
 | `outlined` × `primary` | label 색 | `textNeutralHeaviest` | `color/text/neutral/heaviest` |
 | `outlined` × `secondary` | label 색 | `textNeutralLight` | `color/text/neutral/light` |
 | `outlined` × `destructive` | label 색 | `textAccentRed` | `color/text/accent/red` |
 | `ghost` × `primary` | label 색 | `textNeutralLight` | `color/text/neutral/light` |
 | `ghost` × `secondary` | label 색 | `textNeutralLighter` | `color/text/neutral/lighter` |
 | `ghost` × `destructive` | label 색 | `textAccentRed` | `color/text/accent/red` |
-
-- **모든 variant에서 Spinner 색 = 해당 조합의 label(text) 색**(§5 `text/icon` 컬럼과 동일 토큰). 코드에서는 `loadingSpinnerToken(semantic)`이 `foregroundToken(semantic)`을 그대로 위임한다.
-- 크기 축소(§7 크기 표)는 label 색 스피너가 발생시키는 시선 강탈을 완화하기 위한 후속 조정이다.
-
-> Spinner 색은 GitHub design-team `Button-spec.md §6`(v1.1, "Spinner 색 = 라벨 텍스트 색" 원칙)과 일치한다. 크기(§7 크기 표)는 MOB-5322에서 확정한 값을 유지한다.
 
 ## 8. 매핑되는 코드 심볼
 
@@ -151,3 +168,5 @@ size 별 raw 값:
 | size / variant / semantic 정의 | `BezierButtonSpec.swift` (`BezierButtonSize`, `BezierButtonVariant`, `BezierButtonSemantic`, `BezierButtonConstant`) |
 
 > 코드 측에 본 spec의 SSOT(Figma)와 어긋나는 정의가 존재한다면, 그것은 코드 측의 정리 대상이며 spec에 반영하지 않는다.
+>
+> pressed 배경의 코드 재현은 `BCSemanticToken.pressedColor`(HSL 계산, 노션 "Pressed/Hover Color" 기획 로직)를 사용한다 (디자인 시스템 합의 — `*-hovered` 시맨틱 토큰은 iOS 미sync). 계산 결과는 §6 표의 raw 값과 일치하며, `filled × secondary` 한 조합만 색상부가 `#0000001e`로 미세하게 다르다 (alpha 12% 무채색 간 차이 — 시각 동등, 기획 로직과 Figma 스냅샷의 계산 차).

--- a/Sources/BezierSwift/MasterComponent/BezierButton/SUBezierButton.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierButton/SUBezierButton.swift
@@ -106,19 +106,11 @@ public struct SUBezierButton: View, Themeable {
       }
 
       if let title = self.title, !title.isEmpty {
-        let uiFont = BTGlobalToken.FontFamily.system.uiFont(
-          size: self.size.fontSize,
-          weight: self.size.fontWeight
-        )
+        let uiFont = self.size.uiFont
         let lineSpacing = max(0, self.size.lineHeight - uiFont.lineHeight)
 
         Text(title)
-          .font(
-            BTGlobalToken.FontFamily.system.font(
-              size: self.size.fontSize,
-              weight: self.size.fontWeight
-            )
-          )
+          .font(Font(uiFont))
           .lineSpacing(lineSpacing)
           .padding(.vertical, lineSpacing / 2)
           .foregroundColor(self.palette(self.variant.foregroundToken(self.semantic)))
@@ -159,16 +151,20 @@ private struct SUBezierButtonStyle: ButtonStyle, Themeable {
 
   func makeBody(configuration: Configuration) -> some View {
     configuration.label
-      .background(self.backgroundShape)
+      .background(self.backgroundShape(isPressed: configuration.isPressed))
       .clipShape(Capsule())
       .overlay(self.borderShape)
-      .opacity(configuration.isPressed && !self.isLoading ? BezierButtonConstant.pressedOpacity : 1)
   }
 
   @ViewBuilder
-  private var backgroundShape: some View {
-    if let token = self.variant.backgroundToken(self.semantic) {
-      Capsule().fill(self.palette(token))
+  private func backgroundShape(isPressed: Bool) -> some View {
+    if isPressed, !self.isLoading {
+      Capsule().fill(self.palette(self.variant.pressedBackgroundToken(self.semantic)))
+    } else if let token = self.variant.backgroundToken(self.semantic) {
+      // loading 시 배경 레이어만 opacity/disabled 로 흐려지고 Spinner 는 full opacity (SPEC §6)
+      Capsule()
+        .fill(self.palette(token))
+        .opacity(self.isLoading ? BezierButtonConstant.disabledOpacity : 1)
     } else {
       Color.clear
     }
@@ -192,8 +188,8 @@ struct SUBezierButton_Previews: PreviewProvider {
       SUBezierButton(size: .xsmall, variant: .filled, semantic: .primary, title: "Label") {}
       SUBezierButton(size: .small, variant: .outlined, semantic: .secondary, title: "Label") {}
       SUBezierButton(size: .medium, variant: .ghost, semantic: .destructive, title: "Label") {}
-      SUBezierButton(size: .large, variant: .filled, semantic: .destructive, title: "Confirm", leadingIcon: Image(systemName: "trash")) {}
-      SUBezierButton(size: .xlarge, variant: .filled, semantic: .primary, title: "Continue", trailingIcon: Image(systemName: "arrow.right")) {}
+      SUBezierButton(size: .large, variant: .filled, semantic: .destructive, title: "Confirm", leadingIcon: BezierIcon.trash.image) {}
+      SUBezierButton(size: .xlarge, variant: .filled, semantic: .primary, title: "Continue", trailingIcon: BezierIcon.arrowRight.image) {}
       SUBezierButton(size: .medium, variant: .filled, semantic: .primary, title: "Loading", isLoading: true) {}
     }
     .padding()

--- a/Sources/BezierSwift/MasterComponent/BezierButton/SUBezierButton.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierButton/SUBezierButton.swift
@@ -161,7 +161,6 @@ private struct SUBezierButtonStyle: ButtonStyle, Themeable {
     if isPressed, !self.isLoading {
       Capsule().fill(self.palette(self.variant.pressedBackgroundToken(self.semantic)))
     } else if let token = self.variant.backgroundToken(self.semantic) {
-      // loading 시 배경 레이어만 opacity/disabled 로 흐려지고 Spinner 는 full opacity (SPEC §6)
       Capsule()
         .fill(self.palette(token))
         .opacity(self.isLoading ? BezierButtonConstant.disabledOpacity : 1)


### PR DESCRIPTION
## 개요

Mobile Figma CS [Button (1734:146)](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/%F0%9F%9A%A7-Mobile-Components?node-id=1734-146) 스펙이 갱신되어, figma-component-spec 파이프라인(Phase 0~3)으로 전수 실측 후 SPEC.md와 UIKit/SwiftUI 구현을 정합시켰다.

## 변경 사항 (Figma 실측 기준 4건)

### 1. pressed = 배경색 전환 (구 opacity 0.7 폐기)
Figma pressed variant의 배경이 `*-hovered` 변수에 바인딩되어 있다. 텍스트·아이콘·보더는 default와 동일 유지.

| variant | pressed 배경 |
|---|---|
| filled×primary | `fill/neutral/heaviest-hovered` (#1c1c1cd9) |
| filled×secondary | `fill/neutral-hovered` (#1c1c1c1e) |
| filled×destructive | `fill/accent/red-heavier-hovered` (#da444f) |
| outlined/ghost×전체 | `fill/neutral/transparent-hovered` (#0000000d) fill 추가 |

`*-hovered` 시맨틱 토큰이 iOS에 sync되지 않아 `BCSemanticToken.pressedColor`(HSL 계산, 노션 Pressed/Hover Color 기획)로 재현했다. 계산 결과가 Figma 스냅샷과 일치함을 확인했고(heaviest→#1c1c1cd9, red-heavier→#da444f, transparent→#0000000d), 유일한 편차는 filled×secondary의 색상부(#0000001e vs #1c1c1c1e — alpha 12% 무채색 간 차이, 시각 동등)로 SPEC §8에 협의 편차로 기재했다. 시뮬레이터 픽셀 검증: pressed 중 배경 픽셀이 이론 합성값 (62,62,62)와 정확히 일치 (UIKit·SwiftUI 동일).

### 2. loading 시 filled 배경 dim
Figma는 filled의 loading에서 배경을 별도 레이어로 분리해 노드 opacity를 `opacity/disabled`(40%)에 바인딩하고, Spinner는 full opacity를 유지한다. outlined/ghost는 레이어 없음(보더 유지).
- UIKit: 배경 전담 `backgroundView` 도입 (root backgroundColor → 전담 뷰, loading 시 alpha 0.4)
- SwiftUI: 배경 Capsule에만 `.opacity(disabledOpacity)` 적용

### 3. Typography 토큰 바인딩 + weight 분기
기존 SPEC의 "Custom(토큰 미적용), SemiBold 600 공통"은 stale였다.

| size | Figma 바인딩 | 값 |
|---|---|---|
| xsmall / small / medium | `Typography/label/{small,medium,large}` | 13/18 · 14/20 · 15/20, weight **700** |
| large / xlarge | raw (`font-size/16` + `line-height/24` + `label/weight`) | 16/24, weight **500** |

xsmall~medium은 `BTSemanticToken.label{Small,Medium,Large}`와 값이 완전히 일치해 토큰 경유로 전환. large/xlarge는 대응 semantic 토큰이 없고 `BTFontWeight`(400/700 이진)로 500을 표현할 수 없어 `BezierButtonSize.fontWeight: UIFont.Weight`(.bold/.medium) + `uiFont`로 캡슐화했다 (SwiftUI는 `Font(uiFont)`). weight 분기는 Figma 렌더 스크린샷 확대 비교로도 확인했다.

### 4. filled×destructive 라벨/스피너 = `textAbsoluteWhite`
기존 `.textInverse`는 다크모드에서 검정(black85)으로 렌더되는 실버그였다. 붉은 배경 위 라벨은 테마 무관 항상 흰색이어야 하며, `loadingSpinnerToken`이 `foregroundToken`을 위임하므로 스피너도 함께 고쳐진다.

### 부수 변경
- SPEC §2에 Figma 콘텐츠 property 5개(`text`, `leadingContent`/`trailingContent` BOOLEAN, `leading`/`trailingContentSource` INSTANCE_SWAP) 문서화
- SwiftUI Preview·Examples 카탈로그의 SF Symbol → `BezierIcon.plus`/`.arrowRight`/`.trash` 교체 (asset SSOT)

## 검증

- **Phase 2** (5 subagent / 7차원): Properties·Layout·Color·Typography·Asset·Noise·구현참조 전부 ✅
- **Phase 3**: UIKit·SwiftUI Implementation Validator ✅ (Critical/Minor 0)
- **빌드**: BezierSwift·BezierExamples 모두 clean build BUILD SUCCEEDED
- **시뮬레이터 시각 검증**: 라이트/다크 모드 전 매트릭스 + pressed/loading 픽셀 검증 (아래)

## Screenshots

| 항목 | 스크린샷 |
|---|---|
| BezierIcon 아이콘 슬롯 (plus/arrowRight) | <img width="360" src="https://github.com/user-attachments/assets/215e8d89-45df-4bcf-9bd9-c9a654eea820"> |
| large — weight 500(Medium) 라벨 | <img width="360" src="https://github.com/user-attachments/assets/b47733ff-51c2-4ca7-b6c6-ceb28e59856c"> |
| pressed 배경 전환 (위: default / 아래: pressed) | <img width="480" src="https://github.com/user-attachments/assets/ce2ffe9e-dcfd-47c7-85d9-ee52025716bc"> |
| 매트릭스 + loading colors (배경 dim 0.4 · 스피너 full opacity) | <img width="360" src="https://github.com/user-attachments/assets/8aa7a1e7-caa8-4c41-806c-9775534ca407"> |
| loading 스피너 크기 스케일 (12/12/12/16/20) | <img width="360" src="https://github.com/user-attachments/assets/854474d0-7260-4cb5-aa95-41efeb727f3c"> |
| 다크모드 — destructive 라벨 흰색 유지 (`textAbsoluteWhite`) | <img width="360" src="https://github.com/user-attachments/assets/4dd9bca1-6bab-4a2d-9e42-15ee0218444b"> |

## 참고

- Figma 소스 관찰: large/xlarge의 loading 프레임 폭이 default보다 1px 큼 (74→75, 90→91) — 스펙 위반은 아니며 Figma 원본의 미세 편집 오차로 보임. 디자인팀 전달 권장.
- Mobile IconButton CS(1735:442)도 동일한 pressed/loading 변화가 있을 가능성이 높아 후속 재검증 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 버튼의 눌림, 활성화, 로딩 상태에 따른 배경색과 투명도 표시를 개선했습니다.
  * 버튼 크기별 타이포그래피와 글꼴 적용을 디자인 토큰 기준으로 정비했습니다.
  * 파괴적 채움형 버튼의 전경색과 상태별 아이콘 표시를 일관되게 조정했습니다.
  * 버튼 미리보기에서 프레임워크 아이콘을 사용하도록 변경했습니다.

* **문서**
  * 버튼 속성, 콘텐츠 슬롯, 상태별 동작 및 색상 기준을 최신 디자인 사양에 맞게 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->