### PR TITLE
[MOB-6920] Toast Material 테마와 강도를 조정한다

### DIFF
--- a/Sources/BezierSwift/Extension/View+Extensions.swift
+++ b/Sources/BezierSwift/Extension/View+Extensions.swift
@@ -17,6 +17,14 @@ extension View {
   }
   
   func applyBlurEffect() -> some View {
-    return self.background(.thickMaterial)
+    self.background(.thickMaterial)
+  }
+
+  func applyBlurEffect(colorScheme: ColorScheme) -> some View {
+    self.background(
+      Rectangle()
+        .fill(.ultraThinMaterial)
+        .environment(\.colorScheme, colorScheme)
+    )
   }
 }

--- a/Sources/BezierSwift/MasterComponent/BezierToast/BezierToast.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierToast/BezierToast.swift
@@ -214,12 +214,9 @@ public final class BezierToast: UIView, BezierComponentable {
 
   private func refreshAppearance() {
     self.blurView.contentView.backgroundColor = BezierToastSpec.backgroundToken.palette(self)
-    switch (self.componentTheme, self.colorTheme) {
-    case (.normal, .light), (.inverted, .dark):
-      self.blurView.effect = UIBlurEffect(style: .systemThickMaterialLight)
-    case (.normal, .dark), (.inverted, .light):
-      self.blurView.effect = UIBlurEffect(style: .systemThickMaterialDark)
-    }
+    self.blurView.effect = UIBlurEffect(
+      style: BezierToastSpec.blurEffectStyle(for: self.colorTheme)
+    )
     self.refreshContent()
   }
 }

--- a/Sources/BezierSwift/MasterComponent/BezierToast/BezierToastSpec.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierToast/BezierToastSpec.swift
@@ -4,6 +4,7 @@
 //
 
 import CoreGraphics
+import UIKit
 
 /// 토스트의 표시 유형. Figma `Toast`(Mobile Components) 컴포넌트의 `preset` 프로퍼티(`success` / `error` / `info`)에 대응한다.
 public enum BezierToastPreset: String, CaseIterable {
@@ -49,4 +50,11 @@ public enum BezierToastSpec {
   public static let horizontalPaddingTextOnly: CGFloat = 14
   public static let textVerticalPadding: CGFloat = 1
   public static let textLineLimit: Int = 2
+
+  static func blurEffectStyle(for colorTheme: BezierColorTheme) -> UIBlurEffect.Style {
+    switch colorTheme {
+    case .light: return .systemUltraThinMaterialLight
+    case .dark: return .systemUltraThinMaterialDark
+    }
+  }
 }

--- a/Sources/BezierSwift/MasterComponent/BezierToast/SPEC.md
+++ b/Sources/BezierSwift/MasterComponent/BezierToast/SPEC.md
@@ -138,7 +138,7 @@ Figma 컴포넌트는 정적 목업이며 state 축이 없다. 아래 런타임 
 Figma에 없는 구현 아키텍처 결정을 여기에 분리 표기한다. SSOT 값이 아니다.
 
 1. **표면 반전 구현**: §3의 반전 판독은 `componentTheme = .inverted`(UIKit) / `palette(_:isInverted: true)`(SwiftUI)로 구현한다. 근거: design spec §7 Behavior — "Toast는 `InvertedThemeProvider`로 감싸져 현재 테마가 반전되어 표시됨. 라이트 모드에서는 다크 배경, 다크 모드에서는 라이트 배경".
-2. **backdrop blur 구현**: Figma `Backdrop/large`(BACKGROUND_BLUR, radius 60)는 OS 표준 material로 구현한다 — SwiftUI `.thickMaterial`(저장소 유틸 `applyBlurEffect()`), UIKit `UIVisualEffectView`. 근거: design spec §6 Token Map — "런타임에서는 iOS `.thickMaterial` 또는 `backdrop-filter: blur(60px)` 로 구현".
+2. **backdrop blur 구현**: Figma `Backdrop/large`(BACKGROUND_BLUR, radius 60)는 iOS의 Ultra Thin Material로 구현한다 — SwiftUI `.ultraThinMaterial`(저장소 유틸 `applyBlurEffect(colorScheme:)`), UIKit `UIVisualEffectView`의 `systemUltraThinMaterialLight` / `systemUltraThinMaterialDark`. Toast의 semantic color는 앱 테마와 반전하지만 Material은 뒤 콘텐츠가 속한 앱 테마를 그대로 따른다.
 
 ---
 

--- a/Sources/BezierSwift/MasterComponent/BezierToast/SUBezierToast.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierToast/SUBezierToast.swift
@@ -44,7 +44,9 @@ public struct SUBezierToast: View, Themeable {
     )
     .frame(minHeight: BezierToastSpec.minHeight)
     .background(self.palette(BezierToastSpec.backgroundToken, isInverted: true))
-    .applyBlurEffect()
+    // Toast 색상은 반전하지만 Material은 화면의 원래 테마를 따라야 하므로
+    // 아래의 반전 colorScheme environment와 분리해 전달한다.
+    .applyBlurEffect(colorScheme: self.colorScheme)
     .applyBezierCornerRadius(type: BezierToastSpec.cornerRadius)
     .frame(maxWidth: BezierToastSpec.maxWidth)
     // applyBezierFontStyle 내부 modifier가 자체 @Environment(\.colorScheme)로 텍스트 색을 해석해

--- a/Tests/BezierSwiftTests/BezierToastAppearanceTests.swift
+++ b/Tests/BezierSwiftTests/BezierToastAppearanceTests.swift
@@ -1,0 +1,16 @@
+import Testing
+import UIKit
+@testable import BezierSwift
+
+@Suite("BezierToast Appearance")
+struct BezierToastAppearanceTests {
+  @Test("Blur Material은 앱의 color theme을 따른다")
+  func blurMaterialFollowsAppColorTheme() {
+    #expect(
+      BezierToastSpec.blurEffectStyle(for: .light) == .systemUltraThinMaterialLight
+    )
+    #expect(
+      BezierToastSpec.blurEffectStyle(for: .dark) == .systemUltraThinMaterialDark
+    )
+  }
+}


