### PR TITLE
[MOB-7058] BezierTag와 BezierBadge 긴 텍스트를 말줄임 처리한다

### DIFF
--- a/Sources/BezierSwift/MasterComponent/BezierBadge/BezierBadge.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBadge/BezierBadge.swift
@@ -60,6 +60,7 @@ public final class BezierBadge: UIView, BezierComponentable {
   private let titleLabel: BezierBadgePaddedLabel = {
     let label = BezierBadgePaddedLabel()
     label.numberOfLines = 1
+    label.lineBreakMode = .byTruncatingTail
     label.textAlignment = .center
     return label
   }()
@@ -197,7 +198,8 @@ public final class BezierBadge: UIView, BezierComponentable {
         font: font,
         color: foregroundToken.palette(self),
         letterSpacing: self.size.letterSpacing,
-        alignment: .center
+        alignment: .center,
+        lineBreakMode: .byTruncatingTail
       )
       self.titleLabel.isHidden = false
     } else {

--- a/Sources/BezierSwift/MasterComponent/BezierBadge/SUBezierBadge.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierBadge/SUBezierBadge.swift
@@ -41,7 +41,8 @@ public struct SUBezierBadge: View, Themeable {
           .padding(.vertical, self.size.verticalLineSpacing)
           .foregroundColor(self.palette(self.variant.foregroundToken))
           .padding(.horizontal, self.size.textHorizontalPadding)
-          .fixedSize(horizontal: true, vertical: false)
+          .lineLimit(1)
+          .truncationMode(.tail)
       }
     }
     .padding(.horizontal, self.size.horizontalPadding)

--- a/Sources/BezierSwift/MasterComponent/BezierTag/BezierTag.swift
+++ b/Sources/BezierSwift/MasterComponent/BezierTag/BezierTag.swift
@@ -59,6 +59,7 @@ public final class BezierTag: UIView, BezierComponentable {
   private let titleLabel: BezierTagPaddedLabel = {
     let label = BezierTagPaddedLabel()
     label.numberOfLines = 1
+    label.lineBreakMode = .byTruncatingTail
     label.textAlignment = .center
     return label
   }()
@@ -190,7 +191,8 @@ public final class BezierTag: UIView, BezierComponentable {
         font: font,
         color: foregroundColor,
         letterSpacing: self.size.letterSpacing,
-        alignment: .center
+        alignment: .center,
+        lineBreakMode: .byTruncatingTail
       )
       self.titleLabel.isHidden = false
     } else {

--- a/Tests/BezierSwiftTests/BezierBadgeLayoutTests.swift
+++ b/Tests/BezierSwiftTests/BezierBadgeLayoutTests.swift
@@ -145,13 +145,13 @@ struct BezierBadgeLayoutTests {
     )
   }
 
-  /// 접근 A(라이브러리 무변경): 호출부에서 compressionResistance 를 낮추면, 표준 UIKit 메커니즘에 따라
-  /// 배지가 자연폭 미만으로 축소되고 내부 라벨이 tail truncation 조건(표시폭 < 콘텐츠폭)에 들어간다.
-  /// 즉 별도 API 없이 UIKit 표준만으로 "어느 정도 축소 허용 + 말줄임"이 가능하다.
-  @Test("compressionResistance를 낮추면 배지가 축소되고 라벨이 truncate 조건에 들어간다")
+  /// 호출부에서 compressionResistance 를 낮추면 배지가 자연폭 미만으로 축소되고,
+  /// 내부 라벨은 attributed paragraph style까지 tail truncation을 유지해야 한다.
+  @Test("compressionResistance를 낮추면 배지가 축소되고 라벨이 trailing ellipsis를 사용한다")
   func loweringResistanceAllowsTruncation() {
     let badge = BezierBadge(size: .xsmall)
     badge.label = "botbotbot"
+    badge.leadingIcon = UIImage()
     badge.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
     let natural = badge.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).width
 
