### PR TITLE
[MOB-6882] BezierButton에 intrinsicContentSize를 제공한다

### DIFF
--- a/Examples/BezierExamples/BezierExamples/Components/ButtonCatalog.swift
+++ b/Examples/BezierExamples/BezierExamples/Components/ButtonCatalog.swift
@@ -17,6 +17,11 @@ struct ButtonCatalog: View {
       self.controls
       CatalogSection(.swiftUI) { self.swiftUIPreview }
       CatalogSection(.uiKit) { self.uiKitPreview }
+      Text("Collection view self-sizing (MOB-6882)")
+        .font(.system(size: 13, weight: .semibold))
+        .foregroundStyle(.secondary)
+        .textCase(.uppercase)
+      CatalogSection(.uiKit) { self.selfSizingDemo }
       Text("Matrix (medium · variant × semantic)")
         .font(.system(size: 13, weight: .semibold))
         .foregroundStyle(.secondary)
@@ -103,6 +108,22 @@ struct ButtonCatalog: View {
       Spacer()
     }
     .padding(.vertical, 8)
+  }
+
+  // MARK: - Collection View Self-Sizing (MOB-6882)
+
+  private var selfSizingDemo: some View {
+    VStack(alignment: .leading, spacing: 10) {
+      Text("실제 UICollectionView(compositional list) self-sizing 셀. 세 행은 셀 폭이 같고 버튼 제약만 다르다. 측정값이 초록이면 기대대로 배치된 것이다.")
+        .font(.caption2)
+        .foregroundStyle(.secondary)
+      ButtonSelfSizingDemo(
+        size: self.size,
+        variant: self.variant,
+        semantic: self.semantic,
+        title: self.title
+      )
+    }
   }
 
   // MARK: - Matrix