### PR DESCRIPTION
## Summary

- Toast의 `surfaceGlass` Color Token은 기존처럼 앱 테마와 반전해 적용합니다.
- Toast의 Blur Material은 반전된 컴포넌트 테마가 아니라 앱 테마를 따르도록 수정했습니다.
- Figma의 backdrop 표현과 실제 비교 결과에 맞춰 Material 강도를 Thick에서 Ultra Thin으로 변경했습니다.
- UIKit과 SwiftUI 구현이 동일한 정책을 사용하도록 정리하고 Light/Dark 매핑 테스트를 추가했습니다.

## Appearance policy

| 앱 테마 | Toast 배경색 | Blur Material |
| --- | --- | --- |
| Light | `surfaceGlass.dark` | `systemUltraThinMaterialLight` |
| Dark | `surfaceGlass.light` | `systemUltraThinMaterialDark` |

## Test

- `BezierExamples` scheme build 성공
- `BezierExamples` tests: 5 passed, 0 failed
- `git diff --check` 통과
- Swift Package의 호스트 `swift test`는 macOS 환경에서 UIKit을 불러올 수 없어 실행하지 못했습니다.

## AS-IS / TO-BE

라이트·다크 테마에서 기존 Thick Material과 변경된 Ultra Thin Material을 동일한 배경 콘텐츠 위에서 비교했습니다.

![Toast Material AS-IS / TO-BE](https://github.com/user-attachments/assets/5a590a22-93b0-4376-9b6c-c60f02db1f5e)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 라이트·다크 테마에서 Bezier Toast의 블러 효과가 앱 테마에 맞게 표시됩니다.
  * 반전된 색상 환경에서도 토스트 배경의 머티리얼 효과가 올바른 테마를 유지합니다.
  * SwiftUI와 UIKit의 블러 스타일이 일관되게 적용됩니다.

* **테스트**
  * 라이트·다크 테마별 블러 스타일 적용을 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->