### PR TITLE
[MOB-7059] Button 텍스트 세로 중앙 정렬을 보정한다

### DIFF
--- a/Sources/BezierSwift/Extension/String+Extensions.swift
+++ b/Sources/BezierSwift/Extension/String+Extensions.swift
@@ -19,7 +19,8 @@ extension String {
     color: UIColor,
     letterSpacing: CGFloat,
     alignment: NSTextAlignment = .left,
-    lineBreakMode: NSLineBreakMode = .byWordWrapping
+    lineBreakMode: NSLineBreakMode = .byWordWrapping,
+    baselineOffset: CGFloat? = nil
   ) -> NSMutableAttributedString {
     let paragraphStyle = NSMutableParagraphStyle()
     paragraphStyle.lineBreakMode = lineBreakMode
@@ -35,7 +36,7 @@ extension String {
       .font: font,
       .kern: letterSpacing,
       .paragraphStyle: paragraphStyle,
-      .baselineOffset: (paragraphStyle.minimumLineHeight - font.lineHeight) / 4
+      .baselineOffset: baselineOffset ?? (paragraphStyle.minimumLineHeight - font.lineHeight) / 4
     ]
     
     let attrText = NSMutableAttributedString(string: self)

--- a/Sources/BezierSwift/MasterComponent/BezierBadge/BezierBadge.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBadge/BezierBadge.swift
@@ -197,7 +197,8 @@ public final class BezierBadge: UIView, BezierComponentable {
         font: font,
         color: foregroundToken.palette(self),
         letterSpacing: self.size.letterSpacing,
-        alignment: .center
+        alignment: .center,
+        baselineOffset: (self.size.lineHeight - font.lineHeight) / 2
       )
       self.titleLabel.isHidden = false
     } else {

--- a/Sources/BezierSwift/MasterComponent/BezierButton/BezierButton.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierButton/BezierButton.swift
@@ -321,12 +321,14 @@ public final class BezierButton: UIControl, BezierComponentable {
     self.trailingImageView.tintColor = foregroundColor
 
     if let title = self.title, !title.isEmpty {
+      let font = self.size.uiFont
       self.titleLabel.attributedText = title.applyBezierFont(
         height: self.size.lineHeight,
-        font: self.size.uiFont,
+        font: font,
         color: foregroundColor,
         letterSpacing: 0,
-        alignment: .center
+        alignment: .center,
+        baselineOffset: (self.size.lineHeight - font.lineHeight) / 2
       )
       self.titleLabel.isHidden = false
     } else {

--- a/Sources/BezierSwift/MasterComponent/BezierTag/BezierTag.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierTag/BezierTag.swift
@@ -190,7 +190,8 @@ public final class BezierTag: UIView, BezierComponentable {
         font: font,
         color: foregroundColor,
         letterSpacing: self.size.letterSpacing,
-        alignment: .center
+        alignment: .center,
+        baselineOffset: (self.size.lineHeight - font.lineHeight) / 2
       )
       self.titleLabel.isHidden = false
     } else {

--- a/Tests/BezierSwiftTests/BezierButtonVerticalAlignmentTests.swift
+++ b/Tests/BezierSwiftTests/BezierButtonVerticalAlignmentTests.swift
@@ -1,0 +1,118 @@
+import SwiftUI
+import Testing
+import UIKit
+@testable import BezierSwift
+
+@Suite("BezierButton Vertical Alignment", .serialized)
+@MainActor
+struct BezierButtonVerticalAlignmentTests {
+  @Test("UIKit과 SwiftUI 텍스트는 버튼 중앙에 렌더링된다")
+  func textIsVerticallyCentered() throws {
+    for size in BezierButtonSize.allCases {
+      for text in ["Label", "버튼"] {
+        let uiKitImage = self.renderUIKitButton(size: size, text: text)
+        let swiftUIImage = try self.renderSwiftUIButton(size: size, text: text)
+
+        let uiKitDelta = try self.verticalCenterDelta(in: uiKitImage)
+        let swiftUIDelta = try self.verticalCenterDelta(in: swiftUIImage)
+
+        #expect(abs(uiKitDelta) <= 0.5)
+        #expect(abs(swiftUIDelta) <= 0.5)
+        #expect(abs(uiKitDelta - swiftUIDelta) <= 0.5)
+      }
+    }
+  }
+
+  @Test("Badge와 Tag 텍스트는 컴포넌트 중앙에 렌더링된다")
+  func relatedComponentTextIsVerticallyCentered() throws {
+    for text in ["Label", "버튼"] {
+      for size in BezierBadgeSize.allCases {
+        let badge = BezierBadge(size: size, variant: .default)
+        badge.label = text
+        let window = self.layoutInWindow(badge, size: badge.intrinsicContentSize)
+
+        let label = try #require(self.firstLabel(in: badge))
+        let image = withExtendedLifetime(window) { self.render(view: label) }
+        #expect(abs(try self.verticalCenterDelta(in: image)) <= 0.5)
+      }
+
+      for size in BezierTagSize.allCases {
+        let tag = BezierTag(size: size, variant: .default)
+        tag.label = text
+        let window = self.layoutInWindow(tag, size: CGSize(width: 120, height: size.height))
+
+        let label = try #require(self.firstLabel(in: tag))
+        let image = withExtendedLifetime(window) { self.render(view: label) }
+        #expect(abs(try self.verticalCenterDelta(in: image)) <= 0.5)
+      }
+    }
+  }
+
+  private func renderUIKitButton(size: BezierButtonSize, text: String) -> UIImage {
+    let button = BezierButton(size: size, variant: .ghost, semantic: .primary)
+    button.title = text
+    let window = self.layoutInWindow(button, size: button.intrinsicContentSize)
+
+    return withExtendedLifetime(window) { self.render(view: button) }
+  }
+
+  private func renderSwiftUIButton(size: BezierButtonSize, text: String) throws -> UIImage {
+    let renderer = ImageRenderer(
+      content: SUBezierButton(
+        size: size,
+        variant: .ghost,
+        semantic: .primary,
+        title: text,
+        action: {}
+      )
+    )
+    renderer.scale = 3
+    return try #require(renderer.uiImage)
+  }
+
+  private func verticalCenterDelta(in image: UIImage) throws -> CGFloat {
+    let cgImage = try #require(image.cgImage)
+    let data = try #require(cgImage.dataProvider?.data)
+    let bytes = CFDataGetBytePtr(data)
+    let bytesPerPixel = cgImage.bitsPerPixel / 8
+    var minY = cgImage.height
+    var maxY = -1
+
+    for y in 0..<cgImage.height {
+      for x in 0..<cgImage.width {
+        let index = y * cgImage.bytesPerRow + x * bytesPerPixel
+        if bytes?[index + 3] ?? 0 > 8 {
+          minY = min(minY, y)
+          maxY = max(maxY, y)
+        }
+      }
+    }
+
+    #expect(maxY >= minY)
+    let glyphMidY = CGFloat(minY + maxY + 1) / 2 / image.scale
+    return glyphMidY - image.size.height / 2
+  }
+
+  private func render(view: UIView) -> UIImage {
+    let format = UIGraphicsImageRendererFormat()
+    format.scale = 3
+    format.opaque = false
+    return UIGraphicsImageRenderer(size: view.bounds.size, format: format).image { context in
+      view.layer.render(in: context.cgContext)
+    }
+  }
+
+  private func layoutInWindow(_ view: UIView, size: CGSize) -> UIWindow {
+    let window = UIWindow(frame: CGRect(origin: .zero, size: size))
+    window.addSubview(view)
+    view.frame = window.bounds
+    window.setNeedsLayout()
+    window.layoutIfNeeded()
+    return window
+  }
+
+  private func firstLabel(in view: UIView) -> UILabel? {
+    if let label = view as? UILabel { return label }
+    return view.subviews.lazy.compactMap(self.firstLabel(in:)).first
+  }
+}


### PR DESCRIPTION
## Summary

- UIKit attributed text가 line-height 여백의 1/4만 baseline에 반영해 Button 라벨이 아래로 보이던 문제를 수정했습니다.
- 고정 높이 pill 컴포넌트인 Button, Badge, Tag에 line-height 여백의 절반을 baseline offset으로 적용했습니다.
- SwiftUI Button은 기존에도 상·하 여백을 균등 분배해 중앙 정렬되고 있음을 실제 렌더링으로 확인했습니다.
- 한글·영문과 전체 size를 UIKit·SwiftUI에서 픽셀 단위로 비교하는 회귀 테스트를 추가했습니다.

## Test

- iPhone 17 / iOS 26.4에서 `BezierSwift` clean build 성공
- 전체 `BezierSwiftTests` 통과
- Button·Badge·Tag glyph 중심 오차 ±0.5pt 이내
- `git diff --check` 통과

## AS-IS / TO-BE

- BezierExamples의 동일한 `large / filled / primary / Button Label` 조건으로 비교했습니다.
- 빨간 수평선은 각 Button의 centerY를 표시합니다.

| AS-IS | TO-BE |
| --- | --- |
| <img width="368" alt="Button vertical alignment AS-IS with centerY guide" src="https://github.com/user-attachments/assets/a2b24741-3c27-488b-a4ee-be0294cd6f69"> | <img width="368" alt="Button vertical alignment TO-BE with centerY guide" src="https://github.com/user-attachments/assets/f5388654-f9bf-43ed-8ee4-f37142910143"> |

## Localized labels

- 작업 브랜치의 BezierExamples에서 동일한 `large / filled / primary` 조건으로 렌더링했습니다.
- 빨간 수평선은 SwiftUI·UIKit Button의 centerY를 표시합니다.

| 한국어 — `버튼 레이블` | 일본어 — `ボタンラベル` |
| --- | --- |
| <img width="368" alt="Korean Button vertical alignment with centerY guide" src="https://github.com/user-attachments/assets/159c90fd-55d3-4bd9-b744-278ffa56f500"> | <img width="368" alt="Japanese Button vertical alignment with centerY guide" src="https://github.com/user-attachments/assets/21906d1a-cd4c-40b2-8a95-ce59b30ed623"> |

## Ticket

- [MOB-7059](https://linear.app/channel/issue/MOB-7059/ios-bezierbutton-텍스트-세로-중앙-정렬-보정)