--- a/Examples/BezierExamples/BezierExamples/Components/ButtonSelfSizingDemo.swift
+++ b/Examples/BezierExamples/BezierExamples/Components/ButtonSelfSizingDemo.swift
@@ -1,0 +1,357 @@
+import SwiftUI
+import UIKit
+import BezierSwift
+
+// MOB-6882 재현 화면.
+//
+// UIKitWrap의 systemLayoutSizeFitting 경로에서는 이 버그가 재현되지 않는다. 실제
+// UICollectionView(compositional list) self-sizing 셀에 태워야만 드러나므로 전용
+// representable로 컬렉션뷰를 통째로 얹는다.
+//
+// 재현 조건이 까다롭다. 폭이 모호한 상태(intrinsic 부재)에서는 엔진이 어느 해를 고를지가
+// 주변 제약에 좌우되므로, 아래 두 가지를 어기면 버그가 그냥 hug으로 풀려 가려진다.
+//
+//   1. 버튼 셀에는 버튼만 넣는다 — 같은 셀에 라벨을 함께 두면 hug 쪽으로 풀린다.
+//      그래서 설명·측정값은 별도의 헤더 셀이 들고 있다.
+//   2. 버튼과 제약은 셀 `init`에서 만든다 — `cellForItemAt`에서 뒤늦게 붙이면 self-sizing
+//      첫 측정에 제약이 없어, 역시 hug으로 풀린다.
+
+/// 버튼을 셀에 붙이는 세 가지 배치 레시피. 셀 폭은 같고 제약만 다르다.
+enum ButtonPlacementRecipe: CaseIterable {
+  /// `centerX` + `leading >=` / `trailing <=` — 콘텐츠 폭으로 hug 되기를 기대하는 배치.
+  case hugInequality
+  /// `leading =` / `trailing =` — 컨테이너가 폭을 지정하는 배치.
+  case fillEqual
+  /// 세로 스택 `alignment = .center` — intrinsic이 없던 시절의 소비자 우회.
+  case hugCenterStack
+
+  var title: String {
+    switch self {
+    case .hugInequality: return "centerX + leading ≥ / trailing ≤"
+    case .fillEqual: return "leading = / trailing ="
+    case .hugCenterStack: return "세로 스택 alignment .center"
+    }
+  }
+
+  var expectation: String {
+    switch self {
+    case .hugInequality, .hugCenterStack: return "hug 기대 — 콘텐츠 폭"
+    case .fillEqual: return "fill 기대 — 셀 폭"
+    }
+  }
+
+  var reuseIdentifier: String {
+    switch self {
+    case .hugInequality: return "ButtonSelfSizingHugInequalityCell"
+    case .fillEqual: return "ButtonSelfSizingFillEqualCell"
+    case .hugCenterStack: return "ButtonSelfSizingHugStackCell"
+    }
+  }
+
+  var expectsHug: Bool {
+    switch self {
+    case .hugInequality, .hugCenterStack: return true
+    case .fillEqual: return false
+    }
+  }
+}
+
+struct ButtonSelfSizingDemo: UIViewRepresentable {
+  let size: BezierButtonSize
+  let variant: BezierButtonVariant
+  let semantic: BezierButtonSemantic
+  let title: String
+
+  func makeUIView(context: Context) -> ButtonSelfSizingDemoView {
+    ButtonSelfSizingDemoView()
+  }
+
+  func updateUIView(_ uiView: ButtonSelfSizingDemoView, context: Context) {
+    uiView.configure(size: self.size, variant: self.variant, semantic: self.semantic, title: self.title)
+  }
+
+  func sizeThatFits(
+    _ proposal: ProposedViewSize,
+    uiView: ButtonSelfSizingDemoView,
+    context: Context
+  ) -> CGSize? {
+    let width = proposal.width ?? UIScreen.main.bounds.width
+    return CGSize(width: width, height: uiView.contentHeight(fittingWidth: width))
+  }
+}
+
+// MARK: - Demo View
+
+final class ButtonSelfSizingDemoView: UIView {
+  private static let probeHeight: CGFloat = 2000
+
+  private let collectionView: UICollectionView
+  private let dataSource = RecipeDataSource()
+  private var cachedMeasurement: (key: MeasurementKey, height: CGFloat)?
+
+  fileprivate struct MeasurementKey: Equatable {
+    let width: CGFloat
+    let style: RecipeDataSource.Style
+  }
+
+  override init(frame: CGRect) {
+    var configuration = UICollectionLayoutListConfiguration(appearance: .plain)
+    configuration.showsSeparators = false
+    configuration.backgroundColor = .clear
+    let layout = UICollectionViewCompositionalLayout.list(using: configuration)
+    self.collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+
+    super.init(frame: frame)
+
+    self.collectionView.backgroundColor = .clear
+    self.collectionView.isScrollEnabled = false
+    self.collectionView.translatesAutoresizingMaskIntoConstraints = false
+    self.collectionView.register(RecipeHeaderCell.self, forCellWithReuseIdentifier: RecipeDataSource.headerReuseIdentifier)
+    self.collectionView.register(HugInequalityButtonCell.self, forCellWithReuseIdentifier: ButtonPlacementRecipe.hugInequality.reuseIdentifier)
+    self.collectionView.register(FillEqualButtonCell.self, forCellWithReuseIdentifier: ButtonPlacementRecipe.fillEqual.reuseIdentifier)
+    self.collectionView.register(HugStackButtonCell.self, forCellWithReuseIdentifier: ButtonPlacementRecipe.hugCenterStack.reuseIdentifier)
+    self.collectionView.dataSource = self.dataSource
+
+    self.addSubview(self.collectionView)
+    NSLayoutConstraint.activate([
+      self.collectionView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+      self.collectionView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+      self.collectionView.topAnchor.constraint(equalTo: self.topAnchor),
+      self.collectionView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+    ])
+  }
+
+  required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+  func configure(
+    size: BezierButtonSize,
+    variant: BezierButtonVariant,
+    semantic: BezierButtonSemantic,
+    title: String
+  ) {
+    let style = RecipeDataSource.Style(size: size, variant: variant, semantic: semantic, title: title)
+    guard style != self.dataSource.style else { return }
+
+    self.dataSource.style = style
+    self.cachedMeasurement = nil
+    self.collectionView.reloadData()
+  }
+
+  /// 컬렉션뷰가 스크롤하지 않으므로 콘텐츠 전체 높이를 representable에 알려준다.
+  ///
+  /// 높이 0짜리 프레임으로는 compositional layout이 self-sizing 셀을 준비하지 않아
+  /// `collectionViewContentSize`가 0으로 나온다. 충분히 큰 프레임을 한 번 태워 전 행을
+  /// 준비시킨 뒤 읽는다. 캐시하지 않으면 매 측정마다 레이아웃이 돌아 SwiftUI가 다시
+  /// 측정하는 루프가 생기고, 바깥 `ScrollView`의 오프셋이 계속 초기화된다.
+  func contentHeight(fittingWidth width: CGFloat) -> CGFloat {
+    let key = MeasurementKey(width: width, style: self.dataSource.style)
+    if let cached = self.cachedMeasurement, cached.key == key { return cached.height }
+
+    self.collectionView.frame = CGRect(x: 0, y: 0, width: width, height: Self.probeHeight)
+    self.collectionView.layoutIfNeeded()
+    let height = self.collectionView.collectionViewLayout.collectionViewContentSize.height
+    self.cachedMeasurement = (key, height)
+    return height
+  }
+
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    self.collectionView.layoutIfNeeded()
+    self.publishMeasurements()
+  }
+
+  /// 버튼 셀은 라벨을 갖지 않으므로, 컬렉션뷰 레이아웃이 끝난 뒤 폭을 읽어 헤더 셀에 넘긴다.
+  private func publishMeasurements() {
+    for (index, recipe) in ButtonPlacementRecipe.allCases.enumerated() {
+      let headerPath = IndexPath(item: index * 2, section: 0)
+      let buttonPath = IndexPath(item: index * 2 + 1, section: 0)
+      guard
+        let header = self.collectionView.cellForItem(at: headerPath) as? RecipeHeaderCell,
+        let buttonCell = self.collectionView.cellForItem(at: buttonPath) as? RecipeButtonCell,
+        let width = buttonCell.measuredButtonWidth
+      else { continue }
+
+      header.showMeasurement(width, cellWidth: buttonCell.bounds.width, expectsHug: recipe.expectsHug)
+    }
+  }
+}
+
+// MARK: - Data Source
+
+fileprivate final class RecipeDataSource: NSObject, UICollectionViewDataSource {
+  struct Style: Equatable {
+    var size: BezierButtonSize = .small
+    var variant: BezierButtonVariant = .outlined
+    var semantic: BezierButtonSemantic = .primary
+    var title: String = "더 보기"
+  }
+
+  static let headerReuseIdentifier = "ButtonSelfSizingRecipeHeaderCell"
+
+  var style = Style()
+
+  func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    ButtonPlacementRecipe.allCases.count * 2
+  }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    cellForItemAt indexPath: IndexPath
+  ) -> UICollectionViewCell {
+    let recipe = ButtonPlacementRecipe.allCases[indexPath.item / 2]
+    let isHeader = indexPath.item.isMultiple(of: 2)
+
+    if isHeader {
+      let cell = collectionView.dequeueReusableCell(
+        withReuseIdentifier: Self.headerReuseIdentifier,
+        for: indexPath
+      )
+      (cell as? RecipeHeaderCell)?.apply(recipe: recipe)
+      return cell
+    }
+
+    let cell = collectionView.dequeueReusableCell(
+      withReuseIdentifier: recipe.reuseIdentifier,
+      for: indexPath
+    )
+    (cell as? RecipeButtonCell)?.configure(style: self.style)
+    return cell
+  }
+}
+
+// MARK: - Header Cell
+
+fileprivate final class RecipeHeaderCell: UICollectionViewCell {
+  private let titleLabel = UILabel()
+  private let measurementLabel = UILabel()
+
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+
+    self.titleLabel.font = .monospacedSystemFont(ofSize: 11, weight: .medium)
+    self.titleLabel.textColor = .secondaryLabel
+    self.titleLabel.numberOfLines = 2
+    self.titleLabel.translatesAutoresizingMaskIntoConstraints = false
+
+    self.measurementLabel.font = .monospacedDigitSystemFont(ofSize: 12, weight: .semibold)
+    self.measurementLabel.textAlignment = .right
+    self.measurementLabel.translatesAutoresizingMaskIntoConstraints = false
+
+    self.contentView.addSubview(self.titleLabel)
+    self.contentView.addSubview(self.measurementLabel)
+
+    NSLayoutConstraint.activate([
+      self.titleLabel.topAnchor.constraint(equalTo: self.contentView.topAnchor, constant: 10),
+      self.titleLabel.bottomAnchor.constraint(equalTo: self.contentView.bottomAnchor, constant: -4),
+      self.titleLabel.leadingAnchor.constraint(equalTo: self.contentView.leadingAnchor, constant: 16),
+      self.measurementLabel.leadingAnchor.constraint(equalTo: self.titleLabel.trailingAnchor, constant: 8),
+      self.measurementLabel.trailingAnchor.constraint(equalTo: self.contentView.trailingAnchor, constant: -16),
+      self.measurementLabel.widthAnchor.constraint(equalToConstant: 64),
+      self.measurementLabel.firstBaselineAnchor.constraint(equalTo: self.titleLabel.firstBaselineAnchor),
+    ])
+  }
+
+  required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+  func apply(recipe: ButtonPlacementRecipe) {
+    self.titleLabel.text = "\(recipe.title)\n\(recipe.expectation)"
+    self.measurementLabel.text = nil
+  }
+
+  func showMeasurement(_ width: CGFloat, cellWidth: CGFloat, expectsHug: Bool) {
+    let text = "\(Int(width.rounded())) pt"
+    guard self.measurementLabel.text != text else { return }
+
+    self.measurementLabel.text = text
+    let hugged = width < cellWidth - RecipeButtonCell.horizontalInset * 2
+    self.measurementLabel.textColor = (hugged == expectsHug) ? .systemGreen : .systemRed
+  }
+}
+
+// MARK: - Button Cell
+//
+// 버튼과 제약을 `init`에서 만든다. `cellForItemAt`에서 뒤늦게 붙이면 self-sizing 첫 측정
+// 시점에 제약이 없어 모호성이 hug 쪽으로 풀리고, 재현하려던 버그가 가려진다.
+
+fileprivate class RecipeButtonCell: UICollectionViewCell {
+  static let horizontalInset: CGFloat = 16
+
+  let button = BezierButton(size: .small, variant: .outlined, semantic: .primary)
+
+  /// 컨테이너가 레이아웃 뒤에 읽는다. 아직 배치 전이면 `nil`.
+  var measuredButtonWidth: CGFloat? {
+    self.button.bounds.width > 0 ? self.button.bounds.width : nil
+  }
+
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    self.installButton()
+  }
+
+  required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+  /// 서브클래스가 레시피별 가로 제약을 건다.
+  func installButton() {
+    fatalError("서브클래스가 구현한다")
+  }
+
+  func configure(style: RecipeDataSource.Style) {
+    self.button.size = style.size
+    self.button.variant = style.variant
+    self.button.semantic = style.semantic
+    self.button.title = style.title.isEmpty ? nil : style.title
+  }
+
+  func pinVertically(_ view: UIView) {
+    NSLayoutConstraint.activate([
+      view.topAnchor.constraint(equalTo: self.contentView.topAnchor, constant: 2),
+      view.bottomAnchor.constraint(equalTo: self.contentView.bottomAnchor, constant: -14),
+    ])
+  }
+}
+
+/// `centerX` + 부등호. 폭을 확정하는 제약이 없어 MOB-6882가 드러나는 배치.
+fileprivate final class HugInequalityButtonCell: RecipeButtonCell {
+  override func installButton() {
+    let inset = Self.horizontalInset
+    self.contentView.addSubview(self.button)
+    NSLayoutConstraint.activate([
+      self.button.centerXAnchor.constraint(equalTo: self.contentView.centerXAnchor),
+      self.button.leadingAnchor.constraint(greaterThanOrEqualTo: self.contentView.leadingAnchor, constant: inset),
+      self.button.trailingAnchor.constraint(lessThanOrEqualTo: self.contentView.trailingAnchor, constant: -inset),
+    ])
+    self.pinVertically(self.button)
+  }
+}
+
+/// `leading =` / `trailing =`. 컨테이너가 폭을 확정하므로 항상 셀 폭이다.
+fileprivate final class FillEqualButtonCell: RecipeButtonCell {
+  override func installButton() {
+    let inset = Self.horizontalInset
+    self.contentView.addSubview(self.button)
+    NSLayoutConstraint.activate([
+      self.button.leadingAnchor.constraint(equalTo: self.contentView.leadingAnchor, constant: inset),
+      self.button.trailingAnchor.constraint(equalTo: self.contentView.trailingAnchor, constant: -inset),
+    ])
+    self.pinVertically(self.button)
+  }
+}
+
+/// 세로 스택 `alignment = .center`. intrinsic이 없던 시절의 소비자 우회.
+fileprivate final class HugStackButtonCell: RecipeButtonCell {
+  private let centerStackView = UIStackView()
+
+  override func installButton() {
+    let inset = Self.horizontalInset
+    self.centerStackView.axis = .vertical
+    self.centerStackView.alignment = .center
+    self.centerStackView.translatesAutoresizingMaskIntoConstraints = false
+    self.centerStackView.addArrangedSubview(self.button)
+    self.contentView.addSubview(self.centerStackView)
+    NSLayoutConstraint.activate([
+      self.centerStackView.leadingAnchor.constraint(equalTo: self.contentView.leadingAnchor, constant: inset),
+      self.centerStackView.trailingAnchor.constraint(equalTo: self.contentView.trailingAnchor, constant: -inset),
+    ])
+    self.pinVertically(self.centerStackView)
+  }
+}