@@ -180,14 +180,34 @@ struct BezierBadgeLayoutTests {
     #expect(titleLabel != nil)
     if let titleLabel {
       #expect(titleLabel.numberOfLines == 1)
+      #expect(titleLabel.lineBreakMode == .byTruncatingTail)
       #expect(titleLabel.bounds.width < titleLabel.intrinsicContentSize.width)
+
+      let paragraphStyle = titleLabel.attributedText?.attribute(
+        .paragraphStyle,
+        at: 0,
+        effectiveRange: nil
+      ) as? NSParagraphStyle
+      #expect(paragraphStyle?.lineBreakMode == .byTruncatingTail)
     }
+
+    let leadingImageView = Self.firstImageView(in: badge)
+    #expect(leadingImageView != nil)
+    #expect(abs((leadingImageView?.bounds.width ?? 0) - BezierBadgeSize.xsmall.iconLength) < 0.5)
   }
 
   private static func firstLabel(in view: UIView) -> UILabel? {
     for subview in view.subviews {
       if let label = subview as? UILabel { return label }
       if let found = firstLabel(in: subview) { return found }
+    }
+    return nil
+  }
+
+  private static func firstImageView(in view: UIView) -> UIImageView? {
+    for subview in view.subviews {
+      if let imageView = subview as? UIImageView { return imageView }
+      if let found = firstImageView(in: subview) { return found }
     }
     return nil
   }

--- a/Tests/BezierSwiftTests/BezierBadgeLayoutTests.swift
+++ b/Tests/BezierSwiftTests/BezierBadgeLayoutTests.swift
@@ -151,7 +151,7 @@ struct BezierBadgeLayoutTests {
   func loweringResistanceAllowsTruncation() {
     let badge = BezierBadge(size: .xsmall)
     badge.label = "botbotbot"
-    badge.leadingIcon = UIImage()
+    badge.leadingIcon = BezierIcon.plus.uiImage
     badge.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
     let natural = badge.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).width
 
@@ -193,6 +193,8 @@ struct BezierBadgeLayoutTests {
 
     let leadingImageView = Self.firstImageView(in: badge)
     #expect(leadingImageView != nil)
+    #expect(leadingImageView?.isHidden == false)
+    #expect(leadingImageView?.image != nil)
     #expect(abs((leadingImageView?.bounds.width ?? 0) - BezierBadgeSize.xsmall.iconLength) < 0.5)
   }
 

--- a/Tests/BezierSwiftTests/BezierTagLayoutTests.swift
+++ b/Tests/BezierSwiftTests/BezierTagLayoutTests.swift
@@ -1,0 +1,65 @@
+import Testing
+import UIKit
+@testable import BezierSwift
+
+@Suite("BezierTag Layout - Text Truncation", .serialized)
+@MainActor
+struct BezierTagLayoutTests {
+  @Test("고정 폭에서 긴 라벨은 trailing ellipsis를 사용하고 close 버튼은 보존한다")
+  func fixedWidthUsesTrailingEllipsisAndPreservesCloseButton() {
+    let tag = BezierTag(size: .xsmall)
+    tag.label = "아주 긴 태그 라벨 텍스트"
+    tag.onDelete = {}
+
+    let naturalWidth = tag.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).width
+    let targetWidth = (naturalWidth * 0.6).rounded()
+    let container = UIView(frame: CGRect(x: 0, y: 0, width: targetWidth, height: 40))
+    let window = UIWindow(frame: container.bounds)
+    window.addSubview(container)
+    container.addSubview(tag)
+
+    NSLayoutConstraint.activate([
+      tag.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+      tag.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+      tag.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+    ])
+
+    window.setNeedsLayout()
+    window.layoutIfNeeded()
+
+    let titleLabel = Self.firstLabel(in: tag)
+    #expect(titleLabel != nil)
+    if let titleLabel {
+      #expect(titleLabel.numberOfLines == 1)
+      #expect(titleLabel.lineBreakMode == .byTruncatingTail)
+      #expect(titleLabel.bounds.width < titleLabel.intrinsicContentSize.width)
+
+      let paragraphStyle = titleLabel.attributedText?.attribute(
+        .paragraphStyle,
+        at: 0,
+        effectiveRange: nil
+      ) as? NSParagraphStyle
+      #expect(paragraphStyle?.lineBreakMode == .byTruncatingTail)
+    }
+
+    let closeButton = Self.firstButton(in: tag)
+    #expect(closeButton != nil)
+    #expect(abs((closeButton?.bounds.width ?? 0) - BezierTagSize.xsmall.closeIconLength) < 0.5)
+  }
+
+  private static func firstLabel(in view: UIView) -> UILabel? {
+    for subview in view.subviews {
+      if let label = subview as? UILabel { return label }
+      if let found = firstLabel(in: subview) { return found }
+    }
+    return nil
+  }
+
+  private static func firstButton(in view: UIView) -> UIButton? {
+    for subview in view.subviews {
+      if let button = subview as? UIButton { return button }
+      if let found = firstButton(in: subview) { return found }
+    }
+    return nil
+  }
+}

