### PR TITLE
[MOB-6799] Toast를 변경된 Figma 스펙(glass 배경·radius 20·accent 아이콘)으로 갱신한다

### DIFF
--- a/Examples/BezierExamples/BezierExamples/Components/ToastCatalog.swift
+++ b/Examples/BezierExamples/BezierExamples/Components/ToastCatalog.swift
@@ -69,9 +69,6 @@ struct ToastCatalog: View {
   }
 }
 
-// UIKitWrap의 .fittingSizeLevel 계산은 긴 제목에서 라벨 압축 저항(750)이 제안 폭(50)을 이겨
-// BezierToast가 maxWidth(460)까지 벌어지고 화면 폭을 넘는다. 표시 컨테이너(BezierToastManager)와
-// 같은 제약으로 제안 폭을 required로 고정한 wrapper 안에서 toast가 hug·개행하게 한다.
 private struct ToastUIKitRepresentable: UIViewRepresentable {
   let preset: BezierToastPreset
   let title: String

--- a/Examples/BezierExamples/BezierExamples/Components/ToastCatalog.swift
+++ b/Examples/BezierExamples/BezierExamples/Components/ToastCatalog.swift
@@ -54,14 +54,7 @@ struct ToastCatalog: View {
 
   private var uiKitPreview: some View {
     VStack(spacing: 16) {
-      UIKitWrap(
-        { BezierToast(preset: self.preset, title: self.displayTitle) },
-        update: { toast in
-          toast.preset = self.preset
-          toast.title = self.displayTitle
-        }
-      )
-      .fixedSize()
+      ToastUIKitRepresentable(preset: self.preset, title: self.displayTitle)
 
       SUBezierButton(
         size: .medium,
@@ -73,5 +66,43 @@ struct ToastCatalog: View {
       }
     }
     .frame(maxWidth: .infinity)
+  }
+}
+
+// UIKitWrap의 .fittingSizeLevel 계산은 긴 제목에서 라벨 압축 저항(750)이 제안 폭(50)을 이겨
+// BezierToast가 maxWidth(460)까지 벌어지고 화면 폭을 넘는다. 표시 컨테이너(BezierToastManager)와
+// 같은 제약으로 제안 폭을 required로 고정한 wrapper 안에서 toast가 hug·개행하게 한다.
+private struct ToastUIKitRepresentable: UIViewRepresentable {
+  let preset: BezierToastPreset
+  let title: String
+
+  func makeUIView(context: Context) -> UIView {
+    let wrapper = UIView()
+    let toast = BezierToast(preset: self.preset, title: self.title)
+    wrapper.addSubview(toast)
+    NSLayoutConstraint.activate([
+      toast.topAnchor.constraint(equalTo: wrapper.topAnchor),
+      toast.bottomAnchor.constraint(equalTo: wrapper.bottomAnchor),
+      toast.centerXAnchor.constraint(equalTo: wrapper.centerXAnchor),
+      toast.leadingAnchor.constraint(greaterThanOrEqualTo: wrapper.leadingAnchor),
+      toast.trailingAnchor.constraint(lessThanOrEqualTo: wrapper.trailingAnchor),
+    ])
+    return wrapper
+  }
+
+  func updateUIView(_ uiView: UIView, context: Context) {
+    guard let toast = uiView.subviews.compactMap({ $0 as? BezierToast }).first else { return }
+    toast.preset = self.preset
+    toast.title = self.title
+  }
+
+  func sizeThatFits(_ proposal: ProposedViewSize, uiView: UIView, context: Context) -> CGSize? {
+    let width = proposal.width ?? BezierToastSpec.maxWidth
+    let height = uiView.systemLayoutSizeFitting(
+      CGSize(width: width, height: UIView.layoutFittingCompressedSize.height),
+      withHorizontalFittingPriority: .required,
+      verticalFittingPriority: .fittingSizeLevel
+    ).height
+    return CGSize(width: width, height: height)
   }
 }

--- a/Sources/BezierSwift/MasterComponent/BezierToast/BezierToast.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierToast/BezierToast.swift
@@ -100,7 +100,6 @@ public final class BezierToast: UIView, BezierComponentable {
     self.translatesAutoresizingMaskIntoConstraints = false
     self.layer.masksToBounds = true
     self.layer.cornerRadius = BezierToastSpec.cornerRadius.rawValue
-    // SwiftUI 쌍(applyBezierCornerRadius)이 .continuous 스타일로 클리핑하므로 UIKit도 곡률을 맞춘다.
     self.layer.cornerCurve = .continuous
 
     self.addSubview(self.blurView)
@@ -200,9 +199,6 @@ public final class BezierToast: UIView, BezierComponentable {
         semanticColorToken: BezierToastSpec.textToken,
         alignment: .left
       )
-      // 헬퍼에 lineBreakMode를 인자로 넘기면 .byWordWrapping일 때만 붙는 한글 줄바꿈 전략을 잃는다 —
-      // 전략은 남긴 채 말줄임만 켠다 (BezierTextArea와 동일 패턴). attributedText의 paragraphStyle이
-      // label.lineBreakMode보다 우선하므로 여기서 켜지 않으면 2줄 초과가 "…" 없이 하드 클립된다.
       if let paragraphStyle = (attributes[.paragraphStyle] as? NSParagraphStyle)?
         .mutableCopy() as? NSMutableParagraphStyle {
         paragraphStyle.lineBreakMode = .byTruncatingTail
@@ -217,11 +213,7 @@ public final class BezierToast: UIView, BezierComponentable {
   }
 
   private func refreshAppearance() {
-    // 배경은 반투명 glass fill 아래에 backdrop blur가 깔리는 구조라(SPEC §3) fill을
-    // 뷰 자신이 아니라 blur 위 contentView에 칠한다.
     self.blurView.contentView.backgroundColor = BezierToastSpec.backgroundToken.palette(self)
-    // UIBlurEffect는 semantic 토큰을 받지 못하므로 palette와 동일한
-    // (componentTheme, colorTheme) 스위치로 반전을 직접 해석한다.
     switch (self.componentTheme, self.colorTheme) {
     case (.normal, .light), (.inverted, .dark):
       self.blurView.effect = UIBlurEffect(style: .systemThickMaterialLight)

--- a/Sources/BezierSwift/MasterComponent/BezierToast/BezierToast.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierToast/BezierToast.swift
@@ -34,6 +34,12 @@ public final class BezierToast: UIView, BezierComponentable {
 
   // MARK: - Subviews
 
+  private let blurView: UIVisualEffectView = {
+    let view = UIVisualEffectView()
+    view.translatesAutoresizingMaskIntoConstraints = false
+    return view
+  }()
+
   private let contentStackView: UIStackView = {
     let stackView = UIStackView()
     stackView.axis = .horizontal
@@ -52,10 +58,17 @@ public final class BezierToast: UIView, BezierComponentable {
     return imageView
   }()
 
+  private let titleContainerView: UIView = {
+    let view = UIView()
+    view.translatesAutoresizingMaskIntoConstraints = false
+    return view
+  }()
+
   private let titleLabel: UILabel = {
     let label = UILabel()
     label.numberOfLines = BezierToastSpec.textLineLimit
     label.lineBreakMode = .byTruncatingTail
+    label.translatesAutoresizingMaskIntoConstraints = false
     return label
   }()
 
@@ -86,9 +99,15 @@ public final class BezierToast: UIView, BezierComponentable {
   private func setUp() {
     self.translatesAutoresizingMaskIntoConstraints = false
     self.layer.masksToBounds = true
+    self.layer.cornerRadius = BezierToastSpec.cornerRadius.rawValue
+    // SwiftUI 쌍(applyBezierCornerRadius)이 .continuous 스타일로 클리핑하므로 UIKit도 곡률을 맞춘다.
+    self.layer.cornerCurve = .continuous
 
+    self.addSubview(self.blurView)
+
+    self.titleContainerView.addSubview(self.titleLabel)
     self.contentStackView.addArrangedSubview(self.iconImageView)
-    self.contentStackView.addArrangedSubview(self.titleLabel)
+    self.contentStackView.addArrangedSubview(self.titleContainerView)
     self.addSubview(self.contentStackView)
 
     let hPadding = self.horizontalPadding
@@ -104,6 +123,10 @@ public final class BezierToast: UIView, BezierComponentable {
     let iconHeight = self.iconImageView.heightAnchor.constraint(equalToConstant: BezierToastSpec.iconLength)
 
     NSLayoutConstraint.activate([
+      self.blurView.topAnchor.constraint(equalTo: self.topAnchor),
+      self.blurView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+      self.blurView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+      self.blurView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
       stackLeading,
       stackTrailing,
       self.contentStackView.topAnchor.constraint(
@@ -114,6 +137,16 @@ public final class BezierToast: UIView, BezierComponentable {
         equalTo: self.bottomAnchor,
         constant: -BezierToastSpec.verticalPadding
       ),
+      self.titleLabel.topAnchor.constraint(
+        equalTo: self.titleContainerView.topAnchor,
+        constant: BezierToastSpec.textVerticalPadding
+      ),
+      self.titleLabel.bottomAnchor.constraint(
+        equalTo: self.titleContainerView.bottomAnchor,
+        constant: -BezierToastSpec.textVerticalPadding
+      ),
+      self.titleLabel.leadingAnchor.constraint(equalTo: self.titleContainerView.leadingAnchor),
+      self.titleLabel.trailingAnchor.constraint(equalTo: self.titleContainerView.trailingAnchor),
       iconWidth,
       iconHeight,
       self.widthAnchor.constraint(lessThanOrEqualToConstant: BezierToastSpec.maxWidth),
@@ -129,11 +162,6 @@ public final class BezierToast: UIView, BezierComponentable {
   }
 
   // MARK: - Layout
-
-  public override func layoutSubviews() {
-    super.layoutSubviews()
-    self.layer.cornerRadius = self.bounds.height / 2
-  }
 
   public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
     super.traitCollectionDidChange(previousTraitCollection)
@@ -155,7 +183,7 @@ public final class BezierToast: UIView, BezierComponentable {
   private func refreshContent() {
     if let icon = self.preset.icon {
       self.iconImageView.image = icon.uiImage?.withRenderingMode(.alwaysTemplate)
-      self.iconImageView.tintColor = self.preset.iconColor.palette(self)
+      self.iconImageView.tintColor = self.preset.iconColor?.palette(self)
       self.iconImageView.isHidden = false
       self.iconWidthConstraint?.constant = BezierToastSpec.iconLength
       self.iconHeightConstraint?.constant = BezierToastSpec.iconLength
@@ -167,21 +195,39 @@ public final class BezierToast: UIView, BezierComponentable {
     }
 
     if let title = self.title, !title.isEmpty {
-      self.titleLabel.attributedText = BezierToastSpec.typographyToken.attributedString(
+      var attributes = BezierToastSpec.typographyToken.attributes(
         self,
-        text: title,
         semanticColorToken: BezierToastSpec.textToken,
         alignment: .left
       )
-      self.titleLabel.isHidden = false
+      // 헬퍼에 lineBreakMode를 인자로 넘기면 .byWordWrapping일 때만 붙는 한글 줄바꿈 전략을 잃는다 —
+      // 전략은 남긴 채 말줄임만 켠다 (BezierTextArea와 동일 패턴). attributedText의 paragraphStyle이
+      // label.lineBreakMode보다 우선하므로 여기서 켜지 않으면 2줄 초과가 "…" 없이 하드 클립된다.
+      if let paragraphStyle = (attributes[.paragraphStyle] as? NSParagraphStyle)?
+        .mutableCopy() as? NSMutableParagraphStyle {
+        paragraphStyle.lineBreakMode = .byTruncatingTail
+        attributes[.paragraphStyle] = paragraphStyle
+      }
+      self.titleLabel.attributedText = NSAttributedString(string: title, attributes: attributes)
+      self.titleContainerView.isHidden = false
     } else {
       self.titleLabel.attributedText = nil
-      self.titleLabel.isHidden = true
+      self.titleContainerView.isHidden = true
     }
   }
 
   private func refreshAppearance() {
-    self.backgroundColor = BezierToastSpec.backgroundToken.palette(self)
+    // 배경은 반투명 glass fill 아래에 backdrop blur가 깔리는 구조라(SPEC §3) fill을
+    // 뷰 자신이 아니라 blur 위 contentView에 칠한다.
+    self.blurView.contentView.backgroundColor = BezierToastSpec.backgroundToken.palette(self)
+    // UIBlurEffect는 semantic 토큰을 받지 못하므로 palette와 동일한
+    // (componentTheme, colorTheme) 스위치로 반전을 직접 해석한다.
+    switch (self.componentTheme, self.colorTheme) {
+    case (.normal, .light), (.inverted, .dark):
+      self.blurView.effect = UIBlurEffect(style: .systemThickMaterialLight)
+    case (.normal, .dark), (.inverted, .light):
+      self.blurView.effect = UIBlurEffect(style: .systemThickMaterialDark)
+    }
     self.refreshContent()
   }
 }

--- a/Sources/BezierSwift/MasterComponent/BezierToast/BezierToastSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierToast/BezierToastSpec.swift
@@ -5,13 +5,13 @@
 
 import CoreGraphics
 
-/// 토스트의 표시 유형. Figma `Toast` 컴포넌트의 `preset` 프로퍼티에 대응(Figma `default` ↔ `.info`). Figma의 `warning`은 Swift에서 제공하지 않는다. Figma mobile 스펙 확정 전이라 매핑은 참고용이다.
+/// 토스트의 표시 유형. Figma `Toast`(Mobile Components) 컴포넌트의 `preset` 프로퍼티(`success` / `error` / `info`)에 대응한다.
 public enum BezierToastPreset: String, CaseIterable {
   /// 저장·삭제 등 액션 완료 결과를 알린다. 3초 후 자동 해제된다.
   case success
   /// 액션 실패 결과를 알린다.
   case error
-  /// Figma `default`. 아이콘 없는 중립 알림에 쓴다.
+  /// 아이콘 없는 중립 알림에 쓴다.
   case info
 
   /// preset별 leading 아이콘. `info`는 아이콘 없음(nil).
@@ -23,24 +23,30 @@ public enum BezierToastPreset: String, CaseIterable {
     }
   }
 
-  /// leading 아이콘 tint. Figma export SVG 기준 success·error 모두 `iconNeutralHeavy`(#ffffff99, white opacity 0.6).
-  /// `info`는 아이콘이 없어 사용되지 않는다.
-  public var iconColor: BCSemanticToken {
-    .iconNeutralHeavy
+  /// leading 아이콘 tint. Figma export SVG 기준 success는 `iconAccentGreen`, error는 `iconAccentRed`.
+  /// `info`는 아이콘이 없어 nil.
+  public var iconColor: BCSemanticToken? {
+    switch self {
+    case .success: return .iconAccentGreen
+    case .error: return .iconAccentRed
+    case .info: return nil
+    }
   }
 }
 
 public enum BezierToastSpec {
-  public static let backgroundToken: BCSemanticToken = .fillGreyHeavier
+  public static let backgroundToken: BCSemanticToken = .surfaceGlass
   public static let textToken: BCSemanticToken = .textNeutral
   public static let typographyToken: BTSemanticToken = .textMedium(weight: .bold)
 
+  public static let cornerRadius: BezierCornerRadius = .round20
   public static let maxWidth: CGFloat = 460
   public static let minHeight: CGFloat = 40
   public static let iconLength: CGFloat = 20
   public static let iconTextGap: CGFloat = 6
-  public static let verticalPadding: CGFloat = 10
+  public static let verticalPadding: CGFloat = 12
   public static let horizontalPaddingWithIcon: CGFloat = 12
   public static let horizontalPaddingTextOnly: CGFloat = 14
+  public static let textVerticalPadding: CGFloat = 1
   public static let textLineLimit: Int = 2
 }

--- a/Sources/BezierSwift/MasterComponent/BezierToast/SPEC.md
+++ b/Sources/BezierSwift/MasterComponent/BezierToast/SPEC.md
@@ -5,8 +5,8 @@
 
 화면 상단에 일시적으로 표시되는 비방해적 알림 (iOS 네이티브 관례).
 
-- **모양**: pill (완전 캡슐, radius = height / 2)
-- **표면 모드**: 반전 (앱 테마의 반대 — 라이트에서 dark 표면, 다크에서 light 표면)
+- **모양**: rounded rect — corner radius `20` 고정 (Figma `radius/20`)
+- **표면 모드**: 반전 (앱 테마의 반대 — 라이트에서 dark 표면, 다크에서 light 표면) + glass (반투명 fill + backdrop blur)
 - **위치**: 상단 고정 (`top`)
 - **동시 표시**: 1개 (새 Toast가 오면 기존 Toast 즉시 교체)
 
@@ -18,7 +18,7 @@ Figma 컴포넌트가 정의하는 property와 옵션은 다음이 전부다.
 
 | Property | 값 | 비고 |
 |---|---|---|
-| **preset** | `success` / `error` / `info` | 아이콘 + (아이콘 색) 자동 결정 |
+| **preset** | `success` / `error` / `info` | 아이콘 + 아이콘 색 자동 결정 |
 
 > preset 외 property 없음. size / variant / state 축 없음.
 
@@ -32,17 +32,18 @@ Toast는 size 축이 없다. preset(아이콘 유무)에 따라 수평 padding�
 
 | 항목 | 값 | 비고 |
 |---|---|---|
-| corner radius | `height / 2` (pill) | Figma `rounded-[9999px]` |
-| vertical padding | `10` | 공통 |
+| corner radius | `20` | Figma `radius/20` 변수 바인딩 |
+| vertical padding | `12` | 공통 |
 | horizontal padding | `14` (info) / `12` (success·error) | 아이콘 유무 분기 |
 | icon ↔ text gap | `6` | 아이콘 있는 preset만 |
 | icon length | `20 × 20` | success·error |
+| text 영역 상하 padding | `1` | 단일행 텍스트 블록 높이 20 (= icon length, lineHeight 18 + 1×2) |
 | max width | `460` | HUG + maxWidth |
-| min height | `40` | 아이콘 유무에 따른 높이 변동 방지 |
+| min height | `40` | Figma root `min-h` 값. 단일행 실측 높이는 44 (= 12 + 20 + 12) |
 | text line limit | `2` | 초과 시 tail truncate |
 
-- 정렬: 아이콘과 텍스트 상단 정렬 (아이콘 top 기준), 컨테이너 내부 center
-- 좌우 여백(컨테이너 inset)은 표시 컨테이너 책임 (컴포넌트 밖)
+- 정렬: 아이콘과 텍스트 상단 정렬(cross-axis start), 컨테이너 내부 center. Figma 인스턴스 간 값이 갈리는데(`2089:17` error = start, `2089:2` success = center) 단일행 목업에서는 두 값의 렌더가 동일하다(모두 높이 44). design spec 문서 §6이 web·mobile 공통 `flex-start`로 명시하므로 start로 확정한다
+- 좌우 여백(컨테이너 inset)은 표시 컨테이너 책임 (컴포넌트 밖) — design spec §11 기준 `10`
 
 ---
 
@@ -56,24 +57,22 @@ Toast는 size 축이 없다. preset(아이콘 유무)에 따라 수평 padding�
 
 | Part | Token | Figma Variable | 앱 light → 적용값 | 앱 dark → 적용값 |
 |---|---|---|---|---|
-| 배경 | `fillGreyHeavier` | `color/fill/grey/heavier` | `#313135` (grey750) | `#efeff0` (grey200) |
+| 배경 | `surfaceGlass` | `color/surface/glass` | `#29292de5` (grey800_90) | `#ffffffe5` (white90) |
 | 텍스트 | `textNeutral` | `color/text/neutral` | `#ffffffcc` (white80) | `#000000d9` (black85) |
 
-> 배경 fill은 `color/fill/grey/heavier`(불투명). Figma에는 `Backdrop/small`(BACKGROUND_BLUR radius 6) 이펙트와 description "배경 blur(glass)"도 함께 존재하나, 바인딩된 배경 fill은 불투명이다.
+> 배경 fill은 반투명(alpha 0.9) glass이고, Figma `Backdrop/large` 이펙트(BACKGROUND_BLUR, radius `backdrop/60` = 60)가 함께 걸려 있다 — description의 "배경 blur(glass)". 구현 매핑은 §9-2.
 >
-> **반전 근거** — Figma의 preset 컴포넌트(`2089:2` / `2089:17` / `2089:25`)는 `2. semantic/color` 컬렉션을 `dark-theme` 모드로 `explicitVariableModes` pin하고 있고, 부모 COMPONENT_SET(`2090:17`)과 페이지는 pin 없이 컬렉션 기본값인 `light-theme`을 상속한다. 즉 Figma는 "light 컨텍스트에 놓인 Toast는 dark 표면"이라는 **반전 결과 1개 상태**를 목업으로 고정한 것이다. 대조군인 Banner 컴포넌트는 `semantic/typography`만 Mobile로 pin하고 `semantic/color`는 pin하지 않는다 — color pin은 Toast 고유다.
->
-> Figma는 모드가 2개뿐이라 반전 자체를 표현할 수 없으므로, "항상 dark"가 아니라 "반전"으로 읽어야 한다. 코드는 `componentTheme = .inverted`(UIKit) / `palette(_:isInverted: true)`(SwiftUI)로 구현한다.
+> **반전 근거** — Figma의 preset 컴포넌트(`2089:2` / `2089:17` / `2089:25`)는 `2. semantic/color` 컬렉션을 `dark-theme` 모드로 pin해 "light 컨텍스트에 놓인 Toast는 dark 표면"이라는 **반전 결과 1개 상태**를 목업으로 고정한 것이다. `get_variable_defs`가 dark쪽 값(`#29292de5` = grey800_90, `#51c371` = green300)을 돌려주는 것이 그 증거다. Figma는 모드가 2개뿐이라 반전 자체를 표현할 수 없으므로 "항상 dark"가 아니라 "반전"으로 읽어야 한다. 구현 매핑은 §9-1.
 
 ### Icon (preset별)
 
-| preset | 아이콘 | Token | 앱 light → 적용값 | 앱 dark → 적용값 |
-|---|---|---|---|---|
-| `success` | `check-circle-filled` | `iconNeutralHeavy` | `#ffffff99` (white60) | `#00000099` (black60) |
-| `error` | `error-diamond-filled` | `iconNeutralHeavy` | `#ffffff99` (white60) | `#00000099` (black60) |
-| `info` | — *(없음)* | — | — | — |
+| preset | 아이콘 | Token | Figma Variable | 앱 light → 적용값 | 앱 dark → 적용값 |
+|---|---|---|---|---|---|
+| `success` | `check-circle-filled` | `iconAccentGreen` | `color/icon/accent/green` | `#51c371` (green300) | `#20ab55` (green400) |
+| `error` | `error-diamond-filled` | `iconAccentRed` | `color/icon/accent/red` | `#f36868` (red300) | `#e1535d` (red400) |
+| `info` | — *(없음)* | — | — | — | — |
 
-> 아이콘 색은 Figma **export SVG** 기준으로 확정한다 (`shape` path의 `fill="white" fill-opacity="0.6"` = `#ffffff99` = `iconNeutralHeavy`). success·error 동일. `get_variable_defs`가 반환하는 다중 변수는 아이콘 라이브러리 컴포넌트가 참조하는 변수 목록일 뿐, 이 인스턴스의 실제 렌더 색이 아니다.
+> 아이콘 색은 Figma **export SVG** 기준으로 확정한다 — success `shape` path `fill="#51C371"`(= green300, dark pin 상태의 `iconAccentGreen`), error `shape` path `fill="#F36868"`(= red300, dark pin 상태의 `iconAccentRed`). `get_variable_defs`가 함께 반환하는 `color/icon/neutral`·`color/icon/absolute/white`는 아이콘 라이브러리 컴포넌트가 참조하는 변수 목록일 뿐, 이 인스턴스의 실제 렌더 색이 아니다.
 
 ---
 
@@ -115,7 +114,8 @@ Figma 컴포넌트는 정적 목업이며 state 축이 없다. 아래 런타임 
 
 - 화면 상단에 일시적으로 표시되는 비방해적 알림 (iOS 네이티브 관례)
 - 3초 후 자동 해제 — 사용자가 반드시 확인해야 하는 오류는 Banner 사용
-- 텍스트 최대 2줄 — 긴 메시지는 잘림 처리
+- 배경 blur(glass): 콘텐츠 위에 올라갈 때 backdrop-blur 이펙트 발동
+- 텍스트 최대 2줄 — 긴 메시지는 잘림 처리됨
 - placement: top 고정 (web은 bottom-left/right)
 
 ---
@@ -133,12 +133,21 @@ Figma 컴포넌트는 정적 목업이며 state 축이 없다. 아래 런타임 
 
 ---
 
-## 9. Variant 매트릭스
+## 9. Figma 외 · 협의 사항
+
+Figma에 없는 구현 아키텍처 결정을 여기에 분리 표기한다. SSOT 값이 아니다.
+
+1. **표면 반전 구현**: §3의 반전 판독은 `componentTheme = .inverted`(UIKit) / `palette(_:isInverted: true)`(SwiftUI)로 구현한다. 근거: design spec §7 Behavior — "Toast는 `InvertedThemeProvider`로 감싸져 현재 테마가 반전되어 표시됨. 라이트 모드에서는 다크 배경, 다크 모드에서는 라이트 배경".
+2. **backdrop blur 구현**: Figma `Backdrop/large`(BACKGROUND_BLUR, radius 60)는 OS 표준 material로 구현한다 — SwiftUI `.thickMaterial`(저장소 유틸 `applyBlurEffect()`), UIKit `UIVisualEffectView`. 근거: design spec §6 Token Map — "런타임에서는 iOS `.thickMaterial` 또는 `backdrop-filter: blur(60px)` 로 구현".
+
+---
+
+## 10. Variant 매트릭스
 
 총 instance: preset × 3 = **3개**
 
 ```text
-preset=success = 2089:2   (icon: check-circle-filled, h-padding 12)
-preset=error   = 2089:17  (icon: error-diamond-filled, h-padding 12)
-preset=info    = 2089:25  (icon 없음, h-padding 14)
+preset=success = 2089:2   (icon: check-circle-filled → iconAccentGreen, padding v12/h12)
+preset=error   = 2089:17  (icon: error-diamond-filled → iconAccentRed, padding v12/h12)
+preset=info    = 2089:25  (icon 없음, padding v12/h14)
 ```

--- a/Sources/BezierSwift/MasterComponent/BezierToast/SUBezierToast.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierToast/SUBezierToast.swift
@@ -28,13 +28,14 @@ public struct SUBezierToast: View, Themeable {
           .resizable()
           .scaledToFit()
           .frame(width: BezierToastSpec.iconLength, height: BezierToastSpec.iconLength)
-          .foregroundColor(self.palette(self.preset.iconColor, isInverted: true))
+          .foregroundColor(self.preset.iconColor.map { self.palette($0, isInverted: true) })
       }
 
       Text(self.title)
         .applyBezierFontStyle(BezierToastSpec.typographyToken, semanticColorToken: BezierToastSpec.textToken)
         .lineLimit(BezierToastSpec.textLineLimit)
         .truncationMode(.tail)
+        .padding(.vertical, BezierToastSpec.textVerticalPadding)
     }
     .padding(.vertical, BezierToastSpec.verticalPadding)
     .padding(
@@ -42,8 +43,9 @@ public struct SUBezierToast: View, Themeable {
       self.preset.icon == nil ? BezierToastSpec.horizontalPaddingTextOnly : BezierToastSpec.horizontalPaddingWithIcon
     )
     .frame(minHeight: BezierToastSpec.minHeight)
-    .background(Capsule().fill(self.palette(BezierToastSpec.backgroundToken, isInverted: true)))
-    .clipShape(Capsule())
+    .background(self.palette(BezierToastSpec.backgroundToken, isInverted: true))
+    .applyBlurEffect()
+    .applyBezierCornerRadius(type: BezierToastSpec.cornerRadius)
     .frame(maxWidth: BezierToastSpec.maxWidth)
     // applyBezierFontStyle 내부 modifier가 자체 @Environment(\.colorScheme)로 텍스트 색을 해석해
     // isInverted를 받지 못하므로, 텍스트를 함께 반전시키려면 environment를 뒤집어 주입해야 한다.

--- a/Sources/BezierSwift/Toast/BezierToastContainerView.swift
+++ b/Sources/BezierSwift/Toast/BezierToastContainerView.swift
@@ -7,6 +7,7 @@ import SwiftUI
 
 private enum Metric {
   static let topPadding = CGFloat(5)
+  static let horizontalInset = CGFloat(10)
 }
 
 struct BezierToastContainerView: View, Themeable {
@@ -35,7 +36,9 @@ struct BezierToastContainerView: View, Themeable {
     case .legacy(let param):
       LegacyBezierToast(param: param)
     case .v3(let preset, let title):
+      // LegacyBezierToast는 자체 body에 좌우 10 inset을 갖고 있어 v3 셀에만 컨테이너 inset을 준다.
       SUBezierToast(preset: preset, title: title)
+        .padding(.horizontal, Metric.horizontalInset)
     }
   }
 }

--- a/Sources/BezierSwift/Toast/BezierToastContainerView.swift
+++ b/Sources/BezierSwift/Toast/BezierToastContainerView.swift
@@ -36,7 +36,6 @@ struct BezierToastContainerView: View, Themeable {
     case .legacy(let param):
       LegacyBezierToast(param: param)
     case .v3(let preset, let title):
-      // LegacyBezierToast는 자체 body에 좌우 10 inset을 갖고 있어 v3 셀에만 컨테이너 inset을 준다.
       SUBezierToast(preset: preset, title: title)
         .padding(.horizontal, Metric.horizontalInset)
     }

--- a/docs/agent/uikit-pitfalls.md
+++ b/docs/agent/uikit-pitfalls.md
@@ -106,6 +106,31 @@ func textViewDidChange(_ textView: UITextView) {
   빼지 말 것
 - 실례: `BezierTextArea.swift` — 소프트 키보드 Enter로 줄바꿈할 때 캐럿이 위로 튀는 증상으로 발견
 
+## attributedText의 paragraphStyle이 `label.lineBreakMode`를 덮어쓴다
+
+`UILabel.lineBreakMode = .byTruncatingTail`을 설정해도, `attributedText`에 `paragraphStyle`이
+들어 있으면 **그쪽 `lineBreakMode`(토큰 헬퍼 기본값 `.byWordWrapping`)가 우선**한다.
+line height 토큰을 쓰는 라벨은 항상 paragraphStyle을 갖고 있으므로, 줄 수 제한 초과 시
+말줄임표("…") 없이 하드 클립된다 — 짧은 데모 텍스트로는 안 보이고 2줄 초과에서만 드러난다.
+
+`BTSemanticToken.attributes(...)`에 `lineBreakMode` 인자를 직접 넘기는 것도 답이 아니다 —
+`.byWordWrapping`일 때만 붙는 한글 줄바꿈 전략(`hangulWordPriority`)을 잃는다.
+**전략은 남긴 채 paragraphStyle의 lineBreakMode만 사후 주입한다:**
+
+```swift
+var attributes = token.attributes(self, semanticColorToken: colorToken)
+if let paragraphStyle = (attributes[.paragraphStyle] as? NSParagraphStyle)?
+  .mutableCopy() as? NSMutableParagraphStyle {
+  paragraphStyle.lineBreakMode = .byTruncatingTail
+  attributes[.paragraphStyle] = paragraphStyle
+}
+label.attributedText = NSAttributedString(string: text, attributes: attributes)
+```
+
+- 실례: `BezierTextArea.swift`(placeholder), `BezierToast.swift`(2줄 제한) — 동일 패턴 사용
+- SwiftUI는 `.lineLimit(n).truncationMode(.tail)`이 그대로 동작해 이 함정이 없다 — 두 구현의
+  패리티를 볼 때 UIKit 쪽만 의심할 것
+
 ## 레이아웃 테스트
 
 UIKit 뷰의 압축·크기 거동은 `UIWindow`에 붙여야 측정이 유효하다. 상세는


### PR DESCRIPTION
## 개요

Figma [🚧 Mobile Components — Toast(2090:17)](https://www.figma.com/design/46idSffz5wpiLD5ykWUFZY/Mobile-Components?node-id=2090-17)가 재정의되어([team-design Toast-spec](https://github.com/channel-io/team-design/blob/main/bezier-v3/components/Toast-spec.md) v1.3~v1.5 — "모바일 Toast를 iOS 관례로 재정의" + glass 표면), `figma-component-spec` 파이프라인(Phase 0~3)으로 SPEC.md와 UIKit/SwiftUI 구현을 재정렬했다.

## 스펙 변경 (Figma 실측 기준)

| 항목 | 기존 | 변경 |
|---|---|---|
| 배경 | `fillGreyHeavier` 불투명 | `surfaceGlass`(α0.9) + backdrop blur — Figma `Backdrop/large`(radius 60) |
| corner radius | pill (height/2) | 고정 `20` (`radius/20` → `BezierCornerRadius.round20`, continuous) |
| 아이콘 색 | 공통 `iconNeutralHeavy` | success `iconAccentGreen` / error `iconAccentRed` (export SVG로 확정) |
| vertical padding | 10 | 12 |
| 텍스트 영역 | — | 상하 1pt (단일행 실측 높이 44 재현) |
| SwiftUI 표시 컨테이너 | 좌우 inset 없음 | v3 셀 inset 10 (UIKit 매니저와 정렬) |

min height 40 · max width 460 · h padding 14/12 · gap 6 · 아이콘 20×20 · 2줄 제한 · `textMedium(.bold)` · 반전 표면은 유지.

구현 방식: UIKit은 `UIVisualEffectView`(+glass fill을 contentView에) / SwiftUI는 Legacy와 동일한 `.background(glass)` → `.applyBlurEffect()` → `.applyBezierCornerRadius(.round20)` 체인. blur 스타일은 palette와 동일한 (componentTheme, colorTheme) 스위치로 반전 적응.

## 함께 수정한 결함 2건

1. **UIKit 2줄 말줄임 미동작 (기존 결함)** — attributedText의 paragraphStyle(`.byWordWrapping` 기본값)이 `label.lineBreakMode`를 덮어써 2줄 초과가 "…" 없이 하드 클립되던 문제. BezierTextArea의 사후 주입 패턴으로 수정하고 `docs/agent/uikit-pitfalls.md`에 함정으로 등재.
2. **ToastCatalog 폭 초과** — 긴 제목에서 `UIKitWrap.fixedSize()`가 toast를 maxWidth(460)까지 벌려 화면 폭을 넘던 문제. 표시 컨테이너와 동일한 제약의 전용 representable로 교체.

## 검증

- figma-component-spec **Phase 2 spec 검증 7차원 전부 ✅** (구조/스타일/Asset/Noise/Implementation Reference)
- **Phase 3 구현 검증 UIKit·SwiftUI ✅** (truncate 결함은 이 과정에서 검출·수정)
- clean build (BezierSwift + BezierExamples) `BUILD SUCCEEDED`, 단위 테스트 `TEST SUCCEEDED`
- 별도 시뮬레이터(iPhone 16 Pro / iOS 26.4) 실측 스크린샷 아래 첨부

## 리뷰어 확인 요청

- **Figma 정렬 모순**: success 인스턴스는 `items-center`, error는 `items-start`(단일행 렌더 동일). design spec §6의 공통 `flex-start`를 tie-breaker로 **상단 정렬 채택** (SPEC §2에 근거 기록). 디자이너 확인 권장.
- **team-design 문서 시차**: Toast-spec v1.5의 mobile padding v10/minHeight 44는 Figma 최신(v12/min-h 40)보다 뒤처짐 — 문서 측 갱신 대상.

## 스크린샷

시뮬레이터(iPhone 16 Pro / iOS 26.4) 실측. Toast는 반전 컴포넌트라 라이트 모드에서 dark 표면, 다크 모드에서 light 표면이 적용된다.

### Preset × 테마

| | success | error | info |
|---|---|---|---|
| **라이트** | <img width="250" src="https://github.com/user-attachments/assets/74918a36-43f9-460c-ae99-52564768bbe3"> | <img width="250" src="https://github.com/user-attachments/assets/e32da43e-b35d-4167-b8b6-b718236da84a"> | <img width="250" src="https://github.com/user-attachments/assets/305c758c-cc60-40a6-8240-2a8f17a19fbc"> |
| **다크** | <img width="250" src="https://github.com/user-attachments/assets/523b5975-75a6-45fc-9b66-f39f612da86c"> | <img width="250" src="https://github.com/user-attachments/assets/615b8776-3035-4c4f-9311-30364ce6ee9e"> | <img width="250" src="https://github.com/user-attachments/assets/488fec12-5086-428f-9c3f-061b31229cd7"> |

### 2줄 제한 + tail 말줄임 (카탈로그 정적 프리뷰 — 폭 수정 반영)

<img width="400" src="https://github.com/user-attachments/assets/0e53053c-bbaf-4943-b4e2-ccd98d5e3c4e">

### Present 상태 (컨테이너 inset 10 · 콘텐츠 위 glass · UIKit 말줄임 수정 실증)

| SwiftUI 파이프라인 | UIKit 매니저 |
|---|---|
| <img width="380" src="https://github.com/user-attachments/assets/087fba43-289d-4c06-ad3d-935c7d0b4ffc"> | <img width="380" src="https://github.com/user-attachments/assets/c7f25d1f-e1d0-43fb-a82e-d9acae5e6bbc"> |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