--- a/Sources/BezierSwift/MasterComponent/BezierButton/BezierButton.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierButton/BezierButton.swift
@@ -7,6 +7,38 @@ import UIKit
 
 /// Bezier 디자인 시스템 V3 버튼 (UIKit). `size`·`variant`·`semantic` 세 축으로 형태를 지정하고,
 /// 아이콘과 로딩 상태를 지원한다. SwiftUI에서는 `SUBezierButton`을 사용한다.
+///
+/// ## 폭 배치 — hug / fill
+///
+/// 폭을 정하는 프로퍼티는 없다(`resizing`·`isFullWidth` 같은 축을 두지 않는다). 버튼은
+/// 콘텐츠 크기(``intrinsicContentSize``)를 기본 폭으로 갖고, **늘릴지 말지는 컨테이너가
+/// 제약으로 정한다.** 둘의 차이는 "폭을 확정하는 제약을 걸었는가" 하나뿐이다.
+///
+/// | 목적 | 거는 제약 | 쓰는 곳 |
+/// |---|---|---|
+/// | **hug** — 콘텐츠 폭 | 폭을 확정하지 않는다. `centerX`(또는 `leading =`) + `leading >=` / `trailing <=`, 혹은 세로 `UIStackView`의 `alignment = .center` | 카드·리스트 행 안의 보조 액션 (`.small` / `.outlined`) |
+/// | **fill** — 컨테이너 폭 | 폭을 확정한다. `leading =` + `trailing =`, 세로 `UIStackView`의 `alignment = .fill`, 가로 `UIStackView`의 `distribution = .fillEqually` | 하단 CTA·모달 버튼 (`.large` / `.filled`) |
+///
+/// ```swift
+/// // hug — 셀 폭이 얼마든 "더 보기"만큼만 차지한다
+/// NSLayoutConstraint.activate([
+///   button.centerXAnchor.constraint(equalTo: container.centerXAnchor),
+///   button.leadingAnchor.constraint(greaterThanOrEqualTo: container.leadingAnchor, constant: 16),
+///   button.trailingAnchor.constraint(lessThanOrEqualTo: container.trailingAnchor, constant: -16),
+/// ])
+///
+/// // fill — 컨테이너 폭을 채운다
+/// NSLayoutConstraint.activate([
+///   button.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 16),
+///   button.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -16),
+/// ])
+/// ```
+///
+/// hug 쪽에서 부등호 제약을 **빠뜨리면** 안 된다. 최소 폭(`size.minWidth`)만 남아 컨테이너가
+/// 좁을 때 라벨이 잘린다. 반대로 fill을 원하면서 부등호만 걸면 콘텐츠 폭으로 hug 된다.
+///
+/// `SUBezierButton`(SwiftUI)의 public API는 hug 전용이다 — fill은 모듈 내부 전용 축이라,
+/// SwiftUI에서 폭을 채워야 하면 컨테이너 쪽에서 레이아웃을 잡는다.
 public final class BezierButton: UIControl, BezierComponentable {
   // MARK: - BezierComponentable
 
@@ -206,6 +238,35 @@ public final class BezierButton: UIControl, BezierComponentable {
 
   // MARK: - Layout Update
 
+  /// 콘텐츠(아이콘·라벨)와 `size`의 패딩·간격으로 계산한 자연 크기. 폭의 하한은 `size.minWidth`다.
+  ///
+  /// 배치는 컨테이너 책임이므로 이 값은 기본 폭일 뿐이다. 컨테이너가 `equalTo` 제약이나
+  /// stretch 정렬(`UIStackView`의 `.fill`, `distribution = .fillEqually`)을 걸면 그쪽이 이긴다.
+  ///
+  /// `isLoading`은 반영하지 않는다 — 스피너로 전환될 때 버튼 폭이 흔들리면 안 되기 때문이다.
+  public override var intrinsicContentSize: CGSize {
+    var width = self.size.horizontalPadding * 2
+    var visibleContentCount = 0
+
+    if !self.leadingImageView.isHidden {
+      width += self.size.iconLength
+      visibleContentCount += 1
+    }
+    if !self.titleLabel.isHidden {
+      width += self.titleLabel.intrinsicContentSize.width
+      visibleContentCount += 1
+    }
+    if !self.trailingImageView.isHidden {
+      width += self.size.iconLength
+      visibleContentCount += 1
+    }
+    if visibleContentCount > 1 {
+      width += self.size.contentSpacing * CGFloat(visibleContentCount - 1)
+    }
+
+    return CGSize(width: max(width, self.size.minWidth), height: self.size.height)
+  }
+
   public override func layoutSubviews() {
     super.layoutSubviews()
     self.layer.cornerRadius = self.bounds.height / 2
@@ -244,7 +305,6 @@ public final class BezierButton: UIControl, BezierComponentable {
     self.spinner.size = self.size.spinnerSize
     self.refreshContent()
     self.setNeedsLayout()
-    self.invalidateIntrinsicContentSize()
   }
 
   private func refreshContent() {
@@ -273,6 +333,8 @@ public final class BezierButton: UIControl, BezierComponentable {
       self.titleLabel.attributedText = nil
       self.titleLabel.isHidden = true
     }
+
+    self.invalidateIntrinsicContentSize()
   }
 
   private func refreshAppearance() {

--- a/Sources/BezierSwift/MasterComponent/BezierButton/SUBezierButton.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierButton/SUBezierButton.swift
@@ -7,6 +7,10 @@ import SwiftUI
 
 /// Bezier 디자인 시스템 V3 버튼 (SwiftUI). `size`·`variant`·`semantic` 세 축으로 형태를 지정하고,
 /// 아이콘과 로딩 상태를 지원한다. UIKit에서는 `BezierButton`을 사용한다.
+///
+/// 폭은 콘텐츠를 hug 한다. `.frame(maxWidth: .infinity)`로는 늘어나지 않으므로(내부에서
+/// `fixedSize(horizontal:)`를 건다), 폭을 채워야 하면 컨테이너 쪽에서 레이아웃을 잡는다.
+/// UIKit `BezierButton`은 컨테이너 제약으로 hug·fill을 모두 만들 수 있다.
 public struct SUBezierButton: View, Themeable {
   private let size: BezierButtonSize
   private let variant: BezierButtonVariant

--- a/Tests/BezierSwiftTests/BezierButtonIntrinsicSizeTests.swift
+++ b/Tests/BezierSwiftTests/BezierButtonIntrinsicSizeTests.swift
@@ -1,0 +1,205 @@
+import Testing
+import UIKit
+@testable import BezierSwift
+
+// MARK: - BezierButton intrinsicContentSize / 컬렉션뷰 self-sizing 테스트 (MOB-6882)
+//
+// 재현 대상: BezierButton 이 intrinsicContentSize 를 노출하지 않아 폭이 미결정
+// (hasAmbiguousLayout == true) 상태가 되고, UICollectionView self-sizing 셀 안에서
+// 콘텐츠 폭(58pt) 대신 셀 폭 전체(317pt)로 늘어나던 버그.
+// 제약으로 흉내낸 self-sizing 에서는 재현되지 않아 실제 컬렉션뷰를 태워야만 드러난다.
+
+@Suite("BezierButton Intrinsic Content Size", .serialized)
+@MainActor
+struct BezierButtonIntrinsicSizeTests {
+  private static let cellWidth: CGFloat = 349
+  private static let cellHorizontalInset: CGFloat = 16
+
+  private static func makeButton(
+    size: BezierButtonSize = .small,
+    title: String? = "더 보기"
+  ) -> BezierButton {
+    let button = BezierButton(size: size, variant: .outlined, semantic: .primary)
+    button.title = title
+    return button
+  }
+
+  // MARK: - intrinsicContentSize 자체
+
+  @Test("intrinsicContentSize 가 noIntrinsicMetric 이 아니다")
+  func exposesIntrinsicContentSize() {
+    let button = Self.makeButton()
+    #expect(button.intrinsicContentSize.width != UIView.noIntrinsicMetric)
+    #expect(button.intrinsicContentSize.height == BezierButtonSize.small.height)
+  }
+
+  @Test("intrinsicContentSize.width 가 제약으로 계산한 자연폭과 일치한다")
+  func intrinsicWidthMatchesFittingWidth() {
+    let button = Self.makeButton()
+    let fitted = button.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).width
+    #expect(button.intrinsicContentSize.width == fitted)
+  }
+
+  @Test("콘텐츠가 없으면 minWidth 를 하한으로 쓴다")
+  func emptyContentFallsBackToMinWidth() {
+    let button = Self.makeButton(title: nil)
+    #expect(button.intrinsicContentSize.width == BezierButtonSize.small.minWidth)
+  }
+
+  @Test("아이콘을 추가하면 iconLength 와 contentSpacing 만큼 넓어진다")
+  func iconsWidenIntrinsicWidth() {
+    let size = BezierButtonSize.small
+    let button = Self.makeButton(size: size)
+    let titleOnly = button.intrinsicContentSize.width
+
+    button.leadingIcon = UIImage()
+    let withLeading = button.intrinsicContentSize.width
+    #expect(withLeading == titleOnly + size.iconLength + size.contentSpacing)
+
+    button.trailingIcon = UIImage()
+    let withBoth = button.intrinsicContentSize.width
+    #expect(withBoth == withLeading + size.iconLength + size.contentSpacing)
+  }
+
+  @Test("isLoading 을 켜도 폭이 변하지 않는다")
+  func loadingDoesNotChangeIntrinsicWidth() {
+    let button = Self.makeButton()
+    let before = button.intrinsicContentSize.width
+    button.isLoading = true
+    #expect(button.intrinsicContentSize.width == before)
+  }
+
+  @Test("size 를 바꾸면 intrinsicContentSize 가 따라간다")
+  func sizeChangeInvalidatesIntrinsicContentSize() {
+    let button = Self.makeButton(size: .small)
+    let small = button.intrinsicContentSize
+    button.size = .large
+    let large = button.intrinsicContentSize
+    #expect(large.height == BezierButtonSize.large.height)
+    #expect(large.width > small.width)
+  }
+
+  // MARK: - 컬렉션뷰 self-sizing 회귀 (MOB-6882 본체)
+
+  @Test("컬렉션뷰 self-sizing 셀 안에서 콘텐츠 폭을 유지한다")
+  func doesNotStretchInSelfSizingCollectionViewCell() {
+    let (window, collectionView) = Self.makeListCollectionView()
+    let dataSource = SingleButtonCellDataSource()
+    collectionView.dataSource = dataSource
+    collectionView.register(HuggingButtonCell.self, forCellWithReuseIdentifier: SingleButtonCellDataSource.reuseIdentifier)
+    collectionView.reloadData()
+    collectionView.layoutIfNeeded()
+    window.layoutIfNeeded()
+
+    guard let cell = collectionView.cellForItem(at: IndexPath(item: 0, section: 0)) as? HuggingButtonCell else {
+      Issue.record("셀을 얻지 못했다")
+      return
+    }
+
+    #expect(cell.bounds.width == Self.cellWidth)
+    #expect(cell.button.bounds.width == cell.button.intrinsicContentSize.width)
+    #expect(cell.button.hasAmbiguousLayout == false)
+  }
+
+  @Test("컨테이너가 equalTo 제약을 걸면 여전히 늘어난다")
+  func containerConstraintsStillWin() {
+    let (window, collectionView) = Self.makeListCollectionView()
+    let dataSource = SingleButtonCellDataSource()
+    collectionView.dataSource = dataSource
+    collectionView.register(StretchingButtonCell.self, forCellWithReuseIdentifier: SingleButtonCellDataSource.reuseIdentifier)
+    collectionView.reloadData()
+    collectionView.layoutIfNeeded()
+    window.layoutIfNeeded()
+
+    guard let cell = collectionView.cellForItem(at: IndexPath(item: 0, section: 0)) as? StretchingButtonCell else {
+      Issue.record("셀을 얻지 못했다")
+      return
+    }
+
+    #expect(cell.button.bounds.width == Self.cellWidth - Self.cellHorizontalInset * 2)
+  }
+
+  @Test("세로 스택 .fill 정렬이 intrinsic 을 이긴다")
+  func fillAlignedStackStillStretches() {
+    let window = UIWindow(frame: CGRect(x: 0, y: 0, width: Self.cellWidth, height: 200))
+    let button = Self.makeButton()
+    let stackView = UIStackView(arrangedSubviews: [button])
+    stackView.axis = .vertical
+    stackView.alignment = .fill
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    window.addSubview(stackView)
+    NSLayoutConstraint.activate([
+      stackView.leadingAnchor.constraint(equalTo: window.leadingAnchor),
+      stackView.trailingAnchor.constraint(equalTo: window.trailingAnchor),
+      stackView.topAnchor.constraint(equalTo: window.topAnchor),
+    ])
+    window.makeKeyAndVisible()
+    window.layoutIfNeeded()
+
+    #expect(button.bounds.width == Self.cellWidth)
+  }
+
+  // MARK: - Helpers
+
+  private static func makeListCollectionView() -> (UIWindow, UICollectionView) {
+    var configuration = UICollectionLayoutListConfiguration(appearance: .plain)
+    configuration.showsSeparators = false
+    let layout = UICollectionViewCompositionalLayout.list(using: configuration)
+    let frame = CGRect(x: 0, y: 0, width: Self.cellWidth, height: 600)
+    let collectionView = UICollectionView(frame: frame, collectionViewLayout: layout)
+    let window = UIWindow(frame: frame)
+    window.addSubview(collectionView)
+    window.makeKeyAndVisible()
+    return (window, collectionView)
+  }
+
+  final class HuggingButtonCell: UICollectionViewCell {
+    let button = BezierButtonIntrinsicSizeTests.makeButton()
+
+    override init(frame: CGRect) {
+      super.init(frame: frame)
+      let inset = BezierButtonIntrinsicSizeTests.cellHorizontalInset
+      self.contentView.addSubview(self.button)
+      NSLayoutConstraint.activate([
+        self.button.centerXAnchor.constraint(equalTo: self.contentView.centerXAnchor),
+        self.button.topAnchor.constraint(equalTo: self.contentView.topAnchor, constant: 8),
+        self.button.bottomAnchor.constraint(equalTo: self.contentView.bottomAnchor, constant: -8),
+        self.button.leadingAnchor.constraint(greaterThanOrEqualTo: self.contentView.leadingAnchor, constant: inset),
+        self.button.trailingAnchor.constraint(lessThanOrEqualTo: self.contentView.trailingAnchor, constant: -inset),
+      ])
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+  }
+
+  final class StretchingButtonCell: UICollectionViewCell {
+    let button = BezierButtonIntrinsicSizeTests.makeButton()
+
+    override init(frame: CGRect) {
+      super.init(frame: frame)
+      let inset = BezierButtonIntrinsicSizeTests.cellHorizontalInset
+      self.contentView.addSubview(self.button)
+      NSLayoutConstraint.activate([
+        self.button.leadingAnchor.constraint(equalTo: self.contentView.leadingAnchor, constant: inset),
+        self.button.trailingAnchor.constraint(equalTo: self.contentView.trailingAnchor, constant: -inset),
+        self.button.topAnchor.constraint(equalTo: self.contentView.topAnchor, constant: 8),
+        self.button.bottomAnchor.constraint(equalTo: self.contentView.bottomAnchor, constant: -8),
+      ])
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+  }
+}
+
+final class SingleButtonCellDataSource: NSObject, UICollectionViewDataSource {
+  static let reuseIdentifier = "BezierButtonIntrinsicSizeTestsCell"
+
+  func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int { 1 }
+
+  func collectionView(
+    _ collectionView: UICollectionView,
+    cellForItemAt indexPath: IndexPath
+  ) -> UICollectionViewCell {
+    collectionView.dequeueReusableCell(withReuseIdentifier: Self.reuseIdentifier, for: indexPath)
+  }
+}

--- a/docs/agent/examples-pitfalls.md
+++ b/docs/agent/examples-pitfalls.md
@@ -71,6 +71,34 @@ UIKitWrap({ BezierIconButton(...) }, update: { (button: BezierIconButton) in
 쓰면 제네릭 `V`가 `UIView`로 폴백되어 프로퍼티를 못 찾는 컴파일 에러가 나므로, update
 클로저의 파라미터 타입을 위처럼 명시한다.
 
+### 레이아웃 버그 재현 화면은 셀 구성이 결과를 바꾼다
+
+폭이 모호한 상태(intrinsic 부재)의 버그를 카탈로그에서 재현할 때, 컬렉션뷰를 태우는 것만으로는
+부족하다. 엔진이 어느 해를 고를지는 주변 제약에 좌우되므로 아래 둘 중 하나만 어겨도 hug으로
+풀려 **버그가 가려진다**.
+
+| 지켜야 할 것 | 어기면 |
+|---|---|
+| 버튼 셀에는 검증 대상만 넣는다 | 같은 셀에 설명 라벨을 함께 두면 hug으로 풀림 → 설명·측정값은 별도 헤더 셀로 분리 |
+| 대상과 제약을 셀 `init`에서 만든다 | `cellForItemAt`에서 뒤늦게 붙이면 self-sizing 첫 측정에 제약이 없어 hug으로 풀림 → 레시피별 셀 서브클래스로 나눈다 |
+
+실례: `ButtonSelfSizingDemo.swift`(MOB-6882). 이 두 조건을 맞추기 전까지는 수정 전 코드에서도
+정상(hug)으로 보였다.
+
+### 측정값을 셀 `layoutSubviews`에서 재면 중간값이 잡힌다
+
+셀의 `layoutSubviews`는 `contentView` 내부 배치보다 먼저 돌아, 대상 뷰의 폭이 0이거나 직전
+패스의 값이다. 컨테이너 뷰의 `layoutSubviews`에서 `collectionView.layoutIfNeeded()` 뒤에
+visible cell을 훑어 갱신한다.
+
+### 컬렉션뷰를 `UIViewRepresentable`로 얹을 때 높이 측정은 캐시한다
+
+`sizeThatFits`에서 매번 레이아웃을 돌리면 SwiftUI가 다시 측정하는 루프가 생겨 **바깥
+`ScrollView`의 오프셋이 계속 초기화된다**(스크롤이 튕겨 돌아오는 증상). (width, 콘텐츠) 키로
+캐시하고 콘텐츠가 바뀔 때만 무효화한다. 높이 0짜리 프레임으로 재면 compositional layout이
+self-sizing 셀을 준비하지 않아 `collectionViewContentSize`가 0으로 나오므로, 충분히 큰
+프레임을 한 번 태운 뒤 읽는다.
+
 ## 레이아웃
 
 ### 화면 폭을 넘는 row는 가로 `ScrollView`로 감싼다

--- a/docs/agent/uikit-pitfalls.md
+++ b/docs/agent/uikit-pitfalls.md
@@ -131,6 +131,37 @@ label.attributedText = NSAttributedString(string: text, attributes: attributes)
 - SwiftUI는 `.lineLimit(n).truncationMode(.tail)`이 그대로 동작해 이 함정이 없다 — 두 구현의
   패리티를 볼 때 UIKit 쪽만 의심할 것
 
+## `intrinsicContentSize`를 안 주면 폭이 "모호"해진다
+
+콘텐츠 폭을 하한 제약(`width >= minWidth`, 내부 스택 `leading >=` / `trailing <=`)으로만 잡고
+`intrinsicContentSize`를 오버라이드하지 않으면, **폭을 결정하는 제약이 하나도 없는 상태**가 된다.
+`hasAmbiguousLayout == true`이고, 값은 컨텍스트마다 다르게 나온다.
+
+`BezierButton(size: .small)` 실측 (동일한 제약 세트):
+
+| 호스트 | 결과 |
+|---|---|
+| 단독 컨테이너 / `systemLayoutSizeFitting` / `UIView-Encapsulated-Layout-Width` 흉내 | 58pt (hug) |
+| `UICollectionViewCompositionalLayout` + `UICollectionLayoutListConfiguration` | **317pt** (셀 폭까지 확장) |
+
+제약으로 흉내낸 self-sizing에서는 재현되지 않고 **실제 컬렉션뷰를 태워야만** 드러난다.
+`setContentHuggingPriority`·`setContentCompressionResistancePriority`는 이 상태에서 **무효다** —
+intrinsic size 대비 저항이라 기준이 없으면 작용할 대상이 없다(`.required`로 올려도 317 그대로).
+
+**UIKit 컴포넌트는 `intrinsicContentSize`를 콘텐츠 크기로 제공한다.** 배치는 여전히 컨테이너
+책임이다 — `equalTo` 제약이나 stretch 정렬(`.fill`, `.fillEqually`)이 intrinsic을 이긴다.
+
+```swift
+public override var intrinsicContentSize: CGSize {
+  // 가시 콘텐츠 + 패딩·간격을 더하고 minWidth를 하한으로
+}
+```
+
+- 콘텐츠가 바뀌는 지점(`refreshContent`)에서 `invalidateIntrinsicContentSize()`를 호출한다
+- 로딩 등 **일시 상태는 반영하지 않는다** — 스피너로 전환될 때 폭이 흔들린다
+- 실례: `BezierButton.swift`(MOB-6882), `BezierBadge.swift`(MOB-6018 — 같은 원인, 압축 붕괴로 발현)
+- 반대 증상(폭 붕괴)은 [`examples-pitfalls.md`](examples-pitfalls.md)의 "폭이 무너지는 세 케이스"
+
 ## 레이아웃 테스트
 
 UIKit 뷰의 압축·크기 거동은 `UIWindow`에 붙여야 측정이 유효하다. 상세는


### PR DESCRIPTION
## 배경

[MOB-6882](https://linear.app/channel/issue/MOB-6882) · 선행 [MOB-6825](https://linear.app/channel/issue/MOB-6825)

패널 "더 보기"를 `BezierButton(size: .small, variant: .outlined, semantic: .primary)`로 만들다, 버튼이 콘텐츠 폭이 아니라 **카드 폭 전체로 늘어나는** 것을 발견했다.

## 원인 — 폭이 "모호"했다

`BezierButton`은 폭 제약이 **하한만** 있고 `intrinsicContentSize`를 오버라이드하지 않았다.

```swift
self.widthAnchor.constraint(greaterThanOrEqualToConstant: self.size.minWidth)
self.contentStackView.leadingAnchor.constraint(greaterThanOrEqualTo: self.leadingAnchor, constant: horizontalPadding)
self.contentStackView.trailingAnchor.constraint(lessThanOrEqualTo: self.trailingAnchor, constant: -horizontalPadding)
```

상한이 없으므로 **폭을 결정하는 제약이 하나도 없다.** `hasAmbiguousLayout == true`이고, 아래 두 값은 둘 다 엔진이 임의로 고른 해다 — 외부 컨텍스트가 폭을 "정하는" 게 아니라 정해지지 않아 호스트마다 다르게 나온다.

| 경로 | 버튼 폭 |
|---|---|
| 단독 컨테이너 / `systemLayoutSizeFitting` / `UIView-Encapsulated-Layout-Width` 흉내 | 58 (hug) |
| `UICollectionViewCompositionalLayout` + `UICollectionLayoutListConfiguration` | **317** (셀 폭 349 − 여백 32) |

`setContentHuggingPriority(.defaultHigh)`가 걸려 있었지만 hugging은 intrinsic size 대비 저항이라 기준이 없으면 작용할 대상이 없다 — `.required`로 올려도 317 그대로였다.

## 스펙이 아니라 누락으로 판단한 근거

- **선례**: [MOB-6018](https://linear.app/channel/issue/MOB-6018)(`3735166`)에서 `BezierBadge`가 *정확히 같은 원인*으로 버그 판정을 받고 `public override var intrinsicContentSize`로 고쳐졌다. `BezierProgressBar`·`BezierDivider`·`BezierSectionLabel`도 public으로 intrinsic을 제공한다
- **CLAUDE.md**의 *"배치는 컨테이너 책임 — public `resizing`/`isFullWidth` 류 프로퍼티를 만들지 않는다"* 는 **프로퍼티 금지**이지 intrinsic 금지가 아니다. 이어지는 *"UIKit은 스택·제약이 **intrinsic size를 이기므로** 무수정으로 해결되고"* 는 오히려 intrinsic이 있다는 전제를 깔고 있다
- 모호한 레이아웃은 동작이 정의되지 않았다는 뜻이라 스펙으로 방어할 수 없다

## 변경

### 1. `intrinsicContentSize` 제공 (`BezierButton.swift`)

가시 콘텐츠(아이콘·라벨) + `horizontalPadding * 2` + `contentSpacing * (n-1)`, 하한 `minWidth`.

- `isLoading`은 **반영하지 않는다** — 스피너로 전환될 때 폭이 흔들리면 안 된다. 기존 제약 동작(hidden 상태에서도 constraint 유지)과도 일치한다
- `refreshContent()`에서 `invalidateIntrinsicContentSize()` 호출. `refreshLayout()`의 중복 호출은 제거했다(직전에 `refreshContent()`를 부른다)

### 2. hug / fill 선택 규칙을 doc comment로

폭 프로퍼티가 없으므로 소비자는 제약으로 구분해야 한다. 클래스 레벨 doc comment에 표와 예제를 넣어 LSP hover로 보이게 했다.

| 목적 | 거는 제약 | 쓰는 곳 |
|---|---|---|
| **hug** — 콘텐츠 폭 | 폭을 확정하지 **않는다**. `centerX` + `leading >=` / `trailing <=`, 세로 `UIStackView`의 `alignment = .center` | 카드·리스트 행의 보조 액션 |
| **fill** — 컨테이너 폭 | 폭을 확정한다. `leading =` + `trailing =`, 세로 스택 `.fill`, 가로 스택 `.fillEqually` | 하단 CTA·모달 버튼 |

`SUBezierButton`에는 public API가 hug 전용이고 `.frame(maxWidth: .infinity)`로는 늘어나지 않는다는(내부 `fixedSize(horizontal:)`) 패리티 노트를 덧붙였다.

### 3. 회귀 테스트 (`BezierButtonIntrinsicSizeTests.swift`, 9종)

제약으로 흉내낸 self-sizing에서는 재현되지 않으므로 **실제 컬렉션뷰를 태운다.** 컨테이너가 `equalTo`/`.fill`로 여전히 이기는지도 함께 고정했다.

### 4. Examples 재현 화면 (`ButtonSelfSizingDemo.swift`)

`ButtonCatalog`에 "Collection view self-sizing" 섹션 추가. 셀 폭은 같고 제약만 다른 세 행의 실측 폭을 색으로 판정한다.

**재현 조건이 까다로웠다.** 컬렉션뷰를 태우는 것만으로는 부족하고, 아래 둘 중 하나만 어겨도 모호성이 hug 쪽으로 풀려 수정 전 코드에서도 정상으로 보였다.

1. **버튼 셀에는 버튼만 넣는다** — 같은 셀에 설명 라벨을 두면 hug으로 풀린다 (설명·측정값은 별도 헤더 셀로 분리)
2. **버튼과 제약을 셀 `init`에서 만든다** — `cellForItemAt`에서 뒤늦게 붙이면 self-sizing 첫 측정에 제약이 없어 역시 hug으로 풀린다

### 5. `docs/agent`

- `uikit-pitfalls.md`: "`intrinsicContentSize`를 안 주면 폭이 모호해진다" — BezierBadge에 이어 두 번째 재발이라 관례로 기록
- `examples-pitfalls.md`: 재현 화면 작성 함정 3건 (셀 구성이 재현 여부를 가름 / 측정은 컨테이너 `layoutSubviews`에서 / representable 높이 측정 캐시가 없으면 바깥 ScrollView 오프셋이 초기화됨)

## 시각 검증

전용 시뮬레이터(iPhone 17 Pro / iOS 26.4)에서 동일 조작으로 캡처했다. 측정값이 초록이면 기대대로 배치된 것이다.

| 행 | 수정 전 | 수정 후 |
|---|---|---|
| `centerX + leading ≥ / trailing ≤` (hug 기대) | **314 pt** ❌ | **56 pt** ✅ |
| `leading = / trailing =` (fill 기대) | 314 pt ✅ | 314 pt ✅ |
| 세로 스택 `.center` (hug 기대) | 56 pt ✅ | 56 pt ✅ |

| Before (버그) | After (수정) |
|---|---|
| <img width="380" src="https://github.com/user-attachments/assets/fe8aa8cf-df40-409f-9d18-fe3c6690ca28"> | <img width="380" src="https://github.com/user-attachments/assets/6d3f7180-ca48-4f7d-a04f-f20defd3ad30"> |

## 영향 범위

| 소비자 | 배치 | 영향 |
|---|---|---|
| `BezierConfirmModal` | vertical `.fill` / horizontal `.fillEqually` | 없음 (컨테이너가 폭을 확정) |
| `ButtonCatalog` | `UIKitWrap { }.fixedSize()` | 없음 (동일한 hug 폭) |
| `SUBezierButton` | 순수 SwiftUI 구현 | 없음 |

ch-desk-ios의 `SectionSeeMoreView`·`ChatSharingErrorCell`은 세로 스택 우회를 쓰고 있는데, 이 PR이 배포되면 스택 없이 버튼만 배치하도록 정리할 수 있다.

## 테스트

- `xcodebuild -scheme BezierSwift ... clean test` → **123 tests / 30 suites 통과**
- `xcodebuild -project Examples/... -scheme BezierExamples ... clean build` → **BUILD SUCCEEDED**

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 버튼이 콘텐츠, 아이콘, 패딩에 맞춰 자연스러운 너비를 계산하도록 개선했습니다.
  * UICollectionView 셀에서 버튼이 콘텐츠에 맞게 자동으로 크기를 조정합니다.
  * 버튼 너비를 고정하거나 채우도록 설정하는 레이아웃 동작을 지원합니다.
  * 버튼 크기 조정 및 레이아웃 동작을 확인할 수 있는 예제와 데모를 추가했습니다.

* **문서**
  * UIKit 자동 크기 조정 및 레이아웃 측정 시 유의사항을 보강했습니다.

* **테스트**
  * 버튼 콘텐츠, 아이콘, 로딩 상태, 크기 변경에 따른 레이아웃 동작을 검증합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->