--- a/Tests/BezierSwiftTests/BezierTagLayoutTests.swift
+++ b/Tests/BezierSwiftTests/BezierTagLayoutTests.swift
@@ -44,6 +44,8 @@ struct BezierTagLayoutTests {
 
     let closeButton = Self.firstButton(in: tag)
     #expect(closeButton != nil)
+    #expect(closeButton?.isHidden == false)
+    #expect(closeButton?.image(for: .normal) != nil)
     #expect(abs((closeButton?.bounds.width ?? 0) - BezierTagSize.xsmall.closeIconLength) < 0.5)
   }
 


### PR DESCRIPTION
## 변경 사항

- UIKit `BezierTag`와 `BezierBadge`의 label 및 attributed paragraph style에 trailing truncation을 명시했습니다.
- SwiftUI `SUBezierBadge`가 제한 폭을 무시하던 horizontal fixed size를 제거하고 한 줄 trailing ellipsis를 적용했습니다.
- 고정 폭에서 Tag close 버튼과 Badge leading icon을 보존하면서 텍스트가 말줄임되는 회귀 테스트를 추가했습니다.

## 검증

- `xcodebuild -scheme BezierSwift -destination 'platform=iOS Simulator,id=2C0B2F04-E8AA-44F6-854B-D7DD5973E5DC' clean build`
- `xcodebuild -scheme BezierSwift -destination 'platform=iOS Simulator,id=2C0B2F04-E8AA-44F6-854B-D7DD5973E5DC' test`
- 125 tests / 32 suites 통과
- Example 앱에서 동일한 220pt 고정 폭으로 AS-IS/TO-BE 시각 비교

## 스크린샷

| AS-IS | TO-BE |
|---|---|
| <img width="368" alt="BezierTag와 BezierBadge text overflow AS-IS" src="https://github.com/user-attachments/assets/5ada1d9c-834f-4ae2-8379-03009a440189"> | <img width="368" alt="BezierTag와 BezierBadge trailing ellipsis TO-BE" src="https://github.com/user-attachments/assets/3981b004-1790-47f9-ac6c-dded8061d3ff"> |

## Linear

- [MOB-7058](https://linear.app/channel/issue/MOB-7058/ios-beziertagbadge-%EA%B8%B4-%ED%85%8D%EC%8A%A4%ED%8A%B8-%EB%A7%90%EC%A4%84%EC%9E%84-%EC%B2%98%EB%A6%AC)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 긴 배지와 태그 텍스트가 한 줄로 표시되며, 공간이 부족할 경우 끝부분이 말줄임표로 축약됩니다.
  - 배지의 고정 너비 동작을 개선해 콘텐츠에 맞게 더 유연하게 표시됩니다.
  - 아이콘과 닫기 버튼은 텍스트가 축약되어도 정상적으로 유지됩니다.

- **테스트**
  - 긴 텍스트, 아이콘, 닫기 버튼이 포함된 배지와 태그의 레이아웃 동작을 검증했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->